### PR TITLE
Loosen arches requirement to >= 8.0.0a0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "arches @ git+https://github.com/archesproject/arches.git@dev/8.0.x",
+    "arches >= 8.0.0a0",
     "arches_vue_utils @ git+https://github.com/archesproject/arches-vue-utils.git@main",
     "arches_references @ git+https://github.com/archesproject/arches-references.git@main",
 ]


### PR DESCRIPTION
Similar to archesproject/arches-vue-utils#4

We may want to explicitly depend on the arches model querysets work eventually, but we already depend on that transitively through arches-references. This just removes the conflicts, see failing [action](https://github.com/archesproject/arches-lingo/actions/runs/12141346874).