### PR TITLE
Loosen arches pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "arches @ git+https://github.com/archesproject/arches@dev/8.0.x",
+    "arches~=8.0",
     "arches_component_lab @ git+https://github.com/archesproject/arches-component-lab.git@main",
     "arches_querysets @ git+https://github.com/archesproject/arches-querysets@main",
     "arches_controlled_lists @ git+https://github.com/archesproject/arches-controlled-lists.git@main",


### PR DESCRIPTION
I reproduced the install failure from the deploy job locally, and this resolves it.

~= seems better than >=, we're far away from using arches 8.1.

The alternative would be to change component lab and controlled lists to point to dev/8 also, but component lab supports 7.6 that wouldn't have been friendly.