### PR TITLE
Remove parent tile workaround

### DIFF
--- a/arches_lingo/serializers.py
+++ b/arches_lingo/serializers.py
@@ -3,7 +3,6 @@ from rest_framework.exceptions import ValidationError
 
 from arches.app.models.models import ResourceInstance, TileModel
 from arches.app.models.serializers import ArchesModelSerializer, ArchesTileSerializer
-from arches.app.models.tile import Tile
 
 from arches_references.models import ListItem
 
@@ -16,41 +15,12 @@ class LingoResourceSerializer(ArchesModelSerializer):
         nodegroups = "__all__"
         fields = "__all__"
 
-    def create(self, validated_data):
-        """Repair parenttile until fixed in core."""
-        created = super().create(validated_data)
-        if created.right_statement:
-            self.repair_right_statement(created)
-        return created
-
-    def update(self, instance, validated_data):
-        """Repair parenttile until fixed in core."""
-        updated = super().update(instance, validated_data)
-        if updated.right_statement:
-            self.repair_right_statement(updated)
-        return updated
-
-    def repair_right_statement(self, instance):
-        # Shouldn't need to refresh_from_db() here, but I'll (jtw)
-        # look into that later, since this is all just a workaround.
-        instance.refresh_from_db()
-        if not instance.rights:
-            instance.rights = Tile.get_blank_tile_from_nodegroup_id(
-                instance.right_statement.nodegroup.parentnodegroup_id,
-                resourceid=instance.resourceinstanceid,
-            )
-            instance.rights.save()
-
-        instance.right_statement.parenttile = instance.rights
-        instance.right_statement.save()
-        return instance
-
 
 class LingoTileSerializer(ArchesTileSerializer):
     class Meta:
         model = TileModel
-        graph_slug = None  # generic
-        root_node = None  # generic
+        graph_slug = None
+        root_node = None
         fields = "__all__"
 
     def validate_appellative_status(self, data):

--- a/arches_lingo/src/arches_lingo/components/scheme/report/SchemeLicense.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/report/SchemeLicense.vue
@@ -20,6 +20,7 @@ import type {
     DataComponentMode,
     ResourceInstanceReference,
     ResourceInstanceResult,
+    SchemeInstance,
     SchemeRights,
     SchemeRightStatement,
 } from "@/arches_lingo/types";
@@ -196,9 +197,13 @@ function onUpdateString(node: keyof SchemeRightStatement, val: string) {
 }
 
 async function saveRights() {
-    const schemeInstance = {
-        rights: schemeRights.value,
-        right_statement: schemeRightStatement.value,
+    const schemeInstance: SchemeInstance = {
+        // We could have just tracked a dirty value of the partial
+        // scheme, but since we didn't, build it now.
+        rights: {
+            ...schemeRights.value,
+            right_statement: schemeRightStatement.value,
+        },
     };
     try {
         let updated;
@@ -238,7 +243,7 @@ async function getSectionValue() {
     if (schemeInstance?.rights) {
         parentExists.value = true;
     }
-    schemeRightStatement.value = schemeInstance?.right_statement ?? {};
+    schemeRightStatement.value = schemeInstance?.rights?.right_statement ?? {};
 }
 
 defineExpose({ getSectionValue });

--- a/arches_lingo/src/arches_lingo/declarations.test.ts
+++ b/arches_lingo/src/arches_lingo/declarations.test.ts
@@ -1,1 +1,0 @@
-// empty test file to register coverage of `declarations.d.ts`

--- a/arches_lingo/src/arches_lingo/types.ts
+++ b/arches_lingo/src/arches_lingo/types.ts
@@ -147,6 +147,7 @@ export interface SchemeRights {
     tileid?: string;
     right_holder?: ResourceInstanceReference[];
     right_type?: ControlledListItem[];
+    right_statement?: SchemeRightStatement;
 }
 
 export interface SchemeRightStatement {
@@ -184,7 +185,6 @@ export interface SchemeInstance {
     appellative_status?: AppellativeStatus[];
     statement?: SchemeStatement[];
     rights?: SchemeRights;
-    right_statement?: SchemeRightStatement;
 }
 
 export interface SchemeResource {

--- a/arches_lingo/views/api/generic.py
+++ b/arches_lingo/views/api/generic.py
@@ -6,10 +6,7 @@ from rest_framework.generics import (
 from arches.app.permissions.rest_framework import RDMAdministrator
 from arches.app.views.api.mixins import ArchesModelAPIMixin
 
-from arches_lingo.serializers import (
-    LingoResourceSerializer,
-    LingoTileSerializer,
-)
+from arches_lingo.serializers import LingoResourceSerializer, LingoTileSerializer
 
 
 class LingoResourceListCreateView(ArchesModelAPIMixin, ListCreateAPIView):

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import vue from "@vitejs/plugin-vue";
 
+import { fileURLToPath } from 'url';
 import { defineConfig } from 'vite';
 
 import type { UserConfigExport } from 'vite';
@@ -9,7 +10,10 @@ import type { UserConfigExport } from 'vite';
 
 function generateConfig(): Promise<UserConfigExport> {
     return new Promise((resolve, reject) => {
+        const filePath = path.dirname(fileURLToPath(import.meta.url));
+
         const exclude = [
+            '**/*.d.ts',
             '**/node_modules/**',
             '**/dist/**',
             '**/install/**',
@@ -18,7 +22,10 @@ function generateConfig(): Promise<UserConfigExport> {
             '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*',
         ];
 
-        const rawData = fs.readFileSync(path.join(__dirname, '.frontend-configuration-settings.json'), 'utf-8');
+        const rawData = fs.readFileSync(
+            path.join(filePath, '.frontend-configuration-settings.json'), 
+            'utf-8'
+        );
         const parsedData = JSON.parse(rawData);
 
         const alias: { [key: string]: string } = {
@@ -40,13 +47,13 @@ function generateConfig(): Promise<UserConfigExport> {
             test: {
                 alias: alias,
                 coverage: {
-                    include: [path.join('arches_lingo', 'src', path.sep)],
+                    include: [path.join(parsedData['APP_RELATIVE_PATH'], 'src', path.sep)],
                     exclude: exclude,
                     reporter: [
                         ['clover', { 'file': 'coverage.xml' }],
                         'text',
                     ],
-                    reportsDirectory: path.join(__dirname, 'coverage', 'frontend'),
+                    reportsDirectory: path.join(filePath, 'coverage', 'frontend'),
                 },
                 environment: "jsdom",
                 globals: true,

--- a/vitest.setup.mts
+++ b/vitest.setup.mts
@@ -1,11 +1,10 @@
 import { beforeAll, vi } from 'vitest';
-import '@/arches_lingo/declarations.d.ts';
-
 
 beforeAll(() => {
     vi.mock('arches', () => ({
         default: '',
     }));
+
     vi.mock('vue3-gettext', () => ({
         useGettext: () => ({
             $gettext: (text: string) => (text)


### PR DESCRIPTION
This branch removes the workarounds for parent tile linking and the last custom serializers.
***
Example of nested tile creation with a cardinality 1 parent:

```json
{
    "rights": {
        "right_statement": {
             "right_statement_content": "foo"
        }
    }
}
```


And then with a cardinality-N parent, you can test the following example, but would need to use Concept graph rather than Scheme graph
(notice that the browsable API takes a while to respond because we turned off default pagination, which we might want to revisit, so add it back it globally if you wish by adding the following to settings.py and removing the `pagination_class = None` in  he view)
```py
REST_FRAMEWORK = {
    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
    'PAGE_SIZE': 100  # or settings.MAX_API_PAGE_SIZE
}
```
POST to http://127.0.0.1:8000/api/lingo/concept
```json
{
    "statement": [
        {
            "statement_content": "Foo Statement",
            "statement_data_assignment_statement": {
                "statement_data_assignment_statement_content": "foo"
            }
        },
        {
            "statement_content": "Bar Statement",
            "statement_data_assignment_statement": {
                "statement_data_assignment_statement_content": "bar"
            }
        }
    ]
}
```