### PR TITLE
Surface node-level validation errors to user

### DIFF
--- a/arches_lingo/src/arches_lingo/api.ts
+++ b/arches_lingo/src/arches_lingo/api.ts
@@ -372,10 +372,9 @@ export const upsertLingoTile = async (
     if (!response.ok) {
         let node_validations;
         if (parsed.aliased_data) {
-            for (const msg of parsed.aliased_data[nodegroupAlias]) {
-                if (msg) {
-                    node_validations = node_validations || msg;
-                }
+            const msgs = parsed.aliased_data[nodegroupAlias];
+            if (msgs.length) {
+                node_validations = msgs.join("; ");
             }
         }
         throw new Error(


### PR DESCRIPTION
Displays the validation message(s), for instance when a user tries to save a prefLabel with a language that the concept/scheme already has a prefLabel for.