### PR TITLE
Change lists in resource relationships widget

### DIFF
--- a/arches_lingo/src/arches_lingo/api.ts
+++ b/arches_lingo/src/arches_lingo/api.ts
@@ -39,6 +39,20 @@ export const fetchUser = async () => {
     return parsed;
 };
 
+export const fetchRelatableResources = async (
+    graphSlug: string,
+    nodeAlias: string,
+    page: number,
+) => {
+    const response = await fetch(
+        `/api/graph/${graphSlug}/node/${nodeAlias}/relatable-resources?page=${page}`,
+    );
+
+    const parsed = await response.json();
+    if (!response.ok) throw new Error(parsed.message || response.statusText);
+    return parsed;
+};
+
 export const fetchLingoResources = async (graphSlug: string) => {
     const response = await fetch(arches.urls.api_lingo_resources(graphSlug));
     const parsed = await response.json();
@@ -153,6 +167,19 @@ export const createScheme = async (newScheme: SchemeInstance) => {
         },
         body: JSON.stringify(newScheme),
     });
+    const parsed = await response.json();
+    if (!response.ok) throw new Error(parsed.message || response.statusText);
+    return parsed;
+};
+
+export const fetchRelatableResources = async (
+    graphSlug: string,
+    nodeAlias: string,
+) => {
+    const response = await fetch(
+        `/api/graph/${graphSlug}/node/${nodeAlias}/relatable-resources`,
+    );
+
     const parsed = await response.json();
     if (!response.ok) throw new Error(parsed.message || response.statusText);
     return parsed;

--- a/arches_lingo/src/arches_lingo/api.ts
+++ b/arches_lingo/src/arches_lingo/api.ts
@@ -45,7 +45,7 @@ export const fetchRelatableResources = async (
     page: number,
 ) => {
     const response = await fetch(
-        `/api/graph/${graphSlug}/node/${nodeAlias}/relatable-resources?page=${page}`,
+        `${arches.urls.api_relatable_resources(graphSlug, nodeAlias)}?page=${page}`,
     );
 
     const parsed = await response.json();
@@ -167,19 +167,6 @@ export const createScheme = async (newScheme: SchemeInstance) => {
         },
         body: JSON.stringify(newScheme),
     });
-    const parsed = await response.json();
-    if (!response.ok) throw new Error(parsed.message || response.statusText);
-    return parsed;
-};
-
-export const fetchRelatableResources = async (
-    graphSlug: string,
-    nodeAlias: string,
-) => {
-    const response = await fetch(
-        `/api/graph/${graphSlug}/node/${nodeAlias}/relatable-resources`,
-    );
-
     const parsed = await response.json();
     if (!response.ok) throw new Error(parsed.message || response.statusText);
     return parsed;

--- a/arches_lingo/src/arches_lingo/components/generic/LabelEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/generic/LabelEditor.vue
@@ -8,11 +8,7 @@ import { useToast } from "primevue/usetoast";
 
 import { fetchLists } from "@/arches_references/api.ts";
 
-import {
-    createScheme,
-    fetchLingoResources,
-    upsertLingoTile,
-} from "@/arches_lingo/api.ts";
+import { createScheme, upsertLingoTile } from "@/arches_lingo/api.ts";
 
 import DateDatatype from "@/arches_lingo/components/generic/DateDatatype.vue";
 import NonLocalizedString from "@/arches_lingo/components/generic/NonLocalizedString.vue";
@@ -57,8 +53,6 @@ const typeOptions = ref<ControlledListItem[]>([]);
 const statusOptions = ref<ControlledListItem[]>([]);
 const metatypeOptions = ref<ControlledListItem[]>([]);
 const eventTypeOptions = ref<ControlledListItem[]>([]);
-const groupAndPersonOptions = ref<ResourceInstanceReference[]>();
-const textualWorkOptions = ref<ResourceInstanceReference[]>();
 
 const labelId = useId();
 const labelLanguageId = useId();
@@ -112,15 +106,9 @@ function onUpdateReferenceDatatype(
 
 function onUpdateResourceInstance(
     node: keyof AppellativeStatus,
-    val: string[],
-    options: ResourceInstanceReference[],
+    val: ResourceInstanceReference[],
 ) {
-    if (val.length > 0) {
-        const selectedOptions = options.filter((option) =>
-            val.includes(option.resourceId),
-        );
-        (formValue.value[node] as unknown) = selectedOptions;
-    }
+    (formValue.value[node] as unknown) = val;
 }
 
 async function save() {
@@ -202,9 +190,10 @@ onMounted(async () => {
         :value="formValue?.appellative_status_ascribed_name_content"
         :mode="EDIT"
         :pass-thru-id="labelId"
-        @update="(val) =>
-            onUpdateString('appellative_status_ascribed_name_content', val)
-            "
+        @update="
+            (val) =>
+                onUpdateString('appellative_status_ascribed_name_content', val)
+        "
     />
     <p :id="labelLanguageId">{{ $gettext("Label Language") }}</p>
     <ReferenceDatatype
@@ -213,12 +202,13 @@ onMounted(async () => {
         :multi-value="false"
         :options="languageOptions"
         :pt-aria-labeled-by="labelLanguageId"
-        @update="(val) =>
-            onUpdateReferenceDatatype(
-                'appellative_status_ascribed_name_language',
-                val,
-            )
-            "
+        @update="
+            (val) =>
+                onUpdateReferenceDatatype(
+                    'appellative_status_ascribed_name_language',
+                    val,
+                )
+        "
     />
     <p :id="labelTypeId">{{ $gettext("Label Type") }}</p>
     <ReferenceDatatype
@@ -227,12 +217,13 @@ onMounted(async () => {
         :multi-value="false"
         :options="typeOptions"
         :pt-aria-labeled-by="labelTypeId"
-        @update="(val) =>
-            onUpdateReferenceDatatype(
-                'appellative_status_ascribed_relation',
-                val,
-            )
-            "
+        @update="
+            (val) =>
+                onUpdateReferenceDatatype(
+                    'appellative_status_ascribed_relation',
+                    val,
+                )
+        "
     />
     <p :id="labelStatusId">{{ $gettext("Label Status") }}</p>
     <ReferenceDatatype
@@ -241,8 +232,9 @@ onMounted(async () => {
         :multi-value="false"
         :options="statusOptions"
         :pt-aria-labeled-by="labelStatusId"
-        @update="(val) => onUpdateReferenceDatatype('appellative_status_status', val)
-            "
+        @update="
+            (val) => onUpdateReferenceDatatype('appellative_status_status', val)
+        "
     />
     <p :id="labelMetatypeId">{{ $gettext("Label Metatype") }}</p>
     <ReferenceDatatype
@@ -251,36 +243,39 @@ onMounted(async () => {
         :multi-value="false"
         :options="metatypeOptions"
         :pt-aria-labeled-by="labelMetatypeId"
-        @update="(val) =>
-            onUpdateReferenceDatatype(
-                'appellative_status_status_metatype',
-                val,
-            )
-            "
+        @update="
+            (val) =>
+                onUpdateReferenceDatatype(
+                    'appellative_status_status_metatype',
+                    val,
+                )
+        "
     />
     <p :id="labelStartId">{{ $gettext("Label Temporal Validity Start") }}</p>
     <DateDatatype
         :value="formValue?.appellative_status_timespan_begin_of_the_begin"
         :mode="EDIT"
         :pt-aria-labeled-by="labelStartId"
-        @update="(val) =>
-            onUpdateString(
-                'appellative_status_timespan_begin_of_the_begin',
-                val,
-            )
-            "
+        @update="
+            (val) =>
+                onUpdateString(
+                    'appellative_status_timespan_begin_of_the_begin',
+                    val,
+                )
+        "
     />
     <p :id="labelEndId">{{ $gettext("Label Temporal Validity End") }}</p>
     <DateDatatype
         :value="formValue?.appellative_status_timespan_end_of_the_end"
         :mode="EDIT"
         :pt-aria-labeled-by="labelEndId"
-        @update="(val) =>
-            onUpdateString(
-                'appellative_status_timespan_end_of_the_end',
-                val,
-            )
-            "
+        @update="
+            (val) =>
+                onUpdateString(
+                    'appellative_status_timespan_end_of_the_end',
+                    val,
+                )
+        "
     />
     <p :id="labelContributorId">{{ $gettext("Contributor") }}</p>
     <ResourceInstanceRelationships
@@ -289,13 +284,13 @@ onMounted(async () => {
         :pt-aria-labeled-by="labelContributorId"
         graph-slug="scheme"
         node-alias="appellative_status_data_assignment_actor"
-        @update="(val: string[]) =>
-            onUpdateResourceInstance(
-                'appellative_status_data_assignment_actor',
-                val,
-                groupAndPersonOptions ?? [],
-            )
-            "
+        @update="
+            (val: ResourceInstanceReference[]) =>
+                onUpdateResourceInstance(
+                    'appellative_status_data_assignment_actor',
+                    val,
+                )
+        "
     />
     <p :id="labelSourcesId">{{ $gettext("Sources") }}</p>
     <ResourceInstanceRelationships
@@ -304,13 +299,13 @@ onMounted(async () => {
         graph-slug="scheme"
         node-alias="appellative_status_data_assignment_object_used"
         :pt-aria-labeled-by="labelSourcesId"
-        @update="(val: string[]) =>
-            onUpdateResourceInstance(
-                'appellative_status_data_assignment_object_used',
-                val,
-                textualWorkOptions ?? [],
-            )
-            "
+        @update="
+            (val: ResourceInstanceReference[]) =>
+                onUpdateResourceInstance(
+                    'appellative_status_data_assignment_object_used',
+                    val,
+                )
+        "
     />
     <p :id="labelWarrantId">{{ $gettext("Warrant Type") }}</p>
     <ReferenceDatatype
@@ -319,12 +314,13 @@ onMounted(async () => {
         :multi-value="false"
         :options="eventTypeOptions"
         :pt-aria-labeled-by="labelWarrantId"
-        @update="(val) =>
-            onUpdateReferenceDatatype(
-                'appellative_status_data_assignment_type',
-                val,
-            )
-            "
+        @update="
+            (val) =>
+                onUpdateReferenceDatatype(
+                    'appellative_status_data_assignment_type',
+                    val,
+                )
+        "
     />
     <Button
         :label="$gettext('Update')"

--- a/arches_lingo/src/arches_lingo/components/generic/LabelEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/generic/LabelEditor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, inject, onMounted, ref, toRaw, toRef, useId } from "vue";
+import { computed, onMounted, ref, toRaw, toRef, useId } from "vue";
 
 import Button from "primevue/button";
 import { useGettext } from "vue3-gettext";
@@ -19,30 +19,21 @@ import NonLocalizedString from "@/arches_lingo/components/generic/NonLocalizedSt
 import ReferenceDatatype from "@/arches_lingo/components/generic/ReferenceDatatype.vue";
 import ResourceInstanceRelationships from "@/arches_lingo/components/generic/ResourceInstanceRelationships.vue";
 
-import {
-    EDIT,
-    ERROR,
-    NEW,
-    selectedLanguageKey,
-} from "@/arches_lingo/constants.ts";
+import { EDIT, ERROR, NEW } from "@/arches_lingo/constants.ts";
 
-import type { Ref } from "vue";
 import type {
     AppellativeStatus,
     ControlledListResult,
     ControlledListItem,
     ControlledListItemResult,
     ResourceInstanceReference,
-    ResourceInstanceResult,
     SchemeInstance,
 } from "@/arches_lingo/types.ts";
-import type { Language } from "@/arches_vue_utils/types.ts";
 
 const emit = defineEmits(["update"]);
 const toast = useToast();
 const route = useRoute();
 const router = useRouter();
-const selectedLanguage = inject(selectedLanguageKey) as Ref<Language>;
 const { $gettext } = useGettext();
 
 const props = withDefaults(
@@ -200,51 +191,9 @@ async function getControlledLists() {
     });
 }
 
-async function getResourceInstanceOptions(
-    fetchOptions: () => Promise<ResourceInstanceResult[]>,
-): Promise<ResourceInstanceReference[]> {
-    let options;
-    try {
-        options = await fetchOptions();
-    } catch (error) {
-        toast.add({
-            severity: ERROR,
-            summary: $gettext("Error"),
-            detail:
-                error instanceof Error
-                    ? error.message
-                    : $gettext("Could not fetch the resource instance options"),
-        });
-        return [];
-    }
-    const results = options.map((option: ResourceInstanceResult) => {
-        const result: ResourceInstanceReference = {
-            display_value: option.descriptors[selectedLanguage.value.code].name,
-            resourceId: option.resourceinstanceid,
-            ontologyProperty: "ac41d9be-79db-4256-b368-2f4559cfbe55",
-            inverseOntologyProperty: "ac41d9be-79db-4256-b368-2f4559cfbe55",
-        };
-        return result;
-    });
-    return results;
-}
-async function initializeSelectOptions() {
+onMounted(async () => {
     getControlledLists();
-    groupAndPersonOptions.value = await getResourceInstanceOptions(() =>
-        fetchLingoResources("group"),
-    );
-    groupAndPersonOptions.value = [
-        ...(groupAndPersonOptions.value || []),
-        ...(await getResourceInstanceOptions(() =>
-            fetchLingoResources("person"),
-        )),
-    ];
-    textualWorkOptions.value = await getResourceInstanceOptions(() =>
-        fetchLingoResources("textual_work"),
-    );
-}
-
-onMounted(initializeSelectOptions);
+});
 </script>
 
 <template>
@@ -253,10 +202,9 @@ onMounted(initializeSelectOptions);
         :value="formValue?.appellative_status_ascribed_name_content"
         :mode="EDIT"
         :pass-thru-id="labelId"
-        @update="
-            (val) =>
-                onUpdateString('appellative_status_ascribed_name_content', val)
-        "
+        @update="(val) =>
+            onUpdateString('appellative_status_ascribed_name_content', val)
+            "
     />
     <p :id="labelLanguageId">{{ $gettext("Label Language") }}</p>
     <ReferenceDatatype
@@ -265,13 +213,12 @@ onMounted(initializeSelectOptions);
         :multi-value="false"
         :options="languageOptions"
         :pt-aria-labeled-by="labelLanguageId"
-        @update="
-            (val) =>
-                onUpdateReferenceDatatype(
-                    'appellative_status_ascribed_name_language',
-                    val,
-                )
-        "
+        @update="(val) =>
+            onUpdateReferenceDatatype(
+                'appellative_status_ascribed_name_language',
+                val,
+            )
+            "
     />
     <p :id="labelTypeId">{{ $gettext("Label Type") }}</p>
     <ReferenceDatatype
@@ -280,13 +227,12 @@ onMounted(initializeSelectOptions);
         :multi-value="false"
         :options="typeOptions"
         :pt-aria-labeled-by="labelTypeId"
-        @update="
-            (val) =>
-                onUpdateReferenceDatatype(
-                    'appellative_status_ascribed_relation',
-                    val,
-                )
-        "
+        @update="(val) =>
+            onUpdateReferenceDatatype(
+                'appellative_status_ascribed_relation',
+                val,
+            )
+            "
     />
     <p :id="labelStatusId">{{ $gettext("Label Status") }}</p>
     <ReferenceDatatype
@@ -295,9 +241,8 @@ onMounted(initializeSelectOptions);
         :multi-value="false"
         :options="statusOptions"
         :pt-aria-labeled-by="labelStatusId"
-        @update="
-            (val) => onUpdateReferenceDatatype('appellative_status_status', val)
-        "
+        @update="(val) => onUpdateReferenceDatatype('appellative_status_status', val)
+            "
     />
     <p :id="labelMetatypeId">{{ $gettext("Label Metatype") }}</p>
     <ReferenceDatatype
@@ -306,69 +251,66 @@ onMounted(initializeSelectOptions);
         :multi-value="false"
         :options="metatypeOptions"
         :pt-aria-labeled-by="labelMetatypeId"
-        @update="
-            (val) =>
-                onUpdateReferenceDatatype(
-                    'appellative_status_status_metatype',
-                    val,
-                )
-        "
+        @update="(val) =>
+            onUpdateReferenceDatatype(
+                'appellative_status_status_metatype',
+                val,
+            )
+            "
     />
     <p :id="labelStartId">{{ $gettext("Label Temporal Validity Start") }}</p>
     <DateDatatype
         :value="formValue?.appellative_status_timespan_begin_of_the_begin"
         :mode="EDIT"
         :pt-aria-labeled-by="labelStartId"
-        @update="
-            (val) =>
-                onUpdateString(
-                    'appellative_status_timespan_begin_of_the_begin',
-                    val,
-                )
-        "
+        @update="(val) =>
+            onUpdateString(
+                'appellative_status_timespan_begin_of_the_begin',
+                val,
+            )
+            "
     />
     <p :id="labelEndId">{{ $gettext("Label Temporal Validity End") }}</p>
     <DateDatatype
         :value="formValue?.appellative_status_timespan_end_of_the_end"
         :mode="EDIT"
         :pt-aria-labeled-by="labelEndId"
-        @update="
-            (val) =>
-                onUpdateString(
-                    'appellative_status_timespan_end_of_the_end',
-                    val,
-                )
-        "
+        @update="(val) =>
+            onUpdateString(
+                'appellative_status_timespan_end_of_the_end',
+                val,
+            )
+            "
     />
     <p :id="labelContributorId">{{ $gettext("Contributor") }}</p>
     <ResourceInstanceRelationships
         :value="formValue?.appellative_status_data_assignment_actor"
         :mode="EDIT"
-        :options="groupAndPersonOptions"
         :pt-aria-labeled-by="labelContributorId"
-        @update="
-            (val) =>
-                onUpdateResourceInstance(
-                    'appellative_status_data_assignment_actor',
-                    val,
-                    groupAndPersonOptions ?? [],
-                )
-        "
+        graph-slug="scheme"
+        node-alias="appellative_status_data_assignment_actor"
+        @update="(val: string[]) =>
+            onUpdateResourceInstance(
+                'appellative_status_data_assignment_actor',
+                val,
+                groupAndPersonOptions ?? [],
+            )
+            "
     />
     <p :id="labelSourcesId">{{ $gettext("Sources") }}</p>
     <ResourceInstanceRelationships
         :value="formValue?.appellative_status_data_assignment_object_used"
         :mode="EDIT"
-        :options="textualWorkOptions"
+        graph-slug="scheme"
+        node-alias="appellative_status_data_assignment_object_used"
         :pt-aria-labeled-by="labelSourcesId"
-        @update="
-            (val) =>
-                onUpdateResourceInstance(
-                    'appellative_status_data_assignment_object_used',
-                    val,
-                    textualWorkOptions ?? [],
-                )
-        "
+        @update="(val: string[]) =>
+            onUpdateResourceInstance(
+                'appellative_status_data_assignment_object_used',
+                val,
+                textualWorkOptions ?? [],
+            )
+            "
     />
     <p :id="labelWarrantId">{{ $gettext("Warrant Type") }}</p>
     <ReferenceDatatype
@@ -377,13 +319,12 @@ onMounted(initializeSelectOptions);
         :multi-value="false"
         :options="eventTypeOptions"
         :pt-aria-labeled-by="labelWarrantId"
-        @update="
-            (val) =>
-                onUpdateReferenceDatatype(
-                    'appellative_status_data_assignment_type',
-                    val,
-                )
-        "
+        @update="(val) =>
+            onUpdateReferenceDatatype(
+                'appellative_status_data_assignment_type',
+                val,
+            )
+            "
     />
     <Button
         :label="$gettext('Update')"

--- a/arches_lingo/src/arches_lingo/components/generic/NoteEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/generic/NoteEditor.vue
@@ -1,14 +1,5 @@
 <script setup lang="ts">
-import {
-    computed,
-    inject,
-    onMounted,
-    ref,
-    toRaw,
-    toRef,
-    useId,
-    type Ref,
-} from "vue";
+import { computed, onMounted, ref, toRaw, toRef, useId } from "vue";
 
 import Button from "primevue/button";
 import { useGettext } from "vue3-gettext";
@@ -26,29 +17,21 @@ import NonLocalizedString from "@/arches_lingo/components/generic/NonLocalizedSt
 import ReferenceDatatype from "@/arches_lingo/components/generic/ReferenceDatatype.vue";
 import ResourceInstanceRelationships from "@/arches_lingo/components/generic/ResourceInstanceRelationships.vue";
 
-import {
-    EDIT,
-    ERROR,
-    NEW,
-    selectedLanguageKey,
-} from "@/arches_lingo/constants.ts";
+import { EDIT, ERROR, NEW } from "@/arches_lingo/constants.ts";
 
 import type {
     ControlledListItem,
     ControlledListItemResult,
     ControlledListResult,
     ResourceInstanceReference,
-    ResourceInstanceResult,
     SchemeInstance,
     SchemeStatement,
 } from "@/arches_lingo/types.ts";
-import type { Language } from "@/arches_vue_utils/types.ts";
 
 const emit = defineEmits(["update"]);
 const toast = useToast();
 const route = useRoute();
 const router = useRouter();
-const selectedLanguage = inject(selectedLanguageKey) as Ref<Language>;
 const { $gettext } = useGettext();
 
 const props = withDefaults(
@@ -204,36 +187,8 @@ async function save() {
     }
 }
 
-async function getResourceInstanceOptions(
-    fetchOptions: () => Promise<ResourceInstanceResult[]>,
-): Promise<ResourceInstanceReference[]> {
-    const options = await fetchOptions();
-    const results = options.map((option: ResourceInstanceResult) => {
-        const result: ResourceInstanceReference = {
-            display_value: option.descriptors[selectedLanguage.value.code].name,
-            resourceId: option.resourceinstanceid,
-            ontologyProperty: "ac41d9be-79db-4256-b368-2f4559cfbe55",
-            inverseOntologyProperty: "ac41d9be-79db-4256-b368-2f4559cfbe55",
-        };
-        return result;
-    });
-    return results;
-}
-
 async function initializeSelectOptions() {
     getControlledLists();
-    groupAndPersonOptions.value = await getResourceInstanceOptions(() =>
-        fetchLingoResources("group"),
-    );
-    groupAndPersonOptions.value = [
-        ...(groupAndPersonOptions.value || []),
-        ...(await getResourceInstanceOptions(() =>
-            fetchLingoResources("person"),
-        )),
-    ];
-    textualWorkOptions.value = await getResourceInstanceOptions(() =>
-        fetchLingoResources("textual_work"),
-    );
 }
 </script>
 
@@ -245,6 +200,7 @@ async function initializeSelectOptions() {
         :mode="EDIT"
         @update="(val) => onUpdateString('statement_content_n1', val)"
     />
+
     <!-- Statement Language: reference datatype -->
     <label :for="labelLanguageId">{{ $gettext("Statement Language") }}</label>
     <ReferenceDatatype
@@ -253,10 +209,10 @@ async function initializeSelectOptions() {
         :multi-value="false"
         :options="languageOptions"
         :pt-aria-labeled-by="labelLanguageId"
-        @update="
-            (val) => onUpdateReferenceDatatype('statement_language_n1', val)
-        "
+        @update="(val) => onUpdateReferenceDatatype('statement_language_n1', val)
+            "
     />
+
     <!-- Statement Type: reference datatype -->
     <label :for="labelTypeId">{{ $gettext("Statement Type") }}</label>
     <ReferenceDatatype
@@ -276,10 +232,9 @@ async function initializeSelectOptions() {
         :multi-value="false"
         :options="metatypeOptions"
         :pt-aria-labeled-by="labelMetatypeId"
-        @update="
-            (val) =>
-                onUpdateReferenceDatatype('statement_type_metatype_n1', val)
-        "
+        @update="(val) =>
+            onUpdateReferenceDatatype('statement_type_metatype_n1', val)
+            "
     />
 
     <!-- Statement Temporal Validity Start: date -->
@@ -287,18 +242,16 @@ async function initializeSelectOptions() {
         $gettext("Statement Temporal Validity Start")
     }}</label>
     <DateDatatype
-        :value="
-            formValue?.statement_data_assignment_timespan_begin_of_the_begin
-        "
+        :value="formValue?.statement_data_assignment_timespan_begin_of_the_begin
+            "
         :mode="EDIT"
         :pt-aria-labeled-by="labelStartId"
-        @update="
-            (val) =>
-                onUpdateString(
-                    'statement_data_assignment_timespan_begin_of_the_begin',
-                    val,
-                )
-        "
+        @update="(val) =>
+            onUpdateString(
+                'statement_data_assignment_timespan_begin_of_the_begin',
+                val,
+            )
+            "
     />
 
     <!-- Statement Temporal Validity End: date -->
@@ -309,13 +262,12 @@ async function initializeSelectOptions() {
         :value="formValue?.statement_data_assignment_timespan_end_of_the_end"
         :mode="EDIT"
         :pt-aria-labeled-by="labelEndId"
-        @update="
-            (val) =>
-                onUpdateString(
-                    'statement_data_assignment_timespan_end_of_the_end',
-                    val,
-                )
-        "
+        @update="(val) =>
+            onUpdateString(
+                'statement_data_assignment_timespan_end_of_the_end',
+                val,
+            )
+            "
     />
 
     <!-- Contributor: resource instance -->
@@ -323,33 +275,35 @@ async function initializeSelectOptions() {
     <ResourceInstanceRelationships
         :value="formValue?.statement_data_assignment_actor"
         :mode="EDIT"
-        :options="groupAndPersonOptions"
+        graph-slug="scheme"
+        node-alias="statement_data_assignment_actor"
         :pt-aria-labeled-by="labelContributorId"
-        @update="
-            (val) =>
-                onUpdateResourceInstance(
-                    'statement_data_assignment_actor',
-                    val,
-                    groupAndPersonOptions ?? [],
-                )
-        "
+        @updated="(val) =>
+            onUpdateResourceInstance(
+                'statement_data_assignment_actor',
+                val,
+                groupAndPersonOptions ?? [],
+            )
+            "
     />
+
     <!-- Sources: resource instance -->
     <label :for="labelSourcesId">{{ $gettext("Sources") }}</label>
     <ResourceInstanceRelationships
         :value="formValue?.statement_data_assignment_object_used"
         :mode="EDIT"
-        :options="textualWorkOptions"
+        graph-slug="scheme"
+        node-alias="statement_data_assignment_object_used"
         :pt-aria-labeled-by="labelSourcesId"
-        @update="
-            (val) =>
-                onUpdateResourceInstance(
-                    'statement_data_assignment_object_used',
-                    val,
-                    textualWorkOptions ?? [],
-                )
-        "
+        @updated="(val: string[]) =>
+            onUpdateResourceInstance(
+                'statement_data_assignment_object_used',
+                val,
+                textualWorkOptions ?? [],
+            )
+            "
     />
+
     <!-- Warrant Type: reference datatype -->
     <label :for="labelWarrantId">{{ $gettext("Warrant Type") }}</label>
     <ReferenceDatatype
@@ -358,11 +312,11 @@ async function initializeSelectOptions() {
         :multi-value="false"
         :options="eventTypeOptions"
         :pt-aria-labeled-by="labelWarrantId"
-        @update="
-            (val) =>
-                onUpdateReferenceDatatype('statement_data_assignment_type', val)
-        "
+        @updated="(val) =>
+            onUpdateReferenceDatatype('statement_data_assignment_type', val)
+            "
     />
+
     <Button
         :label="$gettext('Update')"
         @click="save"

--- a/arches_lingo/src/arches_lingo/components/generic/NoteEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/generic/NoteEditor.vue
@@ -6,11 +6,7 @@ import { useGettext } from "vue3-gettext";
 import { useRoute, useRouter } from "vue-router";
 import { useToast } from "primevue/usetoast";
 
-import {
-    createScheme,
-    fetchLingoResources,
-    upsertLingoTile,
-} from "@/arches_lingo/api.ts";
+import { createScheme, upsertLingoTile } from "@/arches_lingo/api.ts";
 import { fetchLists } from "@/arches_references/api.ts";
 import DateDatatype from "@/arches_lingo/components/generic/DateDatatype.vue";
 import NonLocalizedString from "@/arches_lingo/components/generic/NonLocalizedString.vue";
@@ -59,8 +55,6 @@ const languageOptions = ref<ControlledListItem[]>([]);
 const typeOptions = ref<ControlledListItem[]>([]);
 const metatypeOptions = ref<ControlledListItem[]>([]);
 const eventTypeOptions = ref<ControlledListItem[]>([]);
-const groupAndPersonOptions = ref<ResourceInstanceReference[]>();
-const textualWorkOptions = ref<ResourceInstanceReference[]>();
 
 const labelId = useId();
 const labelLanguageId = useId();
@@ -108,15 +102,9 @@ function onUpdateReferenceDatatype(
 
 function onUpdateResourceInstance(
     node: keyof SchemeStatement,
-    val: string[],
-    options: ResourceInstanceReference[],
+    val: ResourceInstanceReference[],
 ) {
-    if (val.length > 0) {
-        const selectedOptions = options.filter((option) =>
-            val.includes(option.resourceId),
-        );
-        (formValue.value[node] as unknown) = selectedOptions;
-    }
+    (formValue.value[node] as unknown) = val ?? [];
 }
 
 async function getControlledLists() {
@@ -209,8 +197,9 @@ async function initializeSelectOptions() {
         :multi-value="false"
         :options="languageOptions"
         :pt-aria-labeled-by="labelLanguageId"
-        @update="(val) => onUpdateReferenceDatatype('statement_language_n1', val)
-            "
+        @update="
+            (val) => onUpdateReferenceDatatype('statement_language_n1', val)
+        "
     />
 
     <!-- Statement Type: reference datatype -->
@@ -232,9 +221,10 @@ async function initializeSelectOptions() {
         :multi-value="false"
         :options="metatypeOptions"
         :pt-aria-labeled-by="labelMetatypeId"
-        @update="(val) =>
-            onUpdateReferenceDatatype('statement_type_metatype_n1', val)
-            "
+        @update="
+            (val) =>
+                onUpdateReferenceDatatype('statement_type_metatype_n1', val)
+        "
     />
 
     <!-- Statement Temporal Validity Start: date -->
@@ -242,16 +232,18 @@ async function initializeSelectOptions() {
         $gettext("Statement Temporal Validity Start")
     }}</label>
     <DateDatatype
-        :value="formValue?.statement_data_assignment_timespan_begin_of_the_begin
-            "
+        :value="
+            formValue?.statement_data_assignment_timespan_begin_of_the_begin
+        "
         :mode="EDIT"
         :pt-aria-labeled-by="labelStartId"
-        @update="(val) =>
-            onUpdateString(
-                'statement_data_assignment_timespan_begin_of_the_begin',
-                val,
-            )
-            "
+        @update="
+            (val) =>
+                onUpdateString(
+                    'statement_data_assignment_timespan_begin_of_the_begin',
+                    val,
+                )
+        "
     />
 
     <!-- Statement Temporal Validity End: date -->
@@ -262,12 +254,13 @@ async function initializeSelectOptions() {
         :value="formValue?.statement_data_assignment_timespan_end_of_the_end"
         :mode="EDIT"
         :pt-aria-labeled-by="labelEndId"
-        @update="(val) =>
-            onUpdateString(
-                'statement_data_assignment_timespan_end_of_the_end',
-                val,
-            )
-            "
+        @update="
+            (val) =>
+                onUpdateString(
+                    'statement_data_assignment_timespan_end_of_the_end',
+                    val,
+                )
+        "
     />
 
     <!-- Contributor: resource instance -->
@@ -278,13 +271,10 @@ async function initializeSelectOptions() {
         graph-slug="scheme"
         node-alias="statement_data_assignment_actor"
         :pt-aria-labeled-by="labelContributorId"
-        @updated="(val) =>
-            onUpdateResourceInstance(
-                'statement_data_assignment_actor',
-                val,
-                groupAndPersonOptions ?? [],
-            )
-            "
+        @updated="
+            (val: ResourceInstanceReference[]) =>
+                onUpdateResourceInstance('statement_data_assignment_actor', val)
+        "
     />
 
     <!-- Sources: resource instance -->
@@ -295,13 +285,13 @@ async function initializeSelectOptions() {
         graph-slug="scheme"
         node-alias="statement_data_assignment_object_used"
         :pt-aria-labeled-by="labelSourcesId"
-        @updated="(val: string[]) =>
-            onUpdateResourceInstance(
-                'statement_data_assignment_object_used',
-                val,
-                textualWorkOptions ?? [],
-            )
-            "
+        @updated="
+            (val: ResourceInstanceReference[]) =>
+                onUpdateResourceInstance(
+                    'statement_data_assignment_object_used',
+                    val,
+                )
+        "
     />
 
     <!-- Warrant Type: reference datatype -->
@@ -312,9 +302,10 @@ async function initializeSelectOptions() {
         :multi-value="false"
         :options="eventTypeOptions"
         :pt-aria-labeled-by="labelWarrantId"
-        @updated="(val) =>
-            onUpdateReferenceDatatype('statement_data_assignment_type', val)
-            "
+        @updated="
+            (val: ControlledListItem[]) =>
+                onUpdateReferenceDatatype('statement_data_assignment_type', val)
+        "
     />
 
     <Button

--- a/arches_lingo/src/arches_lingo/components/generic/ResourceInstanceRelationships.vue
+++ b/arches_lingo/src/arches_lingo/components/generic/ResourceInstanceRelationships.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import ResourceInstanceRelationshipsViewer from "@/arches_lingo/components/generic/resource-instance-relationships/ResourceInstanceRelationshipsViewer.vue";
 import ResourceInstanceRelationshipsEditor from "@/arches_lingo/components/generic/resource-instance-relationships/ResourceInstanceRelationshipsEditor.vue";
-import { EDIT, VIEW } from "@/arches_lingo/constants.ts";
+import { EDIT, UPDATED, VIEW } from "@/arches_lingo/constants.ts";
 import type {
     DataComponentMode,
     ResourceInstanceReference,
@@ -10,28 +10,30 @@ import type {
 const { mode = VIEW } = defineProps<{
     mode?: DataComponentMode;
     value?: ResourceInstanceReference[];
-    options?: ResourceInstanceReference[];
+    graphSlug?: string;
+    nodeAlias?: string;
     ptAriaLabeledBy?: string;
 }>();
 
-const emits = defineEmits(["update"]);
+const emit = defineEmits([UPDATED]);
 
-function onUpdate(val: string[]) {
-    emits("update", val);
+function onUpdate(val: ResourceInstanceReference[]) {
+    emit(UPDATED, val);
 }
 </script>
 <template>
     <div v-if="mode === VIEW">
         <ResourceInstanceRelationshipsViewer :value="value" />
     </div>
-    <div v-if="mode === EDIT">
+    <div v-if="mode === EDIT && graphSlug && nodeAlias">
         <ResourceInstanceRelationshipsEditor
-            :options="options"
             :val="
                 value?.map((referenceValue) => referenceValue.resourceId) ?? []
             "
             :pt-aria-labeled-by="ptAriaLabeledBy"
-            @update="onUpdate"
+            :graph-slug="graphSlug"
+            :node-alias="nodeAlias"
+            @updated="onUpdate"
         />
     </div>
 </template>

--- a/arches_lingo/src/arches_lingo/components/generic/resource-instance-relationships/ResourceInstanceRelationshipsEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/generic/resource-instance-relationships/ResourceInstanceRelationshipsEditor.vue
@@ -159,6 +159,17 @@ function createNewResource(graphId: string) {
     showNewResource.value = true;
     console.log(graphId);
 }
+
+function toggleSelectAll() {
+    // check all selected then remove all selected items
+    if (this.$refs.selectAll.allSelected) {
+        this.selectedItems = [];
+        return;
+    }
+
+    // else add all items
+    this.selectAll = true;
+}
 </script>
 <template>
     <MultiSelect
@@ -187,6 +198,15 @@ function createNewResource(graphId: string) {
         :placeholder="$gettext('Select Resources')"
         :aria-labelledby="ptAriaLabeledBy"
     >
+        <template #header>
+            <div
+                v-if="options.length > 1"
+                class="select-all"
+                @click="toggleSelectAll"
+            >
+                {{ $gettext("Select All Items") }}
+            </div>
+        </template>
         <template #footer>
             <div
                 v-for="element in newElements"
@@ -222,9 +242,16 @@ function createNewResource(graphId: string) {
 .relationship-footer-btn {
     width: 100%;
     border-radius: unset;
+    justify-content: flex-start;
 }
 
 .resource-instance-relationships-selector {
     max-width: 12rem;
+}
+
+.select-all {
+    position: absolute;
+    top: 0.6rem;
+    left: 2.7rem;
 }
 </style>

--- a/arches_lingo/src/arches_lingo/components/generic/resource-instance-relationships/ResourceInstanceRelationshipsEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/generic/resource-instance-relationships/ResourceInstanceRelationshipsEditor.vue
@@ -1,32 +1,90 @@
 <script setup lang="ts">
-import { computed, toRef, ref, watch } from "vue";
+import { computed, onMounted, ref, toRef, watch } from "vue";
 import MultiSelect from "primevue/multiselect";
-import type { ResourceInstanceReference } from "@/arches_lingo/types";
+import Button from "primevue/button";
+import Dialog from "primevue/dialog";
+import type {
+    GraphInfo,
+    NewResourceInstance,
+    ResourceInstanceReference,
+    ResourceInstanceResult,
+} from "@/arches_lingo/types";
 import { useGettext } from "vue3-gettext";
+import { fetchRelatableResources } from "@/arches_lingo/api.ts";
+import {
+    UPDATED,
+    CREATE_NEW_RESOURCE,
+    ERROR,
+    DEFAULT_ERROR_TOAST_LIFE,
+} from "@/arches_lingo/constants.ts";
+import type { VirtualScrollerLazyEvent } from "primevue/virtualscroller";
+import { useToast } from "primevue/usetoast";
 
+const showNewResource = ref(false);
 const { $gettext } = useGettext();
+const toast = useToast();
 
-const props = withDefaults(
-    defineProps<{
-        val?: string[];
-        options?: ResourceInstanceReference[];
-        ptAriaLabeledBy?: string;
-    }>(),
-    {
-        options: () => [],
-    },
-);
+const {
+    val,
+    graphSlug,
+    nodeAlias,
+    ptAriaLabeledBy,
+    itemHeight = 38,
+    resultsPerPage = 25,
+} = defineProps<{
+    val?: string[];
+    graphSlug: string;
+    nodeAlias: string;
+    ptAriaLabeledBy?: string;
+    itemHeight?: number;
+    resultsPerPage?: number;
+}>();
+const options = ref<ResourceInstanceReference[]>([]);
+const newElements = ref<NewResourceInstance[]>([]);
+const isLoading = ref(false);
+const isLoadingAdditionalResults = ref(false);
+const computedResourceResultsHeight = ref("");
+const resourceResultsPage = ref(1);
+const resourceResultsTotalCount = ref(resultsPerPage);
 
-const emit = defineEmits(["update"]);
+watch(options, (resourceResults) => {
+    if (resourceResults?.length) {
+        const rootFontSize = parseFloat(
+            getComputedStyle(document.documentElement).fontSize,
+        );
+        const itemHeightInRem = itemHeight / rootFontSize; // Convert to rem based on the root font size
+        const computedHeightInRem = resourceResults.length * itemHeightInRem;
 
-const valRef = toRef(props, "val");
+        const viewHeightInPixels = window.innerHeight * 0.6;
+        const viewHeightInRem = viewHeightInPixels / rootFontSize; // Convert 60vh to rem
+
+        if (computedHeightInRem > viewHeightInRem) {
+            computedResourceResultsHeight.value = "60vh";
+        } else {
+            computedResourceResultsHeight.value = `${computedHeightInRem}rem`;
+        }
+    } else {
+        computedResourceResultsHeight.value = "2.25rem";
+    }
+});
+
+onMounted(() => {
+    fetchData(1);
+});
+
+const emit = defineEmits([UPDATED, CREATE_NEW_RESOURCE]);
+
+const valRef = toRef(() => val);
 
 const value = computed({
     get() {
         return valRef.value;
     },
     set(value) {
-        emit("update", value);
+        const selected = options.value.filter((option) =>
+            value?.includes(option.resourceId),
+        );
+        emit(UPDATED, selected);
     },
 });
 
@@ -34,19 +92,139 @@ const primeVuePickerVal = ref(value.value);
 watch(primeVuePickerVal, (newVal) => {
     value.value = newVal;
 });
+
+async function fetchData(page: number) {
+    try {
+        const resourceData = await fetchRelatableResources(
+            graphSlug,
+            nodeAlias,
+            page,
+        );
+        const references = resourceData.data.map(
+            (
+                resourceRecord: ResourceInstanceResult,
+            ): ResourceInstanceReference => ({
+                displayValue: resourceRecord.display_value,
+                resourceId: resourceRecord.resourceinstanceid,
+                ontologyProperty: "",
+                inverseOntologyProperty: "",
+            }),
+        );
+
+        if (page === 1) {
+            options.value = references;
+            newElements.value = resourceData.graphs.map(
+                (graphInfo: GraphInfo): NewResourceInstance => ({
+                    displayValue: $gettext("Add a new %{graphName}", {
+                        graphName: graphInfo.name,
+                    }),
+                    graphId: graphInfo.graphid,
+                }),
+            );
+        } else {
+            options.value = [...options.value, ...references];
+        }
+
+        resourceResultsPage.value = resourceData.current_page;
+        resourceResultsTotalCount.value = resourceData.total_results;
+    } catch (error) {
+        toast.add({
+            severity: ERROR,
+            life: DEFAULT_ERROR_TOAST_LIFE,
+            summary: $gettext("Failed to fetch data."),
+            detail: error instanceof Error ? error.message : undefined,
+        });
+
+        options.value = [];
+        resourceResultsPage.value = 1;
+        resourceResultsTotalCount.value = 0;
+    } finally {
+        isLoading.value = false;
+        isLoadingAdditionalResults.value = false;
+    }
+}
+
+async function onLazyLoadResources(event: VirtualScrollerLazyEvent) {
+    if (
+        event.last >= resourceResultsPage.value * resultsPerPage &&
+        event.last <= resourceResultsTotalCount.value
+    ) {
+        isLoadingAdditionalResults.value = true;
+        const page = resourceResultsPage.value + 1;
+        fetchData(page);
+    }
+}
+
+function createNewResource(graphId: string) {
+    showNewResource.value = true;
+    console.log(graphId);
+}
 </script>
 <template>
     <MultiSelect
         v-model="primeVuePickerVal"
-        :show-toggle-all="!!options?.length"
+        :show-toggle-all="options?.length > 1"
         :options
-        option-label="display_value"
+        option-label="displayValue"
         option-value="resourceId"
+        class="resource-instance-relationships-selector"
+        :virtual-scroller-options="{
+            itemSize: itemHeight,
+            lazy: true,
+            onLazyLoad: onLazyLoadResources,
+            scrollHeight: computedResourceResultsHeight,
+            style: {
+                minHeight: computedResourceResultsHeight,
+                maxHeight: computedResourceResultsHeight,
+            },
+        }"
         :pt="{
             emptyMessage: { style: { fontFamily: 'sans-serif' } },
             option: { style: { fontFamily: 'sans-serif' } },
+            overlay: { style: { fontFamily: 'sans-serif' } },
         }"
+        :loading="isLoading && !isLoadingAdditionalResults"
         :placeholder="$gettext('Select Resources')"
-        :aria-labelledby="props.ptAriaLabeledBy"
-    />
+        :aria-labelledby="ptAriaLabeledBy"
+    >
+        <template #footer>
+            <div
+                v-for="element in newElements"
+                :key="`new-${element.graphId}`"
+            >
+                <Button
+                    class="relationship-footer-btn"
+                    :label="element.displayValue"
+                    severity="secondary"
+                    variant="text"
+                    @click="() => createNewResource(element.graphId)"
+                />
+            </div>
+        </template>
+    </MultiSelect>
+    <Dialog
+        v-model:visible="showNewResource"
+        :header="$gettext('New Resource')"
+        :dismissable-mask="true"
+        :close-on-escape="true"
+        :modal="true"
+        :pt="{
+            root: {
+                style: {
+                    borderRadius: '0',
+                    fontFamily: 'sans-serif',
+                },
+            },
+        }"
+    ></Dialog>
 </template>
+<style lang="css" scoped>
+.relationship-footer-btn {
+    width: 100%;
+    border-radius: unset;
+}
+
+.resource-instance-relationships-selector {
+    max-width: 12rem;
+}
+</style>

--- a/arches_lingo/src/arches_lingo/components/generic/resource-instance-relationships/ResourceInstanceRelationshipsViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/generic/resource-instance-relationships/ResourceInstanceRelationshipsViewer.vue
@@ -17,7 +17,7 @@ withDefaults(defineProps<{ value?: ResourceInstanceReference[] }>(), {
             class="resource-instance-relationship-view"
         >
             <a :href="`${arches.urls.resource_editor}${val.resourceId}`">
-                {{ val.display_value }}
+                {{ val.displayValue }}
             </a>
         </span>
     </span>

--- a/arches_lingo/src/arches_lingo/components/scheme/report/SchemeStandard.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/report/SchemeStandard.vue
@@ -11,7 +11,6 @@ import SchemeReportSection from "@/arches_lingo/components/scheme/report/SchemeS
 import {
     createScheme,
     fetchLingoResourcePartial,
-    fetchLingoResources,
     updateLingoResource,
 } from "@/arches_lingo/api.ts";
 import {
@@ -23,11 +22,9 @@ import {
     ERROR,
 } from "@/arches_lingo/constants.ts";
 
-import type { Language } from "@/arches_vue_utils/types.ts";
 import type {
     DataComponentMode,
     ResourceInstanceReference,
-    ResourceInstanceResult,
     SchemeInstance,
 } from "@/arches_lingo/types";
 

--- a/arches_lingo/src/arches_lingo/constants.ts
+++ b/arches_lingo/src/arches_lingo/constants.ts
@@ -9,6 +9,7 @@ export const CONTRAST = "contrast";
 export const EDIT = "edit";
 export const VIEW = "view";
 export const OPEN_EDITOR = "openEditor";
+export const CREATE_NEW_RESOURCE = "createNewResource";
 export const UPDATED = "updated";
 export const NEW = "new";
 export const MAXIMIZE = "maximize";

--- a/arches_lingo/src/arches_lingo/types.ts
+++ b/arches_lingo/src/arches_lingo/types.ts
@@ -75,13 +75,24 @@ export interface ResourceInstanceReference {
     ontologyProperty: string;
     resourceXresourceId?: string;
     inverseOntologyProperty: string;
-    display_value?: string;
+    displayValue?: string;
+}
+
+export interface NewResourceInstance {
+    displayValue: string;
+    graphId: string;
 }
 
 export interface ResourceInstanceResult {
     resourceinstanceid: string;
-    descriptors: { [key: string]: { name: string } };
+    display_value: string;
 }
+
+export interface GraphInfo {
+    graphid: string;
+    name: string;
+}
+
 interface ControlledListItemValue {
     value: string;
 }

--- a/arches_lingo/templates/arches_urls.htm
+++ b/arches_lingo/templates/arches_urls.htm
@@ -9,6 +9,7 @@
 <div class="arches-urls"
     api_concepts="{% url 'api-concepts' %}"
     api_search="{% url 'api-search' %}"
+    api_relatable_resources='(graphSlug, nodeAlias) => {return "{% url "api-node-relatable-resources" "----p1" "----p2" %}".replace("----p1", graphSlug).replace("----p2", nodeAlias)}'
     api_lingo_resources='(graphslug) => {return "{% url "api-lingo-resources" "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" %}".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", graphslug)}'
     api_lingo_resource='(graphslug, resourceinstanceid) => { return "{% url "api-lingo-resource" "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" %}".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", graphslug).replace("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", resourceinstanceid)}'
     api_lingo_resource_partial='(graphslug, resourceinstanceid, nodegroupAlias) => { return "{% url "api-lingo-resource-partial" "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" "cccccccc-cccc-cccc-cccc-cccccccccccc" %}".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", graphslug).replace("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", resourceinstanceid).replace("cccccccc-cccc-cccc-cccc-cccccccccccc", nodegroupAlias)}'

--- a/arches_lingo/urls.py
+++ b/arches_lingo/urls.py
@@ -4,6 +4,7 @@ from django.conf.urls.i18n import i18n_patterns
 from django.urls import include, path
 
 from arches_lingo.views.root import LingoRootView
+from arches_lingo.views.api.relatable_resources import RelatableResourcesView
 from arches_lingo.views.api.concepts import ConceptTreeView, ValueSearchView
 from arches_lingo.views.api.generic import (
     LingoResourceDetailView,
@@ -23,6 +24,11 @@ urlpatterns = [
     path("concept/<uuid:id>", LingoRootView.as_view(), name="concept"),
     path("api/concept-tree", ConceptTreeView.as_view(), name="api-concepts"),
     path("api/search", ValueSearchView.as_view(), name="api-search"),
+    path(
+        "api/lingo/<slug:graph_slug>/node/<slug:node_alias>/relatable-resources",
+        RelatableResourcesView.as_view(),
+        name="api-node-relatable-resources",
+    ),
     path(
         "api/lingo/<slug:graph>",
         LingoResourceListCreateView.as_view(),

--- a/arches_lingo/views/api/relatable_resources.py
+++ b/arches_lingo/views/api/relatable_resources.py
@@ -1,0 +1,56 @@
+from django.core.paginator import Paginator
+from django.utils.decorators import method_decorator
+from arches.app.utils.decorators import group_required
+from django.views import View
+from django.utils.translation import get_language
+from arches.app.models.models import Node, ResourceInstance, GraphModel
+from arches.app.utils.response import JSONResponse
+from arches.app.utils.betterJSONSerializer import JSONDeserializer
+
+from arches.app.utils.decorators import can_edit_resource_instance
+
+
+@method_decorator(can_edit_resource_instance, name="dispatch")
+class RelatableResourcesView(View):
+    def get(self, request, graph_slug, node_alias):
+        node = Node.objects.get(
+            name=node_alias,
+            graph__slug=graph_slug,
+            graph__is_active=True,
+            graph__publication__isnull=False,
+        )
+        page_number = request.GET.get("page", 1)
+        items_per_page = request.GET.get("items", 25)
+
+        config = JSONDeserializer().deserialize(node.config.value)
+        graphs = [graph["graphid"] for graph in config.get("graphs", [])]
+
+        graph_models = GraphModel.objects.filter(graphid__in=graphs).values(
+            "name", "graphid"
+        )
+
+        resources = ResourceInstance.objects.filter(graph_id__in=graphs).order_by(
+            "descriptors__{}__name".format(get_language())
+        )
+
+        paginator = Paginator(resources, items_per_page)
+        page_object = paginator.get_page(page_number)
+        language = get_language()
+        data = [
+            {
+                "resourceinstanceid": resource.resourceinstanceid,
+                "display_value": resource.descriptors[language]["name"],
+            }
+            for resource in page_object
+        ]
+
+        return JSONResponse(
+            {
+                "graphs": graph_models,
+                "current_page": paginator.get_page(page_number).number,
+                "total_pages": paginator.num_pages,
+                "results_per_page": paginator.per_page,
+                "total_results": paginator.count,
+                "data": data,
+            }
+        )


### PR DESCRIPTION
Widget now fetches its own resource lists based on graph and node slugs.  Adds new footer to create new resources, which opens an empty dialog.  