### PR TITLE
Use valid `FILE_TYPE_CHECKING` value

### DIFF
--- a/arches_lingo/settings.py
+++ b/arches_lingo/settings.py
@@ -34,7 +34,7 @@ SEARCH_COMPONENT_LOCATIONS.append("arches_lingo.search_components")
 
 LOCALE_PATHS.insert(0, os.path.join(APP_ROOT, "locale"))
 
-FILE_TYPE_CHECKING = False
+FILE_TYPE_CHECKING = "lenient"
 FILE_TYPES = [
     "bmp",
     "gif",


### PR DESCRIPTION
Follow-up to archesproject/arches#11353.
Matches default for new projects.