### PR TITLE
separates parent concept links in concept header

### DIFF
--- a/arches_lingo/src/arches_lingo/components/concept/ConceptHeader.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptHeader.vue
@@ -178,7 +178,7 @@ function extractConceptHeaderData(concept: ResourceInstanceResult) {
                     <span
                         v-for="parent in data?.parentConcepts"
                         :key="parent.interchange_value"
-                        class="header-item-value"
+                        class="header-item-value parent-concept"
                     >
                         <RouterLink
                             :to="`/concept/${parent.interchange_value}`"
@@ -259,5 +259,9 @@ h2 {
 :deep(a) {
     font-size: var(--p-lingo-font-size-smallnormal);
     color: var(--p-primary-500);
+}
+
+.parent-concept {
+    margin-inline-end: 0.5rem;
 }
 </style>


### PR DESCRIPTION
parent concept links were running together for records w/ multiple parents in the concept header, eg: Bermuda (concept/1efa14a0-fb33-3006-9650-dbc129c8166d)