### PR TITLE
fixes dir change on language select

### DIFF
--- a/arches_lingo/src/arches_lingo/components/header/PageHeader/components/LanguageSelector.vue
+++ b/arches_lingo/src/arches_lingo/components/header/PageHeader/components/LanguageSelector.vue
@@ -33,7 +33,9 @@ const selectedCode = computed({
 const showSelector = computed(() => availableLanguages.value.length > 1);
 
 watchEffect(() => {
-    document.body.dir = selectedLanguage.value.default_direction ?? "ltr";
+    document.documentElement.dir =
+        selectedLanguage.value.default_direction ?? "ltr";
+    document.body.dir = document.documentElement.dir;
 });
 
 function openLanguageSelector(event: MouseEvent) {


### PR DESCRIPTION
follow up to #569 
I noticed while testing i18n that direction changes do not work w/o a refresh when applied to the document.  Applying to the body allows for updating direction on language select