### PR TITLE
Simplify lingo font-family & allow for granular font-weight control

### DIFF
--- a/arches_lingo/src/arches_lingo/ArchesLingo.vue
+++ b/arches_lingo/src/arches_lingo/ArchesLingo.vue
@@ -112,6 +112,7 @@ router.beforeEach(async (to, _from, next) => {
 </template>
 
 <style scoped>
+@import url("https://fonts.googleapis.com/css2?family=Open+Sans:ital,wdth,wght@0,75..100,300..800;1,75..100,300..800&display=swap");
 main {
     font-family: var(--p-lingo-font-family);
     height: 100vh;
@@ -130,6 +131,7 @@ main {
 
 <!-- NOT scoped because dialog gets appended to <body> and is unreachable via scoped styles -->
 <style>
+@import url("https://fonts.googleapis.com/css2?family=Open+Sans:ital,wdth,wght@0,75..100,300..800;1,75..100,300..800&display=swap");
 .p-datepicker-panel,
 .p-tree-node-label,
 .p-toast,

--- a/arches_lingo/src/arches_lingo/components/generic/ComponentManager/ComponentManager.vue
+++ b/arches_lingo/src/arches_lingo/components/generic/ComponentManager/ComponentManager.vue
@@ -217,6 +217,7 @@ provide("refreshReportSection", refreshReportSection);
 :deep(.section-message) {
     padding: 0.5rem 0;
     color: var(--p-inputtext-placeholder-color);
+    font-weight: var(--p-lingo-font-weight-lite);
 }
 
 :deep(.section-header) {

--- a/arches_lingo/src/arches_lingo/components/generic/MetaStringViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/generic/MetaStringViewer.vue
@@ -194,6 +194,7 @@ async function deleteSectionValue(tileId: string) {
     padding: 0.5rem 0;
     margin: 0;
     font-size: var(--p-lingo-font-size-smallnormal);
+    font-weight: var(--p-lingo-font-weight-lite);
     color: var(--p-inputtext-placeholder-color);
 }
 

--- a/arches_lingo/src/arches_lingo/themes/lingo_theme.ts
+++ b/arches_lingo/src/arches_lingo/themes/lingo_theme.ts
@@ -17,7 +17,7 @@ export const LingoPreset = definePreset(ArchesPreset, {
     },
     semantic: {
         lingoFont: {
-            family: "'Open Sans','Lucida Sans','Lucida Sans Regular','Lucida Grande','Lucida Sans Unicode',Geneva,Verdana,sans-serif",
+            family: "'Open Sans',sans-serif",
             size: {
                 xxsmall: "0.75rem",
                 xsmall: "0.8rem",
@@ -30,11 +30,12 @@ export const LingoPreset = definePreset(ArchesPreset, {
                 xxlarge: "2rem",
             },
             weight: {
-                extralight: "100",
-                light: "300",
+                lite: "300",
                 normal: "400",
                 medium: "500",
-                bold: "600",
+                semibold: "600",
+                bold: "700",
+                extrabold: "800",
             },
         },
         colorScheme: {


### PR DESCRIPTION
The TLDR:
- Open Sans is what we use in Core. If you're happy with Lingo looking like Core re. font-family, this PR is your answer
- If you want Lingo to have a distinct look re. font-family, Lucida Sans may be an option, but we may need to purchase the font-family
- There are other options if neither of these work (Geneva / Verdana), but they have fewer weight options

Sources & Context:
- [Core Arches imports](https://github.com/archesproject/arches/blob/e059b86a8393ebe4d90ca442022d5f574b945f93/arches/app/media/css/app.css#L10) `Open Sans` from Google Fonts
- [According to Google](https://fonts.google.com/specimen/Open+Sans), Open Sans has 6 possible weights - I have roughly matched these semantic tokens in the [theme](https://github.com/archesproject/arches-lingo/blob/cd280c17076bb575f7c7ff4fb08ed4f071e32f5e/arches_lingo/src/arches_lingo/themes/lingo_theme.ts#L32-L38), with exception of `light` vs `lite` because PrimeVue resolves the former to "" in the theme.
- [Lucida Sans is available via a CDN](https://www.cdnfonts.com/lucida-sans.font), but only has two weights
- Lucida Sans is also available for [purchase](https://lucidafonts.com/collections/lucida-sans?page=1&phcursor=eyJhbGciOiJIUzI1NiJ9.eyJzayI6InBvc2l0aW9uIiwic3YiOjIxLCJkIjoiYiIsInVpZCI6MjYyNjA0MDE3NDUsImwiOjIwLCJvIjowLCJyIjoiQ0RQIiwidiI6MSwicCI6MX0.Ai5u1XYBgpsTvtve9GYUYrvR1KZXIa7VEdNvxgFR8-s) with more weight options available, but I don't think their licensing would fit our use case - although it's worth a second opinion there.
- From what I can tell, [Verdana](https://fonts.adobe.com/fonts/verdana) only has two weights, and [Geneva](https://www.cdnfonts.com/geneva.font) only has one