### PR TITLE
Fix saving right statement on new scheme

### DIFF
--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeLicense/components/SchemeLicenseEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeLicense/components/SchemeLicenseEditor.vue
@@ -91,7 +91,7 @@ async function save(e: FormSubmitEvent) {
             const updatedScheme = await createLingoResource(
                 {
                     aliased_data: {
-                        [props.nodegroupAlias]: [formData],
+                        [props.nodegroupAlias]: expectedTileShape,
                     },
                 },
                 props.graphSlug,


### PR DESCRIPTION
Before, saving a right statement on a new scheme (as its first tile) didn't transmit the statement content.

I'll look into why we didn't get an error from the backend.