### PR TITLE
Update graphs for correct tile keys, cope with reference datatype changes

### DIFF
--- a/arches_lingo/pkg/graphs/resource_models/Concept.json
+++ b/arches_lingo/pkg/graphs/resource_models/Concept.json
@@ -405,7 +405,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/7b873aed-1dbd-45e4-98e7-85143ee453c6"
                             }
                         ],
@@ -441,7 +441,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/02a0fc69-9f92-4bef-b657-af1ed37c1d3e"
                             }
                         ],
@@ -571,7 +571,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
+                                "list_id": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/14751cb1-f7af-45d9-b32a-59d150bdac0f"
                             }
                         ],
@@ -780,7 +780,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
+                                "list_id": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/14751cb1-f7af-45d9-b32a-59d150bdac0f"
                             }
                         ],
@@ -1034,7 +1034,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/7b873aed-1dbd-45e4-98e7-85143ee453c6"
                             }
                         ],
@@ -1092,7 +1092,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
+                                "list_id": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/14751cb1-f7af-45d9-b32a-59d150bdac0f"
                             }
                         ],
@@ -1172,7 +1172,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
+                                "list_id": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/14751cb1-f7af-45d9-b32a-59d150bdac0f"
                             }
                         ],
@@ -1229,7 +1229,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "a8da34eb-575b-498c-ada7-161ee745fd16",
+                                "list_id": "a8da34eb-575b-498c-ada7-161ee745fd16",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/d98bfcab-fa26-4c8b-992d-a56eb7bbbaa2"
                             }
                         ],
@@ -1330,7 +1330,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
+                                "list_id": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/14751cb1-f7af-45d9-b32a-59d150bdac0f"
                             }
                         ],
@@ -1519,7 +1519,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/9c93be63-b900-4f63-b0cf-7351e5129508"
                             }
                         ],
@@ -1598,7 +1598,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
+                                "list_id": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/14751cb1-f7af-45d9-b32a-59d150bdac0f"
                             }
                         ],
@@ -2202,7 +2202,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/9c93be63-b900-4f63-b0cf-7351e5129508"
                             }
                         ],
@@ -2259,7 +2259,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/7b873aed-1dbd-45e4-98e7-85143ee453c6"
                             }
                         ],
@@ -2393,7 +2393,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
+                                "list_id": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/52eb8678-485d-418c-9ad2-aa97d077ac56"
                             }
                         ],
@@ -2429,7 +2429,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/7b873aed-1dbd-45e4-98e7-85143ee453c6"
                             }
                         ],

--- a/arches_lingo/pkg/graphs/resource_models/Scheme.json
+++ b/arches_lingo/pkg/graphs/resource_models/Scheme.json
@@ -318,7 +318,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "fb5dd406-33ef-4e83-a6a9-9ea02c1ada17",
+                                "list_id": "fb5dd406-33ef-4e83-a6a9-9ea02c1ada17",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/929bfdbf-a592-4f70-bd8b-9c11deb6bff9"
                             }
                         ],
@@ -376,7 +376,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
+                                "list_id": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/14751cb1-f7af-45d9-b32a-59d150bdac0f"
                             }
                         ],
@@ -434,7 +434,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "a8da34eb-575b-498c-ada7-161ee745fd16",
+                                "list_id": "a8da34eb-575b-498c-ada7-161ee745fd16",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/de263fe8-5ebd-4d6c-a7c7-8068598ba962"
                             }
                         ],
@@ -470,7 +470,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/9c93be63-b900-4f63-b0cf-7351e5129508"
                             }
                         ],
@@ -592,7 +592,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/02a0fc69-9f92-4bef-b657-af1ed37c1d3e"
                             }
                         ],
@@ -628,7 +628,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
+                                "list_id": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/52eb8678-485d-418c-9ad2-aa97d077ac56"
                             }
                         ],
@@ -857,7 +857,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
+                                "list_id": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/14751cb1-f7af-45d9-b32a-59d150bdac0f"
                             }
                         ],
@@ -1181,7 +1181,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "a8da34eb-575b-498c-ada7-161ee745fd16",
+                                "list_id": "a8da34eb-575b-498c-ada7-161ee745fd16",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/926aa6de-a7e6-4959-9fc4-5ea87c46d677"
                             }
                         ],
@@ -1438,7 +1438,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/7b873aed-1dbd-45e4-98e7-85143ee453c6"
                             }
                         ],

--- a/arches_lingo/pkg/graphs/resource_models/digital_object_rdm_system.json
+++ b/arches_lingo/pkg/graphs/resource_models/digital_object_rdm_system.json
@@ -319,7 +319,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/02a0fc69-9f92-4bef-b657-af1ed37c1d3e"
                             }
                         ],
@@ -355,7 +355,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
+                                "list_id": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/52eb8678-485d-418c-9ad2-aa97d077ac56"
                             }
                         ],
@@ -495,7 +495,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/9c93be63-b900-4f63-b0cf-7351e5129508"
                             }
                         ],

--- a/arches_lingo/pkg/graphs/resource_models/group_rdm_system.json
+++ b/arches_lingo/pkg/graphs/resource_models/group_rdm_system.json
@@ -303,7 +303,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/9c93be63-b900-4f63-b0cf-7351e5129508"
                             }
                         ],
@@ -339,7 +339,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/02a0fc69-9f92-4bef-b657-af1ed37c1d3e"
                             }
                         ],
@@ -375,7 +375,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
+                                "list_id": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/52eb8678-485d-418c-9ad2-aa97d077ac56"
                             }
                         ],

--- a/arches_lingo/pkg/graphs/resource_models/period_rdm_system.json
+++ b/arches_lingo/pkg/graphs/resource_models/period_rdm_system.json
@@ -171,7 +171,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
+                                "list_id": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/14751cb1-f7af-45d9-b32a-59d150bdac0f"
                             }
                         ],
@@ -389,7 +389,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/7b873aed-1dbd-45e4-98e7-85143ee453c6"
                             }
                         ],
@@ -633,7 +633,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/02a0fc69-9f92-4bef-b657-af1ed37c1d3e"
                             }
                         ],
@@ -669,7 +669,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
+                                "list_id": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/52eb8678-485d-418c-9ad2-aa97d077ac56"
                             }
                         ],
@@ -903,7 +903,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
+                                "list_id": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/14751cb1-f7af-45d9-b32a-59d150bdac0f"
                             }
                         ],
@@ -961,7 +961,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/9c93be63-b900-4f63-b0cf-7351e5129508"
                             }
                         ],

--- a/arches_lingo/pkg/graphs/resource_models/person_rdm_system.json
+++ b/arches_lingo/pkg/graphs/resource_models/person_rdm_system.json
@@ -259,7 +259,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/02a0fc69-9f92-4bef-b657-af1ed37c1d3e"
                             }
                         ],
@@ -295,7 +295,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
+                                "list_id": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/52eb8678-485d-418c-9ad2-aa97d077ac56"
                             }
                         ],
@@ -435,7 +435,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/9c93be63-b900-4f63-b0cf-7351e5129508"
                             }
                         ],

--- a/arches_lingo/pkg/graphs/resource_models/place_rdm_system.json
+++ b/arches_lingo/pkg/graphs/resource_models/place_rdm_system.json
@@ -334,7 +334,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/7b873aed-1dbd-45e4-98e7-85143ee453c6"
                             }
                         ],
@@ -518,7 +518,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/02a0fc69-9f92-4bef-b657-af1ed37c1d3e"
                             }
                         ],
@@ -554,7 +554,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
+                                "list_id": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/52eb8678-485d-418c-9ad2-aa97d077ac56"
                             }
                         ],
@@ -788,7 +788,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
+                                "list_id": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/14751cb1-f7af-45d9-b32a-59d150bdac0f"
                             }
                         ],
@@ -824,7 +824,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
+                                "list_id": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/14751cb1-f7af-45d9-b32a-59d150bdac0f"
                             }
                         ],
@@ -1012,7 +1012,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/9c93be63-b900-4f63-b0cf-7351e5129508"
                             }
                         ],

--- a/arches_lingo/pkg/graphs/resource_models/textual_work_rdm_system.json
+++ b/arches_lingo/pkg/graphs/resource_models/textual_work_rdm_system.json
@@ -300,7 +300,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/02a0fc69-9f92-4bef-b657-af1ed37c1d3e"
                             }
                         ],
@@ -336,7 +336,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
+                                "list_id": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/52eb8678-485d-418c-9ad2-aa97d077ac56"
                             }
                         ],
@@ -476,7 +476,7 @@
                                         "valuetype_id": "prefLabel"
                                     }
                                 ],
-                                "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                 "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/9c93be63-b900-4f63-b0cf-7351e5129508"
                             }
                         ],

--- a/arches_lingo/serializers.py
+++ b/arches_lingo/serializers.py
@@ -4,6 +4,7 @@ from rest_framework.exceptions import ValidationError
 from arches.app.models.models import ResourceInstance, TileModel
 from arches.app.models.serializers import ArchesModelSerializer, ArchesTileSerializer
 
+from arches_references.datatypes.datatypes import ReferenceDataType
 from arches_references.models import ListItem
 
 
@@ -24,6 +25,24 @@ class LingoTileSerializer(ArchesTileSerializer):
         fields = "__all__"
 
     def validate_appellative_status(self, data):
+        if data:
+            # TODO: consider having serializer run to_python().
+            if new_label_languages := ReferenceDataType().to_python(
+                data.get("appellative_status_ascribed_name_language")
+            ):
+                new_label_lang = new_label_languages[0]
+            if new_label_types := ReferenceDataType().to_python(
+                data.get("appellative_status_ascribed_relation")
+            ):
+                new_label_type = new_label_types[0]
+
+            if new_label_lang and new_label_type:
+                self._check_pref_label_uniqueness(data, new_label_lang, new_label_type)
+
+        return data
+
+    @staticmethod
+    def _check_pref_label_uniqueness(data, new_label_language, new_label_type):
         try:
             PREF_LABEL = ListItem.objects.get(list_item_values__value="prefLabel")
         except ListItem.MultipleObjectsReturned:
@@ -32,32 +51,20 @@ class LingoTileSerializer(ArchesTileSerializer):
             )
             raise ValidationError(msg)
 
-        if data:
-            # TODO: reduce nested-fallback awkwardness by returning a dataclass from
-            # ReferenceDataType.to_python() and feeding incoming data to it.
-            new_label_language = next(
-                iter(data.get("appellative_status_ascribed_name_language", None) or []),
-                {},
-            )
-            new_label_type = next(
-                iter(data.get("appellative_status_ascribed_relation", None) or []), {}
-            )
-            current_labels = data["resourceinstance"].appellative_status
-
-            for label in current_labels:
-                label_language = next(
-                    iter(label.appellative_status_ascribed_name_language or []), {}
-                )
-                label_type = next(
-                    iter(label.appellative_status_ascribed_relation or []), {}
-                )
-                if (
-                    data.get("tileid", None) not in (None, label.tileid)
-                    and new_label_type.get("uri", "") == PREF_LABEL.uri
-                    and label_type.get("uri", "") == PREF_LABEL.uri
-                    and label_language.get("uri", "")
-                    == new_label_language.get("uri", "")
-                ):
-                    msg = _("Only one preferred label per language is permitted.")
-                    raise ValidationError(msg)
-        return data
+        for label in data["resourceinstance"].appellative_status or []:
+            if label_languages := label.appellative_status_ascribed_name_language:
+                label_language = label_languages[0]
+            else:
+                continue
+            if label_types := label.appellative_status_ascribed_relation:
+                label_type = label_types[0]
+            else:
+                continue
+            if (
+                data.get("tileid") != label.tileid
+                and new_label_type.uri == PREF_LABEL.uri
+                and label_type.uri == PREF_LABEL.uri
+                and label_language.uri == new_label_language.uri
+            ):
+                msg = _("Only one preferred label per language is permitted.")
+                raise ValidationError(msg)

--- a/tests/fixtures/data/aat_entries_scheme_examples.json
+++ b/tests/fixtures/data/aat_entries_scheme_examples.json
@@ -35,7 +35,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
+                                    "list_id": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/989ca6d8-2376-45c1-af07-3689d41e5602"
                                 }
                             ],
@@ -50,7 +50,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "deb847fc-f4c3-4e82-be19-04641579f129",
+                                    "list_id": "deb847fc-f4c3-4e82-be19-04641579f129",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/2e3a2045-b44e-47fc-a27b-3078b17e08e4"
                                 }
                             ]
@@ -81,7 +81,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "38fc54d4-67ef-4183-8934-66669f1f504c",
+                                    "list_id": "38fc54d4-67ef-4183-8934-66669f1f504c",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/9baf3cd5-33d4-4fbc-b1d1-a2d218732f1e"
                                 }
                             ]

--- a/tests/fixtures/data/digital_object_rdm_system_example_data.json
+++ b/tests/fixtures/data/digital_object_rdm_system_example_data.json
@@ -45,7 +45,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
+                                    "list_id": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/845cc417-ef77-4582-9271-ffba5e4cabc9"
                                 }
                             ],
@@ -60,7 +60,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "891574cc-47bf-4395-a512-d246cd75c1a1",
+                                    "list_id": "891574cc-47bf-4395-a512-d246cd75c1a1",
                                     "uri": "http://localhost:8000/plugins/controlled-list-manager/item/bc6ce063-7ad5-4b92-8685-000bfe27ebf2"
                                 }
                             ]
@@ -85,7 +85,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "f028fe8e-5a23-40a7-8ffe-7865ebac9487",
+                                    "list_id": "f028fe8e-5a23-40a7-8ffe-7865ebac9487",
                                     "uri": "http://localhost:8000/plugins/controlled-list-manager/item/fe814127-d68f-43ed-beb9-67a8d4d6336e"
                                 }
                             ],
@@ -122,7 +122,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                    "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/9c93be63-b900-4f63-b0cf-7351e5129508"
                                 }
                             ]
@@ -147,7 +147,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
+                                    "list_id": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/845cc417-ef77-4582-9271-ffba5e4cabc9"
                                 }
                             ],
@@ -162,7 +162,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                    "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/02a0fc69-9f92-4bef-b657-af1ed37c1d3e"
                                 }
                             ],
@@ -177,7 +177,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
+                                    "list_id": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/52eb8678-485d-418c-9ad2-aa97d077ac56"
                                 }
                             ],

--- a/tests/fixtures/data/group_rdm_system_example_data.json
+++ b/tests/fixtures/data/group_rdm_system_example_data.json
@@ -45,7 +45,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
+                                    "list_id": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/845cc417-ef77-4582-9271-ffba5e4cabc9"
                                 }
                             ],
@@ -60,7 +60,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "891574cc-47bf-4395-a512-d246cd75c1a1",
+                                    "list_id": "891574cc-47bf-4395-a512-d246cd75c1a1",
                                     "uri": "http://localhost:8000/plugins/controlled-list-manager/item/bc6ce063-7ad5-4b92-8685-000bfe27ebf2"
                                 }
                             ]
@@ -85,7 +85,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "f028fe8e-5a23-40a7-8ffe-7865ebac9487",
+                                    "list_id": "f028fe8e-5a23-40a7-8ffe-7865ebac9487",
                                     "uri": "http://localhost:8000/plugins/controlled-list-manager/item/fe814127-d68f-43ed-beb9-67a8d4d6336e"
                                 }
                             ],
@@ -122,7 +122,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                    "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/9c93be63-b900-4f63-b0cf-7351e5129508"
                                 }
                             ]
@@ -147,7 +147,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
+                                    "list_id": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/845cc417-ef77-4582-9271-ffba5e4cabc9"
                                 }
                             ],
@@ -162,7 +162,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                    "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/02a0fc69-9f92-4bef-b657-af1ed37c1d3e"
                                 }
                             ],
@@ -177,7 +177,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
+                                    "list_id": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/52eb8678-485d-418c-9ad2-aa97d077ac56"
                                 }
                             ],

--- a/tests/fixtures/data/period_rdm_system_example_data.json
+++ b/tests/fixtures/data/period_rdm_system_example_data.json
@@ -34,7 +34,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
+                                    "list_id": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/14751cb1-f7af-45d9-b32a-59d150bdac0f"
                                 }
                             ],
@@ -49,7 +49,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "2cc0e054-ef9b-41ae-8e86-e0c3b4e7ca00",
+                                    "list_id": "2cc0e054-ef9b-41ae-8e86-e0c3b4e7ca00",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/c1d8c87d-183c-4c46-aa6f-7920825cba5e"
                                 }
                             ],
@@ -64,7 +64,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                    "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/7b873aed-1dbd-45e4-98e7-85143ee453c6"
                                 }
                             ],
@@ -92,7 +92,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
+                                    "list_id": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/845cc417-ef77-4582-9271-ffba5e4cabc9"
                                 }
                             ],
@@ -108,7 +108,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "deb847fc-f4c3-4e82-be19-04641579f129",
+                                    "list_id": "deb847fc-f4c3-4e82-be19-04641579f129",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/2e3a2045-b44e-47fc-a27b-3078b17e08e4"
                                 }
                             ]
@@ -156,7 +156,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                    "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/9c93be63-b900-4f63-b0cf-7351e5129508"
                                 }
                             ]
@@ -181,7 +181,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
+                                    "list_id": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/14751cb1-f7af-45d9-b32a-59d150bdac0f"
                                 }
                             ],
@@ -198,7 +198,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
+                                    "list_id": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/845cc417-ef77-4582-9271-ffba5e4cabc9"
                                 }
                             ],
@@ -213,7 +213,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                    "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/02a0fc69-9f92-4bef-b657-af1ed37c1d3e"
                                 }
                             ],
@@ -228,7 +228,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
+                                    "list_id": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/52eb8678-485d-418c-9ad2-aa97d077ac56"
                                 }
                             ],

--- a/tests/fixtures/data/person_rdm_system_example_data.json
+++ b/tests/fixtures/data/person_rdm_system_example_data.json
@@ -45,7 +45,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "891574cc-47bf-4395-a512-d246cd75c1a1",
+                                    "list_id": "891574cc-47bf-4395-a512-d246cd75c1a1",
                                     "uri": "http://localhost:8000/plugins/controlled-list-manager/item/bc6ce063-7ad5-4b92-8685-000bfe27ebf2"
                                 }
                             ],
@@ -60,7 +60,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
+                                    "list_id": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/845cc417-ef77-4582-9271-ffba5e4cabc9"
                                 }
                             ]
@@ -85,7 +85,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "f028fe8e-5a23-40a7-8ffe-7865ebac9487",
+                                    "list_id": "f028fe8e-5a23-40a7-8ffe-7865ebac9487",
                                     "uri": "http://localhost:8000/plugins/controlled-list-manager/item/fe814127-d68f-43ed-beb9-67a8d4d6336e"
                                 }
                             ],
@@ -122,7 +122,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                    "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/9c93be63-b900-4f63-b0cf-7351e5129508"
                                 }
                             ]
@@ -147,7 +147,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
+                                    "list_id": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/845cc417-ef77-4582-9271-ffba5e4cabc9"
                                 }
                             ],
@@ -162,7 +162,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                    "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/02a0fc69-9f92-4bef-b657-af1ed37c1d3e"
                                 }
                             ],
@@ -177,7 +177,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
+                                    "list_id": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/52eb8678-485d-418c-9ad2-aa97d077ac56"
                                 }
                             ],

--- a/tests/fixtures/data/place_rdm_system_example_data.json
+++ b/tests/fixtures/data/place_rdm_system_example_data.json
@@ -63,7 +63,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "2cc0e054-ef9b-41ae-8e86-e0c3b4e7ca00",
+                                    "list_id": "2cc0e054-ef9b-41ae-8e86-e0c3b4e7ca00",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/c1d8c87d-183c-4c46-aa6f-7920825cba5e"
                                 }
                             ],
@@ -78,7 +78,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                    "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/7b873aed-1dbd-45e4-98e7-85143ee453c6"
                                 }
                             ],
@@ -106,7 +106,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
+                                    "list_id": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/845cc417-ef77-4582-9271-ffba5e4cabc9"
                                 }
                             ],
@@ -122,7 +122,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "deb847fc-f4c3-4e82-be19-04641579f129",
+                                    "list_id": "deb847fc-f4c3-4e82-be19-04641579f129",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/2e3a2045-b44e-47fc-a27b-3078b17e08e4"
                                 }
                             ],
@@ -137,7 +137,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
+                                    "list_id": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/14751cb1-f7af-45d9-b32a-59d150bdac0f"
                                 }
                             ]
@@ -162,7 +162,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "f028fe8e-5a23-40a7-8ffe-7865ebac9487",
+                                    "list_id": "f028fe8e-5a23-40a7-8ffe-7865ebac9487",
                                     "uri": "http://localhost:8000/plugins/controlled-list-manager/item/fe814127-d68f-43ed-beb9-67a8d4d6336e"
                                 }
                             ],
@@ -199,7 +199,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                    "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/9c93be63-b900-4f63-b0cf-7351e5129508"
                                 }
                             ]
@@ -224,7 +224,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
+                                    "list_id": "6eaa2c6f-af83-464c-9200-051c4cfe7e8e",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/14751cb1-f7af-45d9-b32a-59d150bdac0f"
                                 }
                             ],
@@ -241,7 +241,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
+                                    "list_id": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/845cc417-ef77-4582-9271-ffba5e4cabc9"
                                 }
                             ],
@@ -256,7 +256,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                    "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/02a0fc69-9f92-4bef-b657-af1ed37c1d3e"
                                 }
                             ],
@@ -271,7 +271,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
+                                    "list_id": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/52eb8678-485d-418c-9ad2-aa97d077ac56"
                                 }
                             ],

--- a/tests/fixtures/data/textual_work_rdm_system_example_data.json
+++ b/tests/fixtures/data/textual_work_rdm_system_example_data.json
@@ -45,7 +45,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
+                                    "list_id": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/845cc417-ef77-4582-9271-ffba5e4cabc9"
                                 }
                             ],
@@ -60,7 +60,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "891574cc-47bf-4395-a512-d246cd75c1a1",
+                                    "list_id": "891574cc-47bf-4395-a512-d246cd75c1a1",
                                     "uri": "http://localhost:8000/plugins/controlled-list-manager/item/bc6ce063-7ad5-4b92-8685-000bfe27ebf2"
                                 }
                             ]
@@ -85,7 +85,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "f028fe8e-5a23-40a7-8ffe-7865ebac9487",
+                                    "list_id": "f028fe8e-5a23-40a7-8ffe-7865ebac9487",
                                     "uri": "http://localhost:8000/plugins/controlled-list-manager/item/fe814127-d68f-43ed-beb9-67a8d4d6336e"
                                 }
                             ],
@@ -122,7 +122,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                    "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/9c93be63-b900-4f63-b0cf-7351e5129508"
                                 }
                             ]
@@ -147,7 +147,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
+                                    "list_id": "55ce793b-a51a-4b25-811d-d08ea797f8c3",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/845cc417-ef77-4582-9271-ffba5e4cabc9"
                                 }
                             ],
@@ -162,7 +162,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
+                                    "list_id": "ef69e772-de53-45fe-98d4-bf3e7b10eb57",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/02a0fc69-9f92-4bef-b657-af1ed37c1d3e"
                                 }
                             ],
@@ -177,7 +177,7 @@
                                             "valuetype_id": "prefLabel"
                                         }
                                     ],
-                                    "listid": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
+                                    "list_id": "aba2a0b4-75a4-45ba-8b57-021f3ca92a6a",
                                     "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/52eb8678-485d-418c-9ad2-aa97d077ac56"
                                 }
                             ],


### PR DESCRIPTION
This is the partner PR to archesproject/arches-references#59.

 - Fix `listid` -> `list_id` in models (default value for references dt nodes)
 - Use the dataclass syntax (`.uri` not `["uri"]` assuming archesproject/arches-references#59 merges)
 - Rewrite the `validate_appellative_status()` method for explicitness, fewer nested fallbacks like `next(iter(...`


Should wait to merge this until archesproject/arches-references#59.