### PR TITLE
Fix TS pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,10 @@
 ---
 repos:
 
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+
   - repo: https://github.com/psf/black
     rev: 24.4.2
     hooks:
@@ -22,9 +26,9 @@ repos:
         files: arches_lingo/src
       - id: typescript
         name: typescript
-        entry: npm run ts:check
+        entry: bash -c 'npm run ts:check'
         language: system
-        types: [
+        types_or: [
           "ts",
           "vue",
         ]


### PR DESCRIPTION
Partner to archesproject/arches#11250.

To test, merge this branch into #39, and try commenting out the `if (!token) { ...` block of `getToken()` in api.ts. You shouldn't be able to commit that change. Without these changes, the commit goes through because the hook wasn't firing.