### PR TITLE
adds minimum width to scheme page items

### DIFF
--- a/arches_lingo/src/arches_lingo/pages/SchemePage.vue
+++ b/arches_lingo/src/arches_lingo/pages/SchemePage.vue
@@ -63,7 +63,8 @@ const getRef = (el: object | null, index: number) => {
     <Splitter>
         <SplitterPanel
             v-if="sectionVisible"
-            :size="75"
+            :size="66"
+            :min-size="33"
         >
             <template
                 v-for="(component, index) in components"
@@ -79,7 +80,8 @@ const getRef = (el: object | null, index: number) => {
         </SplitterPanel>
         <SplitterPanel
             v-if="editorVisible"
-            :size="25"
+            :size="33"
+            :min-size="33"
         >
             <SchemeEditor
                 v-if="editorTab"
@@ -93,8 +95,3 @@ const getRef = (el: object | null, index: number) => {
         </SplitterPanel>
     </Splitter>
 </template>
-<style scoped>
-:deep(.p-splitterpanel) {
-    min-width: 25%;
-}
-</style>

--- a/arches_lingo/src/arches_lingo/pages/SchemePage.vue
+++ b/arches_lingo/src/arches_lingo/pages/SchemePage.vue
@@ -93,3 +93,8 @@ const getRef = (el: object | null, index: number) => {
         </SplitterPanel>
     </Splitter>
 </template>
+<style scoped>
+:deep(.p-splitterpanel) {
+    min-width: 25%;
+}
+</style>


### PR DESCRIPTION
closes #145 

Adds min-width at the splitter panel level - section level min-width is not respected at the section level.  If desired, I can delve into that, but this seemed to solve the concern in #145 faster.  