### PR TITLE
Add generic error handlers per v8 release notes

### DIFF
--- a/arches_lingo/urls.py
+++ b/arches_lingo/urls.py
@@ -17,6 +17,11 @@ from arches_lingo.views.api.generic import (
     LingoTileListCreateView,
 )
 
+handler400 = "arches.app.views.main.custom_400"
+handler403 = "arches.app.views.main.custom_403"
+handler404 = "arches.app.views.main.custom_404"
+handler500 = "arches.app.views.main.custom_500"
+
 urlpatterns = [
     path("", LingoRootView.as_view(), name="root"),
     path("scheme/<uuid:id>", LingoRootView.as_view(), name="scheme-root"),


### PR DESCRIPTION
Per v8 release notes

Log in as a non-rdm user:

**Before**
<img width="517" height="246" alt="Screenshot 2025-08-21 at 11 18 46 AM" src="https://github.com/user-attachments/assets/fb59f5ad-b934-4456-bafc-e30451f56162" />
**After**
<img width="525" height="223" alt="Screenshot 2025-08-21 at 11 18 32 AM" src="https://github.com/user-attachments/assets/d093deb8-b156-4f88-b524-2e5304782e7e" />
