### PR TITLE
don't show hierarchy by default

### DIFF
--- a/arches_lingo/src/arches_lingo/components/tree/HierarchySplitter.vue
+++ b/arches_lingo/src/arches_lingo/components/tree/HierarchySplitter.vue
@@ -46,7 +46,7 @@ const setDisplayedRow = (val: Concept | Scheme | null) => {
 // @ts-expect-error vue-tsc doesn't like arbitrary properties here
 provide(displayedRowKey, { displayedRow, setDisplayedRow });
 
-const showHierarchy = ref(true);
+const showHierarchy = ref(false);
 </script>
 
 <template>

--- a/arches_lingo/src/arches_lingo/pages/SchemePage.vue
+++ b/arches_lingo/src/arches_lingo/pages/SchemePage.vue
@@ -9,7 +9,7 @@ import SchemeStandard from "@/arches_lingo/components/scheme/report/SchemeStanda
 import SchemeAuthority from "@/arches_lingo/components/scheme/report/SchemeAuthority.vue";
 import SchemeEditor from "@/arches_lingo/components/scheme/editor/SchemeEditor.vue";
 
-const editorVisible = ref(true);
+const editorVisible = ref(false);
 const sectionVisible = ref(true);
 const editorTab = ref<string>();
 type sectionTypes =


### PR DESCRIPTION
Sets the hierarchy to be hidden by default.  