### PR TITLE
Fix concept label save

### DIFF
--- a/arches_lingo/src/arches_lingo/components/concept/ConceptLabel/components/ConceptLabelEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptLabel/components/ConceptLabelEditor.vue
@@ -61,9 +61,7 @@ async function save(e: FormSubmitEvent) {
     isSaving.value = true;
 
     try {
-        const formData = Object.fromEntries(
-            Object.entries(e.states).map(([key, state]) => [key, state.value]),
-        );
+        const formData = e.values;
 
         let updatedTileId;
 

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptNote/components/ConceptNoteEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptNote/components/ConceptNoteEditor.vue
@@ -62,9 +62,7 @@ async function save(e: FormSubmitEvent) {
     isSaving.value = true;
 
     try {
-        const formData = Object.fromEntries(
-            Object.entries(e.states).map(([key, state]) => [key, state.value]),
-        );
+        const formData = e.values;
 
         let updatedTileId;
 


### PR DESCRIPTION
In anticipation of merging archesproject/arches-controlled-lists#63.

Similar changes already merged for scheme label save in #213. I was under the impression that we were planning to merge all these branches early in the week to minimize disruption, but what I appear to have done instead is cause disruption. Apologies.

Concepts should now save labels just like schemes. Test with archesproject/arches-controlled-lists#63.