### PR TITLE
Progressive hierarchy loading

### DIFF
--- a/arches_lingo/migrations/0013_add_broader_concept_gin_index.py
+++ b/arches_lingo/migrations/0013_add_broader_concept_gin_index.py
@@ -1,0 +1,30 @@
+from django.db import migrations
+
+from arches_lingo.const import (
+    CLASSIFICATION_STATUS_ASCRIBED_CLASSIFICATION_NODEID,
+    CLASSIFICATION_STATUS_NODEGROUP,
+)
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("arches_lingo", "0012_add_label_search_index"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=f"""
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS
+                    tiles_broader_concept_gin
+                ON tiles
+                USING GIN (
+                    (tiledata -> '{CLASSIFICATION_STATUS_ASCRIBED_CLASSIFICATION_NODEID}')
+                    jsonb_path_ops
+                )
+                WHERE nodegroupid = '{CLASSIFICATION_STATUS_NODEGROUP}'::uuid;
+            """,
+            reverse_sql="DROP INDEX IF EXISTS tiles_broader_concept_gin;",
+        ),
+    ]

--- a/arches_lingo/src/arches_lingo/api.ts
+++ b/arches_lingo/src/arches_lingo/api.ts
@@ -585,6 +585,23 @@ export const fetchConcepts = async () => {
     return parsed;
 };
 
+export const fetchConceptChildren = async (conceptId: string) => {
+    const response = await fetch(arches.urls.api_concept_children(conceptId));
+    const parsed = await response.json();
+    if (!response.ok) throw new Error(parsed.message || response.statusText);
+    return parsed.children;
+};
+
+export const fetchConceptAncestorPaths = async (conceptId: string) => {
+    const url = generateArchesURL("arches_lingo:api-concept-ancestors", {
+        concept_id: conceptId,
+    });
+    const response = await fetch(url);
+    const parsed = await response.json();
+    if (!response.ok) throw new Error(parsed.message || response.statusText);
+    return parsed.paths;
+};
+
 export const fetchLifecycleStates = async (): Promise<LifecycleState[]> => {
     const response = await fetch(
         generateArchesURL("arches_lingo:api-lingo-lifecycle-states"),

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
@@ -19,6 +19,8 @@ import {
     CONCEPT_TYPE_NODE_ALIAS,
     DEFAULT_ERROR_TOAST_LIFE,
     ERROR,
+    SKOS_PREF_LABEL_URI,
+    SKOS_ALT_LABEL_URI,
 } from "@/arches_lingo/constants.ts";
 import { PREF_LABEL, ALT_LABEL } from "@/arches_controlled_lists/constants.ts";
 
@@ -125,8 +127,6 @@ watch(
         extractConceptHeaderData(resource);
         isResourceLoaded.value = true;
 
-        // Fetch ancestor paths to populate labels for parent concepts
-        // (the concept store may not have them if navigated directly).
         fetchConceptAncestorPaths(props.resourceInstanceId)
             .then((paths) => {
                 const map = new Map<string, Label[]>();
@@ -139,9 +139,7 @@ watch(
                 }
                 ancestorLabelsById.value = map;
             })
-            .catch(() => {
-                // Non-critical; parent labels fall back to display_value
-            });
+            .catch(() => {});
     },
     { immediate: true },
 );
@@ -155,9 +153,6 @@ watch(
     },
 );
 
-const SKOS_PREF_LABEL_URI = "http://www.w3.org/2004/02/skos/core#prefLabel";
-const SKOS_ALT_LABEL_URI = "http://www.w3.org/2004/02/skos/core#altLabel";
-
 function valuetypeFromUri(uri: string | undefined): string {
     if (uri === SKOS_PREF_LABEL_URI) return PREF_LABEL;
     if (uri === SKOS_ALT_LABEL_URI) return ALT_LABEL;
@@ -169,19 +164,22 @@ function extractLabelsFromResource(resource: ResourceInstanceResult): Label[] {
         resource.aliased_data?.appellative_status ?? [];
     const labels: Label[] = [];
     for (const tile of tiles) {
-        const ad = tile.aliased_data;
-        if (!ad) continue;
+        const aliasedData = tile.aliased_data;
+        if (!aliasedData) continue;
         const value =
-            ad.appellative_status_ascribed_name_content?.display_value;
-        // node_value is the language code (e.g. "en")
-        const languageNodeValue =
-            ad.appellative_status_ascribed_name_language?.node_value;
-        const languageId =
-            typeof languageNodeValue === "string"
-                ? languageNodeValue
-                : ad.appellative_status_ascribed_name_language?.display_value;
+            aliasedData.appellative_status_ascribed_name_content?.display_value;
+        const termLanguageNode =
+            aliasedData.appellative_status_ascribed_name_language;
+        const termLanguageNodeValue = termLanguageNode?.node_value;
+        let languageId: string | undefined;
+        if (typeof termLanguageNodeValue === "string") {
+            languageId = termLanguageNodeValue;
+        } else {
+            languageId = termLanguageNode?.display_value;
+        }
         const typeUri =
-            ad.appellative_status_ascribed_relation?.node_value?.[0]?.uri;
+            aliasedData.appellative_status_ascribed_relation?.node_value?.[0]
+                ?.uri;
         if (value && languageId) {
             labels.push({
                 value,

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
@@ -11,13 +11,16 @@ import Skeleton from "primevue/skeleton";
 import ConceptHeaderToolbar from "@/arches_lingo/components/concept/ConceptHeader/components/ConceptHeaderToolbar.vue";
 import LifecycleStateBadge from "@/arches_lingo/components/generic/LifecycleStateBadge.vue";
 
-import { fetchResourceIdentifiers } from "@/arches_lingo/api.ts";
+import {
+    fetchResourceIdentifiers,
+    fetchConceptAncestorPaths,
+} from "@/arches_lingo/api.ts";
 import {
     CONCEPT_TYPE_NODE_ALIAS,
     DEFAULT_ERROR_TOAST_LIFE,
     ERROR,
 } from "@/arches_lingo/constants.ts";
-import { PREF_LABEL } from "@/arches_controlled_lists/constants.ts";
+import { PREF_LABEL, ALT_LABEL } from "@/arches_controlled_lists/constants.ts";
 
 import { extractDescriptors } from "@/arches_lingo/utils.ts";
 import { getItemLabel } from "@/arches_controlled_lists/utils.ts";
@@ -28,6 +31,7 @@ import { useLanguageStore } from "@/arches_lingo/stores/useLanguageStore.ts";
 
 import type { Ref } from "vue";
 import type {
+    AppellativeStatus,
     ConceptClassificationStatusAliases,
     ConceptHeaderData,
     DataComponentMode,
@@ -66,11 +70,11 @@ const isIdentifierLoaded = ref(false);
 const conceptIdentifierValue = ref<string>();
 const conceptTypeTile = ref();
 const isWidgetLoading = ref(false);
+const ancestorLabelsById = ref<Map<string, Label[]>>(new Map());
 
 const isLoading = computed(function () {
     if (!isIdentifierLoaded.value) return true;
     if (props.resourceInstanceId && !isResourceLoaded.value) return true;
-    if (props.resourceInstanceId && conceptStore.isLoading) return true;
     if (isWidgetLoading.value) return true;
 
     return false;
@@ -120,6 +124,24 @@ watch(
         isTopConcept.value = Boolean(resource.aliased_data?.top_concept_of);
         extractConceptHeaderData(resource);
         isResourceLoaded.value = true;
+
+        // Fetch ancestor paths to populate labels for parent concepts
+        // (the concept store may not have them if navigated directly).
+        fetchConceptAncestorPaths(props.resourceInstanceId)
+            .then((paths) => {
+                const map = new Map<string, Label[]>();
+                for (const path of paths) {
+                    for (const node of path.searchResults) {
+                        if (node.labels?.length) {
+                            map.set(node.id, node.labels);
+                        }
+                    }
+                }
+                ancestorLabelsById.value = map;
+            })
+            .catch(() => {
+                // Non-critical; parent labels fall back to display_value
+            });
     },
     { immediate: true },
 );
@@ -132,6 +154,44 @@ watch(
         }
     },
 );
+
+const SKOS_PREF_LABEL_URI = "http://www.w3.org/2004/02/skos/core#prefLabel";
+const SKOS_ALT_LABEL_URI = "http://www.w3.org/2004/02/skos/core#altLabel";
+
+function valuetypeFromUri(uri: string | undefined): string {
+    if (uri === SKOS_PREF_LABEL_URI) return PREF_LABEL;
+    if (uri === SKOS_ALT_LABEL_URI) return ALT_LABEL;
+    return "unknown";
+}
+
+function extractLabelsFromResource(resource: ResourceInstanceResult): Label[] {
+    const tiles: AppellativeStatus[] =
+        resource.aliased_data?.appellative_status ?? [];
+    const labels: Label[] = [];
+    for (const tile of tiles) {
+        const ad = tile.aliased_data;
+        if (!ad) continue;
+        const value =
+            ad.appellative_status_ascribed_name_content?.display_value;
+        // node_value is the language code (e.g. "en")
+        const languageNodeValue =
+            ad.appellative_status_ascribed_name_language?.node_value;
+        const languageId =
+            typeof languageNodeValue === "string"
+                ? languageNodeValue
+                : ad.appellative_status_ascribed_name_language?.display_value;
+        const typeUri =
+            ad.appellative_status_ascribed_relation?.node_value?.[0]?.uri;
+        if (value && languageId) {
+            labels.push({
+                value,
+                language_id: languageId,
+                valuetype_id: valuetypeFromUri(typeUri),
+            });
+        }
+    }
+    return labels;
+}
 
 const label = computed<Label | undefined>(function () {
     if (!props.resourceInstanceId) {
@@ -151,6 +211,17 @@ const label = computed<Label | undefined>(function () {
         );
     }
 
+    if (concept.value) {
+        const resourceLabels = extractLabelsFromResource(concept.value);
+        if (resourceLabels.length) {
+            return getItemLabel(
+                { labels: resourceLabels },
+                selectedLanguage.value.code,
+                systemLanguage.value.code,
+            );
+        }
+    }
+
     return undefined;
 });
 
@@ -160,7 +231,9 @@ const parentConceptLabelMap = computed<Map<string, Label[]>>(function () {
         const id = parent.details[0]?.resource_id;
 
         if (id) {
-            map.set(id, conceptStore.findConcept(id)?.labels ?? []);
+            const storeLabels = conceptStore.findConcept(id)?.labels;
+            const ancestorLabels = ancestorLabelsById.value.get(id);
+            map.set(id, storeLabels ?? ancestorLabels ?? []);
         }
     }
     return map;

--- a/arches_lingo/src/arches_lingo/components/concept/HierarchicalPosition/HierarchicalPosition.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/HierarchicalPosition/HierarchicalPosition.vue
@@ -10,13 +10,12 @@ import HierarchicalPositionEditor from "@/arches_lingo/components/concept/Hierar
 import { EDIT, VIEW } from "@/arches_lingo/constants.ts";
 
 import { fetchTileData } from "@/arches_component_lab/generics/GenericCard/api.ts";
+import { fetchConceptAncestorPaths } from "@/arches_lingo/api.ts";
 import { useResourceStore } from "@/arches_lingo/composables/useResourceStore.ts";
-import { useConceptStore } from "@/arches_lingo/stores/useConceptStore.ts";
 
 import type {
     ConceptClassificationStatus,
     DataComponentMode,
-    SearchResultItem,
     SearchResultHierarchy,
 } from "@/arches_lingo/types.ts";
 
@@ -35,7 +34,6 @@ const emit = defineEmits<{
 }>();
 
 const resourceStore = useResourceStore();
-const conceptStore = useConceptStore();
 
 const fetchError = ref();
 const hierarchicalData = ref<SearchResultHierarchy[]>([]);
@@ -60,11 +58,6 @@ const activeTileData = computed((): ConceptClassificationStatus | undefined => {
 });
 
 onMounted(async () => {
-    schemeId.value =
-        resourceStore.resource.value?.aliased_data?.part_of_scheme.aliased_data
-            .part_of_scheme?.details[0]?.resource_id ??
-        conceptStore.getParentPaths(props.resourceInstanceId ?? "")[0]?.[0]?.id;
-
     if (shouldCreateNewTile.value) {
         const blankTileData = await fetchTileData(
             props.graphSlug,
@@ -104,20 +97,18 @@ watch(
                 props.nodegroupAlias
             ] as ConceptClassificationStatus[];
 
-            await conceptStore.initialize();
-
-            const paths = conceptStore.getParentPaths(
+            const ancestorPaths = await fetchConceptAncestorPaths(
                 props.resourceInstanceId!,
             );
 
-            schemeId.value = paths[0]?.[0]?.id;
-            hierarchicalData.value = paths.map((path) => ({
-                searchResults: path as SearchResultItem[],
-            }));
+            const paths = ancestorPaths as SearchResultHierarchy[];
+            schemeId.value = paths[0]?.searchResults[0]?.id;
+            hierarchicalData.value = paths;
 
             for (const datum of hierarchicalData.value) {
-                const parentId =
-                    datum.searchResults[datum.searchResults.length - 2].id;
+                const pathLength = datum.searchResults.length;
+                const parentId = datum.searchResults[pathLength - 2]?.id;
+                if (!parentId) continue;
                 const match = tileData.value?.find((tile) =>
                     tile.aliased_data.classification_status_ascribed_classification.node_value?.some(
                         (nodeValue) => nodeValue.resourceId === parentId,

--- a/arches_lingo/src/arches_lingo/components/tree/ConceptTree.vue
+++ b/arches_lingo/src/arches_lingo/components/tree/ConceptTree.vue
@@ -5,6 +5,7 @@ import {
     nextTick,
     onMounted,
     provide,
+    reactive,
     ref,
     watch,
 } from "vue";
@@ -206,6 +207,14 @@ provide(
     "resourceInstanceLifecycleStateIsRetiredById",
     resourceInstanceLifecycleStateIsRetiredById,
 );
+
+// Tracks occurrence keys of tree nodes whose children are currently being
+// fetched so the tree can show a loading indicator on the relevant expand
+// toggle.  Using the occurrence key (rather than the concept ID) means that
+// when a polyhierarchical concept appears in multiple places in the tree,
+// only the one node that was actually clicked shows the spinner.
+const loadingNodeKeys = reactive(new Set<string>());
+provide("loadingNodeKeys", loadingNodeKeys);
 
 const sortIcon = computed(() => {
     const direction = shouldSortByAscending.value ? "down" : "up";
@@ -885,6 +894,29 @@ async function onNodeSelect(node: TreeNode) {
         scrollOccurrenceIntoView(primaryOriginalKey);
     }
 }
+
+async function onNodeExpand(node: TreeNode) {
+    const conceptId: string = node.data?.id;
+    if (!conceptId || node.data?.top_concepts !== undefined) return;
+
+    const concept = conceptStore.findConcept(conceptId);
+    if (!concept || concept.childrenLoaded) return;
+
+    const nodeKey: string = node.key as string;
+    loadingNodeKeys.add(nodeKey);
+    try {
+        await conceptStore.loadChildren(conceptId);
+    } catch {
+        toast.add({
+            severity: ERROR,
+            life: DEFAULT_ERROR_TOAST_LIFE,
+            summary: $gettext("Unable to fetch concepts"),
+            detail: $gettext("Failed to load child concepts."),
+        });
+    } finally {
+        loadingNodeKeys.delete(nodeKey);
+    }
+}
 </script>
 
 <template>
@@ -958,8 +990,18 @@ async function onNodeSelect(node: TreeNode) {
                 nodeLabel: {
                     style: { textWrap: 'nowrap' },
                 },
+                nodeToggleButton: ({
+                    instance,
+                }: TreePassThroughMethodOptions) => ({
+                    class: {
+                        'node-children-loading': loadingNodeKeys.has(
+                            instance.node?.key as string,
+                        ),
+                    },
+                }),
             }"
             @node-select="onNodeSelect"
+            @node-expand="onNodeExpand"
         >
             <template #default="slotProps">
                 <div :id="`tree-node-${slotProps.node.key}`">
@@ -1079,5 +1121,20 @@ async function onNodeSelect(node: TreeNode) {
 
 :deep(.p-tree-node-selected.new-node) {
     background: var(--p-yellow-500) !important;
+}
+
+/* Spin the expand toggle icon while children are being fetched */
+:deep(.node-children-loading .p-tree-node-toggle-icon) {
+    animation: tree-toggle-spin 0.6s linear infinite;
+    pointer-events: none;
+}
+
+@keyframes tree-toggle-spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
 }
 </style>

--- a/arches_lingo/src/arches_lingo/components/tree/ConceptTree.vue
+++ b/arches_lingo/src/arches_lingo/components/tree/ConceptTree.vue
@@ -36,7 +36,10 @@ import {
 import { RETIRED_LIFECYCLE_STATE_ID } from "@/arches_lingo/constants.ts";
 
 import { useConceptStore } from "@/arches_lingo/stores/useConceptStore.ts";
-import { fetchLifecycleStates } from "@/arches_lingo/api.ts";
+import {
+    fetchLifecycleStates,
+    fetchConceptAncestorPaths,
+} from "@/arches_lingo/api.ts";
 import { useLanguageStore } from "@/arches_lingo/stores/useLanguageStore.ts";
 
 import {
@@ -775,7 +778,7 @@ function scrollToItemInTree(
     }
 
     if (!matches.length) {
-        return;
+        return false;
     }
 
     const keysToExpand = new Set<string>();
@@ -825,10 +828,77 @@ function scrollToItemInTree(
     );
 
     if (!shouldScroll) {
-        return;
+        return true;
     }
 
     scrollOccurrenceIntoView(primaryOccurrenceKey);
+    return true;
+}
+
+// Ensures a concept is visible and selected in the tree, loading ancestor
+// levels on demand when the concept has not yet been loaded into the tree.
+//
+// For concepts already present in the tree (common case after in-app
+// navigation) this is just a direct call to scrollToItemInTree.  For deep
+// concepts reached via direct URL or an external link, the ancestor path is
+// fetched from the API and each level is loaded in sequence, showing the
+// spinning caret on each ancestor node while its children are being fetched.
+async function revealConceptInTree(
+    conceptId: string,
+    shouldScroll: boolean,
+    preferredOccurrenceKey?: string,
+) {
+    if (scrollToItemInTree(conceptId, shouldScroll, preferredOccurrenceKey)) {
+        return;
+    }
+
+    let paths: Array<{ searchResults: Array<{ id: string }> }>;
+    try {
+        paths = await fetchConceptAncestorPaths(conceptId);
+    } catch {
+        return;
+    }
+
+    if (!paths?.length || !paths[0].searchResults?.length) return;
+
+    const pathNodes = paths[0].searchResults;
+
+    // pathNodes is ordered root → target:
+    //   [scheme, top_concept, concept, ..., direct_parent, target]
+    // To make `target` visible we must load the children of every ancestor
+    // between the scheme (already loaded at init) and the target itself.
+    // pathNodes.slice(1, -1) gives exactly those intermediate ancestors.
+    const schemeId: string = pathNodes[0].id;
+    const ancestorsToLoad = pathNodes.slice(1, -1);
+
+    for (let i = 0; i < ancestorsToLoad.length; i++) {
+        const ancestor = ancestorsToLoad[i];
+        if (conceptStore.findConcept(ancestor.id)?.childrenLoaded) continue;
+
+        // The occurrence key for the ancestor at position i in ancestorsToLoad
+        // is pathNodes[i+1], so its path from the scheme root is
+        // pathNodes[1..i+1] (the concept IDs below the scheme down to here).
+        const pathIds = pathNodes.slice(1, i + 2).map((n) => n.id);
+        const occurrenceKey = `${schemeId}::${pathIds.join(">")}`;
+
+        loadingNodeKeys.add(occurrenceKey);
+        try {
+            await conceptStore.loadChildren(ancestor.id);
+        } catch {
+            toast.add({
+                severity: ERROR,
+                life: DEFAULT_ERROR_TOAST_LIFE,
+                summary: $gettext("Unable to fetch concepts"),
+                detail: $gettext("Failed to load concept path."),
+            });
+            return;
+        } finally {
+            loadingNodeKeys.delete(occurrenceKey);
+        }
+        await nextTick();
+    }
+
+    scrollToItemInTree(conceptId, shouldScroll, preferredOccurrenceKey);
 }
 
 async function selectNodeFromRoute(
@@ -864,13 +934,40 @@ async function selectNodeFromRoute(
         preferredOccurrenceKey = priorSelectedPrimaryKey ?? undefined;
     }
 
-    scrollToItemInTree(routeNodeId, shouldScroll, preferredOccurrenceKey);
+    await revealConceptInTree(
+        routeNodeId,
+        shouldScroll,
+        preferredOccurrenceKey,
+    );
 
     await ensureFilterParentsExpanded();
 }
 
 async function onNodeSelect(node: TreeNode) {
     if (node.data.id === NEW) return;
+
+    // When a concept with unloaded children is selected, prefetch the children
+    // immediately so they are ready by the time the user expands.  This also
+    // drives the spinning caret while the fetch is in progress, matching the
+    // behaviour the user already gets when clicking the expand toggle directly.
+    const conceptId: string = node.data?.id;
+    const isConcept = node.data?.top_concepts === undefined;
+    const concept = isConcept ? conceptStore.findConcept(conceptId) : null;
+    if (concept && !concept.childrenLoaded && concept.has_narrower) {
+        const nodeKey = node.key as string;
+        loadingNodeKeys.add(nodeKey);
+        conceptStore
+            .loadChildren(conceptId)
+            .catch(() => {
+                toast.add({
+                    severity: ERROR,
+                    life: DEFAULT_ERROR_TOAST_LIFE,
+                    summary: $gettext("Unable to fetch concepts"),
+                    detail: $gettext("Failed to load child concepts."),
+                });
+            })
+            .finally(() => loadingNodeKeys.delete(nodeKey));
+    }
 
     const selectedKeysBeforeNavigation = { ...selectedKeys.value };
 

--- a/arches_lingo/src/arches_lingo/components/tree/ConceptTree.vue
+++ b/arches_lingo/src/arches_lingo/components/tree/ConceptTree.vue
@@ -211,11 +211,6 @@ provide(
     resourceInstanceLifecycleStateIsRetiredById,
 );
 
-// Tracks occurrence keys of tree nodes whose children are currently being
-// fetched so the tree can show a loading indicator on the relevant expand
-// toggle.  Using the occurrence key (rather than the concept ID) means that
-// when a polyhierarchical concept appears in multiple places in the tree,
-// only the one node that was actually clicked shows the spinner.
 const loadingNodeKeys = reactive(new Set<string>());
 provide("loadingNodeKeys", loadingNodeKeys);
 
@@ -232,6 +227,7 @@ const tree = computed(() => {
         iconLabels.value,
         focusedOccurrenceKey.value,
         shouldSortByAscending.value,
+        conceptStore.hasLoadedChildren,
     );
 });
 
@@ -633,8 +629,6 @@ function scrollToOccurrenceKeyInTree(
         if (currentTreeNode.key === occurrenceKey) {
             const keysToExpand = new Set<string>();
 
-            // Expand only the ancestors (currentPath includes the target node
-            // as its last element; slice(0, -1) excludes it).
             for (const ancestorNode of currentPath.slice(0, -1)) {
                 keysToExpand.add(ancestorNode.key);
             }
@@ -784,11 +778,6 @@ function scrollToItemInTree(
 
     const keysToExpand = new Set<string>();
     for (const matchItem of matches) {
-        // Expand only the ancestors. The path array includes the target node
-        // as its last element, so slice(0, -1) gives only ancestors. The
-        // target itself must not be auto-expanded: if its children have not
-        // been fetched yet, adding it to expandedKeys produces a visually
-        // empty open node with the expand toggle stuck in the open position.
         for (const ancestorNode of matchItem.path.slice(0, -1)) {
             keysToExpand.add(ancestorNode.key);
         }
@@ -840,14 +829,6 @@ function scrollToItemInTree(
     return true;
 }
 
-// Ensures a concept is visible and selected in the tree, loading ancestor
-// levels on demand when the concept has not yet been loaded into the tree.
-//
-// For concepts already present in the tree (common case after in-app
-// navigation) this is just a direct call to scrollToItemInTree.  For deep
-// concepts reached via direct URL or an external link, the ancestor path is
-// fetched from the API and each level is loaded in sequence, showing the
-// spinning caret on each ancestor node while its children are being fetched.
 async function revealConceptInTree(
     conceptId: string,
     shouldScroll: boolean,
@@ -867,23 +848,13 @@ async function revealConceptInTree(
     if (!paths?.length || !paths[0].searchResults?.length) return;
 
     const pathNodes = paths[0].searchResults;
-
-    // pathNodes is ordered root → target:
-    //   [scheme, top_concept, concept, ..., direct_parent, target]
-    // To make `target` visible we must load the children of every ancestor
-    // between the scheme (already loaded at init) and the target itself.
-    // pathNodes.slice(1, -1) gives exactly those intermediate ancestors.
     const schemeId: string = pathNodes[0].id;
     const ancestorsToLoad = pathNodes.slice(1, -1);
 
-    for (let i = 0; i < ancestorsToLoad.length; i++) {
-        const ancestor = ancestorsToLoad[i];
-        if (conceptStore.findConcept(ancestor.id)?.childrenLoaded) continue;
+    for (const [index, ancestor] of ancestorsToLoad.entries()) {
+        if (conceptStore.hasLoadedChildren(ancestor.id)) continue;
 
-        // The occurrence key for the ancestor at position i in ancestorsToLoad
-        // is pathNodes[i+1], so its path from the scheme root is
-        // pathNodes[1..i+1] (the concept IDs below the scheme down to here).
-        const pathIds = pathNodes.slice(1, i + 2).map((n) => n.id);
+        const pathIds = pathNodes.slice(1, index + 2).map((node) => node.id);
         const occurrenceKey = `${schemeId}::${pathIds.join(">")}`;
 
         loadingNodeKeys.add(occurrenceKey);
@@ -951,14 +922,14 @@ async function selectNodeFromRoute(
 async function onNodeSelect(node: TreeNode) {
     if (node.data.id === NEW) return;
 
-    // When a concept with unloaded children is selected, prefetch the children
-    // immediately so they are ready by the time the user expands.  This also
-    // drives the spinning caret while the fetch is in progress, matching the
-    // behaviour the user already gets when clicking the expand toggle directly.
     const conceptId: string = node.data?.id;
     const isConcept = node.data?.top_concepts === undefined;
     const concept = isConcept ? conceptStore.findConcept(conceptId) : null;
-    if (concept && !concept.childrenLoaded && concept.has_narrower) {
+    if (
+        concept &&
+        !conceptStore.hasLoadedChildren(conceptId) &&
+        concept.has_narrower
+    ) {
         const nodeKey = node.key as string;
         loadingNodeKeys.add(nodeKey);
         conceptStore
@@ -1002,7 +973,7 @@ async function onNodeExpand(node: TreeNode) {
     if (!conceptId || node.data?.top_concepts !== undefined) return;
 
     const concept = conceptStore.findConcept(conceptId);
-    if (!concept || concept.childrenLoaded) return;
+    if (!concept || conceptStore.hasLoadedChildren(conceptId)) return;
 
     const nodeKey: string = node.key as string;
     loadingNodeKeys.add(nodeKey);

--- a/arches_lingo/src/arches_lingo/components/tree/ConceptTree.vue
+++ b/arches_lingo/src/arches_lingo/components/tree/ConceptTree.vue
@@ -633,11 +633,12 @@ function scrollToOccurrenceKeyInTree(
         if (currentTreeNode.key === occurrenceKey) {
             const keysToExpand = new Set<string>();
 
-            for (const pathNode of currentPath) {
-                keysToExpand.add(pathNode.key);
+            // Expand only the ancestors (currentPath includes the target node
+            // as its last element; slice(0, -1) excludes it).
+            for (const ancestorNode of currentPath.slice(0, -1)) {
+                keysToExpand.add(ancestorNode.key);
             }
 
-            keysToExpand.add(occurrenceKey);
             mergeExpandedKeys(keysToExpand);
 
             selectedKeys.value = { [occurrenceKey]: true };
@@ -783,10 +784,14 @@ function scrollToItemInTree(
 
     const keysToExpand = new Set<string>();
     for (const matchItem of matches) {
-        for (const pathNode of matchItem.path) {
-            keysToExpand.add(pathNode.key);
+        // Expand only the ancestors. The path array includes the target node
+        // as its last element, so slice(0, -1) gives only ancestors. The
+        // target itself must not be auto-expanded: if its children have not
+        // been fetched yet, adding it to expandedKeys produces a visually
+        // empty open node with the expand toggle stuck in the open position.
+        for (const ancestorNode of matchItem.path.slice(0, -1)) {
+            keysToExpand.add(ancestorNode.key);
         }
-        keysToExpand.add(matchItem.treeNode.key);
     }
 
     if (!debouncedFilterValue.value) {

--- a/arches_lingo/src/arches_lingo/constants.ts
+++ b/arches_lingo/src/arches_lingo/constants.ts
@@ -62,6 +62,10 @@ export const RETIRED_LIFECYCLE_STATE_ID =
 
 // URIs
 export const GUIDE_TERM_URI = "http://vocab.getty.edu/page/aat/300386700";
+export const SKOS_PREF_LABEL_URI =
+    "http://www.w3.org/2004/02/skos/core#prefLabel";
+export const SKOS_ALT_LABEL_URI =
+    "http://www.w3.org/2004/02/skos/core#altLabel";
 
 // Injection keys
 export const openPanelComponentKey = Symbol() as InjectionKey<

--- a/arches_lingo/src/arches_lingo/stores/useConceptStore.ts
+++ b/arches_lingo/src/arches_lingo/stores/useConceptStore.ts
@@ -37,11 +37,9 @@ export const useConceptStore = defineStore("concepts", () => {
     const isLoading = ref(false);
     const error = ref<Error | null>(null);
 
-    // Flat lookup map for O(1) concept access without recursive search.
     const conceptsById = ref<Map<string, Concept>>(new Map());
-
-    // Track in-flight child fetch requests to avoid duplicate requests.
     const inflightChildFetches = new Map<string, Promise<Concept[]>>();
+    const loadedChildrenIds = new Set<string>();
 
     let inflightRefresh: Promise<void> | null = null;
 
@@ -58,8 +56,6 @@ export const useConceptStore = defineStore("concepts", () => {
             try {
                 const data = await fetchConcepts();
                 const fetchedSchemes = data.schemes as Scheme[];
-                // Initialize every shallow concept with an empty narrower array
-                // so consumers can always rely on concept.narrower being an array.
                 for (const scheme of fetchedSchemes) {
                     for (const topConcept of scheme.top_concepts) {
                         topConcept.narrower = topConcept.narrower ?? [];
@@ -67,6 +63,7 @@ export const useConceptStore = defineStore("concepts", () => {
                     }
                 }
                 schemes.value = fetchedSchemes;
+                loadedChildrenIds.clear();
             } catch (err) {
                 error.value =
                     err instanceof Error ? err : new Error(String(err));
@@ -83,7 +80,7 @@ export const useConceptStore = defineStore("concepts", () => {
     async function loadChildren(conceptId: string): Promise<Concept[]> {
         const existing = conceptsById.value.get(conceptId);
 
-        if (existing?.childrenLoaded) {
+        if (existing && loadedChildrenIds.has(conceptId)) {
             return existing.narrower;
         }
 
@@ -96,18 +93,6 @@ export const useConceptStore = defineStore("concepts", () => {
                 conceptId,
             )) as Concept[];
 
-            // For each fetched child, reuse the canonical Concept object
-            // already in the map if one exists. A polyhierarchical concept
-            // (one with multiple parents) appears in the API response for
-            // every parent that is expanded. Without this, each parent load
-            // creates a separate JS object for the same concept:
-            //   parentA.narrower = [C_a]
-            //   parentE.narrower = [C_e]   (different objects, same id)
-            // When loadChildren("C") later fires, it updates only the object
-            // in conceptsById (whichever was stored last), leaving the other
-            // stale copy permanently un-expandable. Reusing the canonical
-            // object ensures all parents share the same reference, so a
-            // single update propagates to every occurrence in the tree.
             const children = fetchedChildren.map((child) => {
                 const canonicalChild = conceptsById.value.get(child.id);
                 if (canonicalChild) {
@@ -121,7 +106,7 @@ export const useConceptStore = defineStore("concepts", () => {
             const concept = conceptsById.value.get(conceptId);
             if (concept) {
                 concept.narrower = children;
-                concept.childrenLoaded = true;
+                loadedChildrenIds.add(conceptId);
             }
             inflightChildFetches.delete(conceptId);
             return children;
@@ -129,6 +114,10 @@ export const useConceptStore = defineStore("concepts", () => {
 
         inflightChildFetches.set(conceptId, fetchPromise);
         return fetchPromise;
+    }
+
+    function hasLoadedChildren(conceptId: string): boolean {
+        return loadedChildrenIds.has(conceptId);
     }
 
     function findConcept(conceptId: string): Concept | null {
@@ -164,6 +153,7 @@ export const useConceptStore = defineStore("concepts", () => {
         initialize,
         refresh,
         loadChildren,
+        hasLoadedChildren,
         getNarrower,
         findConcept,
         getParentPaths,

--- a/arches_lingo/src/arches_lingo/stores/useConceptStore.ts
+++ b/arches_lingo/src/arches_lingo/stores/useConceptStore.ts
@@ -1,21 +1,9 @@
 import { ref } from "vue";
 import { defineStore } from "pinia";
 
-import { fetchConcepts } from "@/arches_lingo/api.ts";
+import { fetchConcepts, fetchConceptChildren } from "@/arches_lingo/api.ts";
 
 import type { Concept, ConceptPathNode, Scheme } from "@/arches_lingo/types.ts";
-
-function searchConcepts(
-    concepts: Concept[],
-    conceptId: string,
-): Concept | null {
-    for (const concept of concepts) {
-        if (concept.id === conceptId) return concept;
-        const found = searchConcepts(concept.narrower, conceptId);
-        if (found !== null) return found;
-    }
-    return null;
-}
 
 function searchParentPaths(
     concepts: Concept[],
@@ -49,6 +37,12 @@ export const useConceptStore = defineStore("concepts", () => {
     const isLoading = ref(false);
     const error = ref<Error | null>(null);
 
+    // Flat lookup map for O(1) concept access without recursive search.
+    const conceptsById = ref<Map<string, Concept>>(new Map());
+
+    // Track in-flight child fetch requests to avoid duplicate requests.
+    const inflightChildFetches = new Map<string, Promise<Concept[]>>();
+
     let inflightRefresh: Promise<void> | null = null;
 
     async function initialize() {
@@ -63,7 +57,16 @@ export const useConceptStore = defineStore("concepts", () => {
             error.value = null;
             try {
                 const data = await fetchConcepts();
-                schemes.value = data.schemes as Scheme[];
+                const fetchedSchemes = data.schemes as Scheme[];
+                // Initialize every shallow concept with an empty narrower array
+                // so consumers can always rely on concept.narrower being an array.
+                for (const scheme of fetchedSchemes) {
+                    for (const topConcept of scheme.top_concepts) {
+                        topConcept.narrower = topConcept.narrower ?? [];
+                        conceptsById.value.set(topConcept.id, topConcept);
+                    }
+                }
+                schemes.value = fetchedSchemes;
             } catch (err) {
                 error.value =
                     err instanceof Error ? err : new Error(String(err));
@@ -77,12 +80,40 @@ export const useConceptStore = defineStore("concepts", () => {
         return fetchPromise;
     }
 
-    function findConcept(conceptId: string): Concept | null {
-        for (const scheme of schemes.value) {
-            const found = searchConcepts(scheme.top_concepts, conceptId);
-            if (found !== null) return found;
+    async function loadChildren(conceptId: string): Promise<Concept[]> {
+        const existing = conceptsById.value.get(conceptId);
+
+        if (existing?.childrenLoaded) {
+            return existing.narrower;
         }
-        return null;
+
+        if (inflightChildFetches.has(conceptId)) {
+            return inflightChildFetches.get(conceptId)!;
+        }
+
+        const fetchPromise = (async () => {
+            const children = (await fetchConceptChildren(
+                conceptId,
+            )) as Concept[];
+            for (const child of children) {
+                child.narrower = child.narrower ?? [];
+                conceptsById.value.set(child.id, child);
+            }
+            const concept = conceptsById.value.get(conceptId);
+            if (concept) {
+                concept.narrower = children;
+                concept.childrenLoaded = true;
+            }
+            inflightChildFetches.delete(conceptId);
+            return children;
+        })();
+
+        inflightChildFetches.set(conceptId, fetchPromise);
+        return fetchPromise;
+    }
+
+    function findConcept(conceptId: string): Concept | null {
+        return conceptsById.value.get(conceptId) ?? null;
     }
 
     function getNarrower(conceptId: string): Concept[] {
@@ -113,6 +144,7 @@ export const useConceptStore = defineStore("concepts", () => {
         error,
         initialize,
         refresh,
+        loadChildren,
         getNarrower,
         findConcept,
         getParentPaths,

--- a/arches_lingo/src/arches_lingo/stores/useConceptStore.ts
+++ b/arches_lingo/src/arches_lingo/stores/useConceptStore.ts
@@ -92,13 +92,32 @@ export const useConceptStore = defineStore("concepts", () => {
         }
 
         const fetchPromise = (async () => {
-            const children = (await fetchConceptChildren(
+            const fetchedChildren = (await fetchConceptChildren(
                 conceptId,
             )) as Concept[];
-            for (const child of children) {
+
+            // For each fetched child, reuse the canonical Concept object
+            // already in the map if one exists. A polyhierarchical concept
+            // (one with multiple parents) appears in the API response for
+            // every parent that is expanded. Without this, each parent load
+            // creates a separate JS object for the same concept:
+            //   parentA.narrower = [C_a]
+            //   parentE.narrower = [C_e]   (different objects, same id)
+            // When loadChildren("C") later fires, it updates only the object
+            // in conceptsById (whichever was stored last), leaving the other
+            // stale copy permanently un-expandable. Reusing the canonical
+            // object ensures all parents share the same reference, so a
+            // single update propagates to every occurrence in the tree.
+            const children = fetchedChildren.map((child) => {
+                const canonicalChild = conceptsById.value.get(child.id);
+                if (canonicalChild) {
+                    return canonicalChild;
+                }
                 child.narrower = child.narrower ?? [];
                 conceptsById.value.set(child.id, child);
-            }
+                return child;
+            });
+
             const concept = conceptsById.value.get(conceptId);
             if (concept) {
                 concept.narrower = children;

--- a/arches_lingo/src/arches_lingo/types.ts
+++ b/arches_lingo/src/arches_lingo/types.ts
@@ -42,10 +42,12 @@ export interface Concept {
     id: string;
     labels: Label[];
     narrower: Concept[];
+    has_narrower?: boolean;
     guide_term?: boolean;
     top_concept?: boolean;
     resource_instance_lifecycle_state_id?: string;
     resource_instance_lifecycle_state_name?: string;
+    childrenLoaded?: boolean;
 }
 
 export type ConceptPathNode = Pick<

--- a/arches_lingo/src/arches_lingo/types.ts
+++ b/arches_lingo/src/arches_lingo/types.ts
@@ -47,7 +47,6 @@ export interface Concept {
     top_concept?: boolean;
     resource_instance_lifecycle_state_id?: string;
     resource_instance_lifecycle_state_name?: string;
-    childrenLoaded?: boolean;
 }
 
 export type ConceptPathNode = Pick<

--- a/arches_lingo/src/arches_lingo/utils.ts
+++ b/arches_lingo/src/arches_lingo/utils.ts
@@ -114,6 +114,7 @@ export function treeFromSchemes(
     iconLabels: IconLabels,
     focusedOccurrenceKey: string | null,
     sortAscending: boolean = true,
+    hasLoadedChildren: (id: string) => boolean = () => false,
 ): TreeNode[] {
     function buildOccurrenceKey(schemeId: string, pathIds: string[]) {
         return `${schemeId}::${pathIds.join(">")}`;
@@ -136,7 +137,7 @@ export function treeFromSchemes(
         // (PrimeVue defaults to checking children array length).
         let leaf: boolean | undefined;
         if (!("top_concepts" in item)) {
-            if (concept.has_narrower && !concept.childrenLoaded) {
+            if (concept.has_narrower && !hasLoadedChildren(concept.id)) {
                 leaf = false;
             } else if (!concept.has_narrower && !concept.narrower?.length) {
                 leaf = true;

--- a/arches_lingo/src/arches_lingo/utils.ts
+++ b/arches_lingo/src/arches_lingo/utils.ts
@@ -130,6 +130,19 @@ export function treeFromSchemes(
                 ? item.id
                 : buildOccurrenceKey(schemeId, pathIds);
 
+        const concept = item as Concept;
+        // leaf=false tells PrimeVue Tree the node has children that haven't
+        // been loaded yet. For schemes and fully-loaded concepts use undefined
+        // (PrimeVue defaults to checking children array length).
+        let leaf: boolean | undefined;
+        if (!("top_concepts" in item)) {
+            if (concept.has_narrower && !concept.childrenLoaded) {
+                leaf = false;
+            } else if (!concept.has_narrower && !concept.narrower?.length) {
+                leaf = true;
+            }
+        }
+
         return {
             key,
             label: getItemLabel(
@@ -144,6 +157,7 @@ export function treeFromSchemes(
             },
             icon: getItemIcon(item),
             iconLabel: getIconLabel(item, iconLabels),
+            ...(leaf !== undefined ? { leaf } : {}),
         };
     }
 

--- a/arches_lingo/templates/arches_urls.htm
+++ b/arches_lingo/templates/arches_urls.htm
@@ -8,6 +8,7 @@
 {{ block.super }}
 <div class="arches-urls"
     api_concepts="{% url 'api-concepts' %}"
+    api_concept_children='(conceptId) => { return "{% url "api-concept-children" "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" %}".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", conceptId)}'
     api_search="{% url 'api-search' %}"
     api_lingo_concept_resources="{% url 'api-lingo-concept-resources' %}"
     api_lingo_concept_relationships="{% url 'api-lingo-concept-relationships' %}"

--- a/arches_lingo/urls.py
+++ b/arches_lingo/urls.py
@@ -4,6 +4,8 @@ from django.urls import include, path
 
 from arches_lingo.views.root import LingoRootView
 from arches_lingo.views.api.concepts import (
+    ConceptAncestorsView,
+    ConceptChildrenView,
     ConceptDeleteView,
     ConceptTreeView,
     ValueSearchView,
@@ -113,6 +115,16 @@ urlpatterns = [
         name="api-lingo-missing-translations",
     ),
     path("api/concept-tree", ConceptTreeView.as_view(), name="api-concepts"),
+    path(
+        "api/concept-tree/children/<uuid:concept_id>",
+        ConceptChildrenView.as_view(),
+        name="api-concept-children",
+    ),
+    path(
+        "api/concept-tree/ancestors/<uuid:concept_id>",
+        ConceptAncestorsView.as_view(),
+        name="api-concept-ancestors",
+    ),
     path(
         "api/lingo/lifecycle-states",
         LifecycleStatesView.as_view(),

--- a/arches_lingo/utils/concept_builder.py
+++ b/arches_lingo/utils/concept_builder.py
@@ -49,7 +49,6 @@ class ConceptBuilder:
     def __init__(
         self,
         concept_ids: list[str] | None = None,
-        *,
         include_parents: bool = False,
         shallow: bool = False,
     ):
@@ -233,7 +232,6 @@ class ConceptBuilder:
         builder.resource_instance_lifecycle_state_ids_by_resource_instance_id = {}
         builder.lifecycle_state_names_by_id = {}
 
-        # Query 1: Get direct child resource instance IDs.
         child_ids: set[str] = set()
         child_tiles = TileModel.objects.filter(
             nodegroup_id=CLASSIFICATION_STATUS_NODEGROUP,

--- a/arches_lingo/utils/concept_builder.py
+++ b/arches_lingo/utils/concept_builder.py
@@ -321,8 +321,9 @@ class ConceptBuilder:
     def batch_check_has_narrower(self, concept_ids: list[str]) -> None:
         """Check which of the given concept IDs have narrower concepts.
 
-        Uses a single unnest + EXISTS query against the GIN-indexed broader
-        concept column, avoiding a full scan of all classification tiles.
+        The node ID for the broader-concept JSON key is embedded as a literal
+        so that the query expression structurally matches the partial GIN index
+        definition on that column, enabling per-row GIN bitmap index scans.
         """
         if not concept_ids:
             return
@@ -330,6 +331,9 @@ class ConceptBuilder:
         _tile_table = TileModel._meta.db_table
         _nodegroup_col = TileModel._meta.get_field("nodegroup").column
         _data_col = TileModel._meta.get_field("data").column
+        _node_key = str(CLASSIFICATION_STATUS_ASCRIBED_CLASSIFICATION_NODEID)
+        _nodegroup_id = str(CLASSIFICATION_STATUS_NODEGROUP)
+
         with connection.cursor() as cursor:
             cursor.execute(
                 f"""
@@ -339,7 +343,7 @@ class ConceptBuilder:
                     SELECT 1
                     FROM "{_tile_table}" sub
                     WHERE sub."{_nodegroup_col}" = %(nodegroup)s::uuid
-                      AND sub."{_data_col}"->%(node_id)s
+                      AND sub."{_data_col}"->'{_node_key}'
                           @> jsonb_build_array(
                               jsonb_build_object('resourceId', concept_id)
                           )
@@ -347,10 +351,7 @@ class ConceptBuilder:
                 """,
                 {
                     "concept_ids": concept_ids,
-                    "nodegroup": str(CLASSIFICATION_STATUS_NODEGROUP),
-                    "node_id": str(
-                        CLASSIFICATION_STATUS_ASCRIBED_CLASSIFICATION_NODEID
-                    ),
+                    "nodegroup": _nodegroup_id,
                 },
             )
             for (concept_id,) in cursor.fetchall():

--- a/arches_lingo/utils/concept_builder.py
+++ b/arches_lingo/utils/concept_builder.py
@@ -2,8 +2,8 @@ import logging
 from collections import defaultdict
 
 from django.contrib.postgres.expressions import ArraySubquery
-from django.db.models import CharField, F, OuterRef, Value
-from django.db.models.expressions import CombinedExpression
+from django.db.models import BooleanField, CharField, F, OuterRef, Value
+from django.db.models.expressions import CombinedExpression, RawSQL
 from django.utils.translation import gettext as _
 
 from arches.app.models.models import (
@@ -46,7 +46,11 @@ CONCEPT_TYPE_LOOKUP = f"data__{CONCEPT_TYPE_NODEID}"
 
 class ConceptBuilder:
     def __init__(
-        self, concept_ids: list[str] | None = None, *, include_parents: bool = False
+        self,
+        concept_ids: list[str] | None = None,
+        *,
+        include_parents: bool = False,
+        shallow: bool = False,
     ):
         self.schemes = ResourceInstance.objects.none()
         self.schemes_by_id: dict[str, ResourceInstance] = {}
@@ -69,7 +73,10 @@ class ConceptBuilder:
 
         if concept_ids is None:
             self.top_concepts_map()
-            self.narrower_concepts_map()
+            if not shallow:
+                self.narrower_concepts_map()
+            else:
+                self.narrower_exists_map()
             self.populate_guide_term_concepts()
             self.populate_schemes()
             self.populate_resource_instance_lifecycle_state_ids(
@@ -197,6 +204,117 @@ class ConceptBuilder:
             concept_id = str(tile["resourceinstance_id"])
             self.labels[concept_id].append(tile["data"])
 
+    @classmethod
+    def for_concept_children(cls, parent_concept_id: str) -> "ConceptBuilder":
+        """Build a ConceptBuilder loaded with the direct children of a concept.
+
+        The resulting instance has `narrower_concepts`, `labels`,
+        `schemes_by_top_concept`, and `guide_term_concepts` populated only for
+        the immediate children of `parent_concept_id`.
+        """
+        builder = cls.__new__(cls)
+        builder.schemes = ResourceInstance.objects.none()
+        builder.schemes_by_id = {}
+        builder.top_concepts = defaultdict(set)
+        builder.narrower_concepts = defaultdict(set)
+        builder.labels = defaultdict(list)
+        builder.broader_concepts = defaultdict(set)
+        builder.schemes_by_top_concept = defaultdict(set)
+        builder.polyhierarchical_concepts = set()
+        builder.guide_term_concepts = set()
+        builder.language_lookup = {
+            lang.code: lang.name for lang in Language.objects.all()
+        }
+        builder.resource_instance_lifecycle_state_ids_by_resource_instance_id = {}
+        builder.lifecycle_state_names_by_id = {}
+
+        # Per-child EXISTS subquery: checks whether any tile records this
+        # child concept as its broader target, i.e. whether the child already
+        # has its own narrower concepts.  The check uses the JSONB @> (contains)
+        # operator with jsonb_build_array/jsonb_build_object so that the JSON
+        # value is constructed dynamically per row without any set-returning
+        # function (which PostgreSQL forbids in correlated WHERE clauses).  This
+        # folds the old separate narrower_exists_map call into the same query,
+        # removing the previous O(n) OR-based containment checks that were very
+        # slow for nodes with many children.
+        #
+        # Column names come from the model metadata because arches uses
+        # Django's legacy "my_fk_field" → "my_fk_fieldid" (no underscore)
+        # column naming, which RawSQL must reference explicitly.
+        _tile_table = TileModel._meta.db_table
+        _nodegroup_col = TileModel._meta.get_field("nodegroup").column
+        _resourceinstance_col = TileModel._meta.get_field("resourceinstance").column
+        _data_col = TileModel._meta.get_field("data").column
+        has_children_sql = RawSQL(
+            f"""
+            EXISTS (
+                SELECT 1
+                FROM "{_tile_table}" sub
+                WHERE sub.{_nodegroup_col} = %s::uuid
+                  AND sub."{_data_col}"->%s
+                      @> jsonb_build_array(
+                          jsonb_build_object(
+                              'resourceId',
+                              "{_tile_table}".{_resourceinstance_col}::text
+                          )
+                      )
+            )
+            """,
+            [
+                CLASSIFICATION_STATUS_NODEGROUP,
+                CLASSIFICATION_STATUS_ASCRIBED_CLASSIFICATION_NODEID,
+            ],
+            output_field=BooleanField(),
+        )
+
+        # Load direct children of this concept.
+        child_ids: set[str] = set()
+        broader_tiles = (
+            TileModel.objects.filter(
+                nodegroup_id=CLASSIFICATION_STATUS_NODEGROUP,
+                **{f"{BROADER_LOOKUP}__contains": [{"resourceId": parent_concept_id}]},
+            )
+            .annotate(labels=builder.labels_subquery(CONCEPT_NAME_NODEGROUP))
+            .annotate(has_children=has_children_sql)
+            .values("resourceinstance_id", "labels", "has_children")
+        )
+        for tile in broader_tiles.iterator():
+            child_id = str(tile["resourceinstance_id"])
+            child_ids.add(child_id)
+            builder.narrower_concepts[parent_concept_id].add(child_id)
+            builder.labels[child_id] = tile["labels"]
+            if tile["has_children"]:
+                # Mark this child as having narrower concepts so the frontend
+                # knows to show the expand toggle.  The sentinel value is
+                # sufficient — the actual grandchildren aren't loaded yet.
+                builder.narrower_concepts[child_id].add("__narrower_exists__")
+
+        # Track which children are top concepts of any scheme.
+        if child_ids:
+            top_concept_of_tiles = (
+                TileModel.objects.filter(
+                    nodegroup_id=TOP_CONCEPT_OF_NODE_AND_NODEGROUP,
+                    resourceinstance_id__in=child_ids,
+                )
+                .annotate(
+                    top_concept_of=builder.resources_from_tiles(TOP_CONCEPT_OF_LOOKUP)
+                )
+                .values("resourceinstance_id", "top_concept_of")
+            )
+            for tile in top_concept_of_tiles.iterator():
+                top_concept_id = str(tile["resourceinstance_id"])
+                builder.schemes_by_top_concept[top_concept_id].add(
+                    tile["top_concept_of"]
+                )
+
+            builder.populate_guide_term_concepts(list(child_ids))
+            builder.populate_resource_instance_lifecycle_state_ids(
+                scheme_ids=[],
+                concept_ids=list(child_ids),
+            )
+
+        return builder
+
     def top_concepts_map(self):
         top_concept_of_tiles = (
             TileModel.objects.filter(nodegroup_id=TOP_CONCEPT_OF_NODE_AND_NODEGROUP)
@@ -210,6 +328,31 @@ class ConceptBuilder:
             self.top_concepts[scheme_id].add(top_concept_id)
             self.schemes_by_top_concept[top_concept_id].add(scheme_id)
             self.labels[top_concept_id] = tile["labels"]
+
+    def narrower_exists_map(self):
+        """Populate `narrower_concepts` to record which concepts have children.
+
+        Used by the shallow initial tree load to flag every concept that has at
+        least one narrower concept, without loading the full child set.  The
+        stored value is a non-empty set when a parent has at least one child.
+
+        For the per-concept children endpoint, `has_narrower` is now computed
+        inline via an EXISTS subquery in `for_concept_children`, which avoids
+        the OR-of-containment-checks approach that was very slow for nodes
+        with many children.
+        """
+        broader_tiles = (
+            TileModel.objects.filter(
+                nodegroup_id=CLASSIFICATION_STATUS_NODEGROUP,
+            )
+            .annotate(broader_concept=self.resources_from_tiles(BROADER_LOOKUP))
+            .values("resourceinstance_id", "broader_concept")
+        )
+        for tile in broader_tiles.iterator():
+            broader_concept_id = tile["broader_concept"]
+            child_id = str(tile["resourceinstance_id"])
+            if broader_concept_id:
+                self.narrower_concepts[broader_concept_id].add(child_id)
 
     def narrower_concepts_map(self):
         broader_concept_tiles = (
@@ -290,7 +433,9 @@ class ConceptBuilder:
         )
         self.populate_guide_term_concepts(list(closure_concept_ids))
 
-    def serialize_scheme(self, scheme: ResourceInstance, *, children=True):
+    def serialize_scheme(
+        self, scheme: ResourceInstance, *, children=True, shallow=False
+    ):
         scheme_id: str = str(scheme.pk)
         scheme_lifecycle_state_id = (
             self.resource_instance_lifecycle_state_ids_by_resource_instance_id.get(
@@ -306,10 +451,16 @@ class ConceptBuilder:
             "labels": [self.serialize_scheme_label(label) for label in scheme.labels],
         }
         if children:
-            data["top_concepts"] = [
-                self.serialize_concept(concept_id)
-                for concept_id in sorted(self.top_concepts[scheme_id])
-            ]
+            if shallow:
+                data["top_concepts"] = [
+                    self.serialize_concept_shallow(concept_id)
+                    for concept_id in sorted(self.top_concepts[scheme_id])
+                ]
+            else:
+                data["top_concepts"] = [
+                    self.serialize_concept(concept_id)
+                    for concept_id in sorted(self.top_concepts[scheme_id])
+                ]
         return data
 
     def serialize_scheme_label(self, label_tile: dict):
@@ -382,7 +533,7 @@ class ConceptBuilder:
             for scheme_id, *parent_concept_ids in paths:
                 scheme_object = self.lookup_scheme(scheme_id)
                 if scheme_object is None:
-                    # skip any path whose scheme_id isn’t found
+                    # skip any path whose scheme_id isn't found
                     continue
 
                 serialized_scheme = self.serialize_scheme(scheme_object, children=False)
@@ -401,6 +552,31 @@ class ConceptBuilder:
             )
 
         return data
+
+    def serialize_concept_shallow(self, conceptid: str) -> dict:
+        """Serialize a concept without recursing into its children.
+
+        Includes a `has_narrower` boolean so the frontend can show an expand
+        toggle without having loaded the children yet.
+        """
+        concept_lifecycle_state_id = (
+            self.resource_instance_lifecycle_state_ids_by_resource_instance_id.get(
+                conceptid
+            )
+        )
+        return {
+            "id": conceptid,
+            "resource_instance_lifecycle_state_id": concept_lifecycle_state_id,
+            "resource_instance_lifecycle_state_name": self.lifecycle_state_names_by_id.get(
+                concept_lifecycle_state_id or ""
+            ),
+            "labels": [
+                self.serialize_concept_label(label) for label in self.labels[conceptid]
+            ],
+            "guide_term": conceptid in self.guide_term_concepts,
+            "top_concept": bool(self.schemes_by_top_concept.get(conceptid)),
+            "has_narrower": bool(self.narrower_concepts.get(conceptid)),
+        }
 
     def find_paths_to_root(self, working_path, conceptid) -> list[list[str]]:
         """Return an array of paths (path: an array of scheme & concept ids).

--- a/arches_lingo/utils/concept_builder.py
+++ b/arches_lingo/utils/concept_builder.py
@@ -50,7 +50,7 @@ class ConceptBuilder:
         self,
         concept_ids: list[str] | None = None,
         include_parents: bool = False,
-        shallow: bool = False,
+        depth: int | None = None,
     ):
         self.schemes = ResourceInstance.objects.none()
         self.schemes_by_id: dict[str, ResourceInstance] = {}
@@ -74,11 +74,13 @@ class ConceptBuilder:
         if concept_ids is None:
             self.top_concepts_map()
             top_concept_ids = list(self.labels.keys())
-            if not shallow:
+            if depth is None:
                 self.narrower_concepts_map()
             else:
                 self.batch_check_has_narrower(top_concept_ids)
-            self.populate_guide_term_concepts(top_concept_ids if shallow else None)
+            self.populate_guide_term_concepts(
+                top_concept_ids if depth is not None else None
+            )
             self.populate_schemes()
             self.populate_resource_instance_lifecycle_state_ids(
                 scheme_ids=list(self.schemes_by_id.keys()),
@@ -88,6 +90,45 @@ class ConceptBuilder:
 
         if include_parents:
             self.build_scoped_parents(concept_ids)
+            return
+
+        if depth == 1:
+            child_ids: set[str] = set()
+            for parent_id in concept_ids:
+                child_tiles = TileModel.objects.filter(
+                    nodegroup_id=CLASSIFICATION_STATUS_NODEGROUP,
+                    **{f"{BROADER_LOOKUP}__contains": [{"resourceId": parent_id}]},
+                ).values_list("resourceinstance_id", flat=True)
+                for resource_instance_id in child_tiles.iterator():
+                    child_id = str(resource_instance_id)
+                    child_ids.add(child_id)
+                    self.narrower_concepts[parent_id].add(child_id)
+
+            if not child_ids:
+                return
+
+            self.populate_concept_labels(list(child_ids))
+            self.batch_check_has_narrower(list(child_ids))
+
+            top_concept_of_tiles = (
+                TileModel.objects.filter(
+                    nodegroup_id=TOP_CONCEPT_OF_NODE_AND_NODEGROUP,
+                    resourceinstance_id__in=child_ids,
+                )
+                .annotate(
+                    top_concept_of=self.resources_from_tiles(TOP_CONCEPT_OF_LOOKUP)
+                )
+                .values("resourceinstance_id", "top_concept_of")
+            )
+            for tile in top_concept_of_tiles.iterator():
+                top_concept_id = str(tile["resourceinstance_id"])
+                self.schemes_by_top_concept[top_concept_id].add(tile["top_concept_of"])
+
+            self.populate_guide_term_concepts(list(child_ids))
+            self.populate_resource_instance_lifecycle_state_ids(
+                scheme_ids=[],
+                concept_ids=list(child_ids),
+            )
             return
 
         self.populate_concept_labels(concept_ids)
@@ -205,78 +246,6 @@ class ConceptBuilder:
             concept_id = str(tile["resourceinstance_id"])
             self.labels[concept_id].append(tile["data"])
 
-    @classmethod
-    def for_concept_children(cls, parent_concept_id: str) -> "ConceptBuilder":
-        """Build a ConceptBuilder loaded with the direct children of a concept.
-
-        The resulting instance has `narrower_concepts`, `labels`,
-        `schemes_by_top_concept`, and `guide_term_concepts` populated only for
-        the immediate children of `parent_concept_id`.
-
-        Uses separate batch queries instead of correlated subqueries for
-        labels and has_children to avoid O(N * table_scan) execution plans.
-        """
-        builder = cls.__new__(cls)
-        builder.schemes = ResourceInstance.objects.none()
-        builder.schemes_by_id = {}
-        builder.top_concepts = defaultdict(set)
-        builder.narrower_concepts = defaultdict(set)
-        builder.labels = defaultdict(list)
-        builder.broader_concepts = defaultdict(set)
-        builder.schemes_by_top_concept = defaultdict(set)
-        builder.polyhierarchical_concepts = set()
-        builder.guide_term_concepts = set()
-        builder.language_lookup = {
-            lang.code: lang.name for lang in Language.objects.all()
-        }
-        builder.resource_instance_lifecycle_state_ids_by_resource_instance_id = {}
-        builder.lifecycle_state_names_by_id = {}
-
-        child_ids: set[str] = set()
-        child_tiles = TileModel.objects.filter(
-            nodegroup_id=CLASSIFICATION_STATUS_NODEGROUP,
-            **{f"{BROADER_LOOKUP}__contains": [{"resourceId": parent_concept_id}]},
-        ).values_list("resourceinstance_id", flat=True)
-        for resource_instance_id in child_tiles.iterator():
-            child_id = str(resource_instance_id)
-            child_ids.add(child_id)
-            builder.narrower_concepts[parent_concept_id].add(child_id)
-
-        if not child_ids:
-            return builder
-
-        # Query 2: Batch-fetch labels for all children at once.
-        builder.populate_concept_labels(list(child_ids))
-
-        # Query 3: Batch-check which children have their own narrower
-        # concepts. Uses a single unnest + EXISTS query so the GIN index
-        # on the broader-concept JSONB column is hit once per child_id
-        # instead of running a correlated subquery per outer row.
-        builder.batch_check_has_narrower(list(child_ids))
-
-        # Track which children are top concepts of any scheme.
-        top_concept_of_tiles = (
-            TileModel.objects.filter(
-                nodegroup_id=TOP_CONCEPT_OF_NODE_AND_NODEGROUP,
-                resourceinstance_id__in=child_ids,
-            )
-            .annotate(
-                top_concept_of=builder.resources_from_tiles(TOP_CONCEPT_OF_LOOKUP)
-            )
-            .values("resourceinstance_id", "top_concept_of")
-        )
-        for tile in top_concept_of_tiles.iterator():
-            top_concept_id = str(tile["resourceinstance_id"])
-            builder.schemes_by_top_concept[top_concept_id].add(tile["top_concept_of"])
-
-        builder.populate_guide_term_concepts(list(child_ids))
-        builder.populate_resource_instance_lifecycle_state_ids(
-            scheme_ids=[],
-            concept_ids=list(child_ids),
-        )
-
-        return builder
-
     def top_concepts_map(self):
         top_concept_of_tiles = (
             TileModel.objects.filter(nodegroup_id=TOP_CONCEPT_OF_NODE_AND_NODEGROUP)
@@ -292,17 +261,6 @@ class ConceptBuilder:
             self.labels[top_concept_id] = tile["labels"]
 
     def narrower_exists_map(self):
-        """Populate `narrower_concepts` to record which concepts have children.
-
-        Used by the shallow initial tree load to flag every concept that has at
-        least one narrower concept, without loading the full child set.  The
-        stored value is a non-empty set when a parent has at least one child.
-
-        For the per-concept children endpoint, `has_narrower` is now computed
-        inline via an EXISTS subquery in `for_concept_children`, which avoids
-        the OR-of-containment-checks approach that was very slow for nodes
-        with many children.
-        """
         broader_tiles = (
             TileModel.objects.filter(
                 nodegroup_id=CLASSIFICATION_STATUS_NODEGROUP,

--- a/arches_lingo/utils/concept_builder.py
+++ b/arches_lingo/utils/concept_builder.py
@@ -2,8 +2,9 @@ import logging
 from collections import defaultdict
 
 from django.contrib.postgres.expressions import ArraySubquery
-from django.db.models import BooleanField, CharField, F, OuterRef, Value
-from django.db.models.expressions import CombinedExpression, RawSQL
+from django.db import connection
+from django.db.models import CharField, F, OuterRef, Value
+from django.db.models.expressions import CombinedExpression
 from django.utils.translation import gettext as _
 
 from arches.app.models.models import (
@@ -211,6 +212,9 @@ class ConceptBuilder:
         The resulting instance has `narrower_concepts`, `labels`,
         `schemes_by_top_concept`, and `guide_term_concepts` populated only for
         the immediate children of `parent_concept_id`.
+
+        Uses separate batch queries instead of correlated subqueries for
+        labels and has_children to avoid O(N * table_scan) execution plans.
         """
         builder = cls.__new__(cls)
         builder.schemes = ResourceInstance.objects.none()
@@ -228,90 +232,78 @@ class ConceptBuilder:
         builder.resource_instance_lifecycle_state_ids_by_resource_instance_id = {}
         builder.lifecycle_state_names_by_id = {}
 
-        # Per-child EXISTS subquery: checks whether any tile records this
-        # child concept as its broader target, i.e. whether the child already
-        # has its own narrower concepts.  The check uses the JSONB @> (contains)
-        # operator with jsonb_build_array/jsonb_build_object so that the JSON
-        # value is constructed dynamically per row without any set-returning
-        # function (which PostgreSQL forbids in correlated WHERE clauses).  This
-        # folds the old separate narrower_exists_map call into the same query,
-        # removing the previous O(n) OR-based containment checks that were very
-        # slow for nodes with many children.
-        #
-        # Column names come from the model metadata because arches uses
-        # Django's legacy "my_fk_field" → "my_fk_fieldid" (no underscore)
-        # column naming, which RawSQL must reference explicitly.
-        _tile_table = TileModel._meta.db_table
-        _nodegroup_col = TileModel._meta.get_field("nodegroup").column
-        _resourceinstance_col = TileModel._meta.get_field("resourceinstance").column
-        _data_col = TileModel._meta.get_field("data").column
-        has_children_sql = RawSQL(
-            f"""
-            EXISTS (
-                SELECT 1
-                FROM "{_tile_table}" sub
-                WHERE sub.{_nodegroup_col} = %s::uuid
-                  AND sub."{_data_col}"->%s
-                      @> jsonb_build_array(
-                          jsonb_build_object(
-                              'resourceId',
-                              "{_tile_table}".{_resourceinstance_col}::text
-                          )
-                      )
-            )
-            """,
-            [
-                CLASSIFICATION_STATUS_NODEGROUP,
-                CLASSIFICATION_STATUS_ASCRIBED_CLASSIFICATION_NODEID,
-            ],
-            output_field=BooleanField(),
-        )
-
-        # Load direct children of this concept.
+        # Query 1: Get direct child resource instance IDs.
         child_ids: set[str] = set()
-        broader_tiles = (
-            TileModel.objects.filter(
-                nodegroup_id=CLASSIFICATION_STATUS_NODEGROUP,
-                **{f"{BROADER_LOOKUP}__contains": [{"resourceId": parent_concept_id}]},
-            )
-            .annotate(labels=builder.labels_subquery(CONCEPT_NAME_NODEGROUP))
-            .annotate(has_children=has_children_sql)
-            .values("resourceinstance_id", "labels", "has_children")
-        )
-        for tile in broader_tiles.iterator():
-            child_id = str(tile["resourceinstance_id"])
+        child_tiles = TileModel.objects.filter(
+            nodegroup_id=CLASSIFICATION_STATUS_NODEGROUP,
+            **{f"{BROADER_LOOKUP}__contains": [{"resourceId": parent_concept_id}]},
+        ).values_list("resourceinstance_id", flat=True)
+        for resource_instance_id in child_tiles.iterator():
+            child_id = str(resource_instance_id)
             child_ids.add(child_id)
             builder.narrower_concepts[parent_concept_id].add(child_id)
-            builder.labels[child_id] = tile["labels"]
-            if tile["has_children"]:
-                # Mark this child as having narrower concepts so the frontend
-                # knows to show the expand toggle.  The sentinel value is
-                # sufficient — the actual grandchildren aren't loaded yet.
-                builder.narrower_concepts[child_id].add("__narrower_exists__")
+
+        if not child_ids:
+            return builder
+
+        # Query 2: Batch-fetch labels for all children at once.
+        builder.populate_concept_labels(list(child_ids))
+
+        # Query 3: Batch-check which children have their own narrower
+        # concepts. Uses a single unnest + EXISTS query so the GIN index
+        # on the broader-concept JSONB column is hit once per child_id
+        # instead of running a correlated subquery per outer row.
+        _tile_table = TileModel._meta.db_table
+        _nodegroup_col = TileModel._meta.get_field("nodegroup").column
+        _data_col = TileModel._meta.get_field("data").column
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT child_id
+                FROM unnest(%(child_ids)s::text[]) AS child_id
+                WHERE EXISTS (
+                    SELECT 1
+                    FROM "{_tile_table}" sub
+                    WHERE sub."{_nodegroup_col}" = %(nodegroup)s::uuid
+                      AND sub."{_data_col}"->%(node_id)s
+                          @> jsonb_build_array(
+                              jsonb_build_object('resourceId', child_id)
+                          )
+                )
+                """,
+                {
+                    "child_ids": list(child_ids),
+                    "nodegroup": str(CLASSIFICATION_STATUS_NODEGROUP),
+                    "node_id": str(
+                        CLASSIFICATION_STATUS_ASCRIBED_CLASSIFICATION_NODEID
+                    ),
+                },
+            )
+            children_with_narrower = {row[0] for row in cursor.fetchall()}
+
+        for child_id in children_with_narrower:
+            builder.narrower_concepts[child_id].add("__narrower_exists__")
 
         # Track which children are top concepts of any scheme.
-        if child_ids:
-            top_concept_of_tiles = (
-                TileModel.objects.filter(
-                    nodegroup_id=TOP_CONCEPT_OF_NODE_AND_NODEGROUP,
-                    resourceinstance_id__in=child_ids,
-                )
-                .annotate(
-                    top_concept_of=builder.resources_from_tiles(TOP_CONCEPT_OF_LOOKUP)
-                )
-                .values("resourceinstance_id", "top_concept_of")
+        top_concept_of_tiles = (
+            TileModel.objects.filter(
+                nodegroup_id=TOP_CONCEPT_OF_NODE_AND_NODEGROUP,
+                resourceinstance_id__in=child_ids,
             )
-            for tile in top_concept_of_tiles.iterator():
-                top_concept_id = str(tile["resourceinstance_id"])
-                builder.schemes_by_top_concept[top_concept_id].add(
-                    tile["top_concept_of"]
-                )
+            .annotate(
+                top_concept_of=builder.resources_from_tiles(TOP_CONCEPT_OF_LOOKUP)
+            )
+            .values("resourceinstance_id", "top_concept_of")
+        )
+        for tile in top_concept_of_tiles.iterator():
+            top_concept_id = str(tile["resourceinstance_id"])
+            builder.schemes_by_top_concept[top_concept_id].add(tile["top_concept_of"])
 
-            builder.populate_guide_term_concepts(list(child_ids))
-            builder.populate_resource_instance_lifecycle_state_ids(
-                scheme_ids=[],
-                concept_ids=list(child_ids),
-            )
+        builder.populate_guide_term_concepts(list(child_ids))
+        builder.populate_resource_instance_lifecycle_state_ids(
+            scheme_ids=[],
+            concept_ids=list(child_ids),
+        )
 
         return builder
 

--- a/arches_lingo/utils/concept_builder.py
+++ b/arches_lingo/utils/concept_builder.py
@@ -74,15 +74,16 @@ class ConceptBuilder:
 
         if concept_ids is None:
             self.top_concepts_map()
+            top_concept_ids = list(self.labels.keys())
             if not shallow:
                 self.narrower_concepts_map()
             else:
-                self.narrower_exists_map()
-            self.populate_guide_term_concepts()
+                self.batch_check_has_narrower(top_concept_ids)
+            self.populate_guide_term_concepts(top_concept_ids if shallow else None)
             self.populate_schemes()
             self.populate_resource_instance_lifecycle_state_ids(
                 scheme_ids=list(self.schemes_by_id.keys()),
-                concept_ids=list(self.labels.keys()),
+                concept_ids=top_concept_ids,
             )
             return
 
@@ -253,36 +254,7 @@ class ConceptBuilder:
         # concepts. Uses a single unnest + EXISTS query so the GIN index
         # on the broader-concept JSONB column is hit once per child_id
         # instead of running a correlated subquery per outer row.
-        _tile_table = TileModel._meta.db_table
-        _nodegroup_col = TileModel._meta.get_field("nodegroup").column
-        _data_col = TileModel._meta.get_field("data").column
-        with connection.cursor() as cursor:
-            cursor.execute(
-                f"""
-                SELECT child_id
-                FROM unnest(%(child_ids)s::text[]) AS child_id
-                WHERE EXISTS (
-                    SELECT 1
-                    FROM "{_tile_table}" sub
-                    WHERE sub."{_nodegroup_col}" = %(nodegroup)s::uuid
-                      AND sub."{_data_col}"->%(node_id)s
-                          @> jsonb_build_array(
-                              jsonb_build_object('resourceId', child_id)
-                          )
-                )
-                """,
-                {
-                    "child_ids": list(child_ids),
-                    "nodegroup": str(CLASSIFICATION_STATUS_NODEGROUP),
-                    "node_id": str(
-                        CLASSIFICATION_STATUS_ASCRIBED_CLASSIFICATION_NODEID
-                    ),
-                },
-            )
-            children_with_narrower = {row[0] for row in cursor.fetchall()}
-
-        for child_id in children_with_narrower:
-            builder.narrower_concepts[child_id].add("__narrower_exists__")
+        builder.batch_check_has_narrower(list(child_ids))
 
         # Track which children are top concepts of any scheme.
         top_concept_of_tiles = (
@@ -345,6 +317,44 @@ class ConceptBuilder:
             child_id = str(tile["resourceinstance_id"])
             if broader_concept_id:
                 self.narrower_concepts[broader_concept_id].add(child_id)
+
+    def batch_check_has_narrower(self, concept_ids: list[str]) -> None:
+        """Check which of the given concept IDs have narrower concepts.
+
+        Uses a single unnest + EXISTS query against the GIN-indexed broader
+        concept column, avoiding a full scan of all classification tiles.
+        """
+        if not concept_ids:
+            return
+
+        _tile_table = TileModel._meta.db_table
+        _nodegroup_col = TileModel._meta.get_field("nodegroup").column
+        _data_col = TileModel._meta.get_field("data").column
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT concept_id
+                FROM unnest(%(concept_ids)s::text[]) AS concept_id
+                WHERE EXISTS (
+                    SELECT 1
+                    FROM "{_tile_table}" sub
+                    WHERE sub."{_nodegroup_col}" = %(nodegroup)s::uuid
+                      AND sub."{_data_col}"->%(node_id)s
+                          @> jsonb_build_array(
+                              jsonb_build_object('resourceId', concept_id)
+                          )
+                )
+                """,
+                {
+                    "concept_ids": concept_ids,
+                    "nodegroup": str(CLASSIFICATION_STATUS_NODEGROUP),
+                    "node_id": str(
+                        CLASSIFICATION_STATUS_ASCRIBED_CLASSIFICATION_NODEID
+                    ),
+                },
+            )
+            for (concept_id,) in cursor.fetchall():
+                self.narrower_concepts[concept_id].add("__narrower_exists__")
 
     def narrower_concepts_map(self):
         broader_concept_tiles = (

--- a/arches_lingo/views/api/concepts.py
+++ b/arches_lingo/views/api/concepts.py
@@ -33,7 +33,7 @@ from arches_lingo.utils.dashboard import (
 
 class ConceptTreeView(AnonymousAccessMixin, View):
     def get(self, request):
-        builder = ConceptBuilder(shallow=True)
+        builder = ConceptBuilder(depth=1)
         data = {
             "schemes": [
                 builder.serialize_scheme(scheme, shallow=True)
@@ -45,7 +45,7 @@ class ConceptTreeView(AnonymousAccessMixin, View):
 
 class ConceptChildrenView(AnonymousAccessMixin, View):
     def get(self, request, concept_id):
-        builder = ConceptBuilder.for_concept_children(str(concept_id))
+        builder = ConceptBuilder([str(concept_id)], depth=1)
         children = [
             builder.serialize_concept_shallow(child_id)
             for child_id in sorted(

--- a/arches_lingo/views/api/concepts.py
+++ b/arches_lingo/views/api/concepts.py
@@ -33,11 +33,52 @@ from arches_lingo.utils.dashboard import (
 
 class ConceptTreeView(AnonymousAccessMixin, View):
     def get(self, request):
-        builder = ConceptBuilder()
+        builder = ConceptBuilder(shallow=True)
         data = {
-            "schemes": [builder.serialize_scheme(scheme) for scheme in builder.schemes]
+            "schemes": [
+                builder.serialize_scheme(scheme, shallow=True)
+                for scheme in builder.schemes
+            ]
         }
         return JSONResponse(data)
+
+
+class ConceptChildrenView(AnonymousAccessMixin, View):
+    def get(self, request, concept_id):
+        builder = ConceptBuilder.for_concept_children(str(concept_id))
+        children = [
+            builder.serialize_concept_shallow(child_id)
+            for child_id in sorted(
+                builder.narrower_concepts.get(str(concept_id), set())
+            )
+        ]
+        return JSONResponse({"children": children})
+
+
+class ConceptAncestorsView(AnonymousAccessMixin, View):
+    def get(self, request, concept_id):
+        concept_id_str = str(concept_id)
+        builder = ConceptBuilder([concept_id_str], include_parents=True)
+        paths = builder.find_paths_to_root([concept_id_str], concept_id_str)
+
+        ancestor_paths = []
+        for path in paths:
+            search_results = []
+            for node_id in path:
+                scheme = builder.lookup_scheme(node_id)
+                if scheme is not None:
+                    search_results.append(
+                        builder.serialize_scheme(scheme, children=False)
+                    )
+                else:
+                    search_results.append(
+                        builder.serialize_concept(
+                            node_id, parents=False, children=False
+                        )
+                    )
+            ancestor_paths.append({"searchResults": search_results})
+
+        return JSONResponse({"paths": ancestor_paths})
 
 
 class ValueSearchView(ConceptTreeView):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -256,7 +256,7 @@ class ViewTests(TestCase):
         with self.assertNumQueries(9):
             # 1: session
             # 2: auth
-            # 3: select broader tiles, subquery for labels
+            # 3: select broader tiles (narrower_exists_map), subquery for labels
             # 4: select top concept tiles, subquery for labels
             # 5: select guide term concept type tiles
             # 6: select schemes, subquery for labels
@@ -282,24 +282,49 @@ class ViewTests(TestCase):
         self.assertIsNotNone(top["resource_instance_lifecycle_state_id"])
         self.assertIn("resource_instance_lifecycle_state_name", top)
         self.assertIsNotNone(top["resource_instance_lifecycle_state_name"])
-        self.assertEqual(len(top["narrower"]), 4)
+        # Shallow response: no narrower array, but has_narrower flag.
+        self.assertNotIn("narrower", top)
+        self.assertTrue(top["has_narrower"])
+
+    def test_get_concept_children(self):
+        response = self.client.get(
+            reverse(
+                "api-concept-children",
+                kwargs={"concept_id": self.concepts[0].pk},
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.content)
+
+        self.assertIn("children", result)
+        self.assertEqual(len(result["children"]), 4)
         self.assertEqual(
-            {n["labels"][0]["value"] for n in top["narrower"]},
+            {c["labels"][0]["value"] for c in result["children"]},
             {"Concept 2", "Concept 3", "Concept 4", "Concept 5"},
         )
-        concept_2 = [
-            concept
-            for concept in top["narrower"]
-            if concept["labels"][0]["value"] == "Concept 2"
-        ][0]
-        self.assertEqual(
-            {n["labels"][0]["value"] for n in concept_2["narrower"]},
-            {"Concept 3"},
+        # Each child should have a has_narrower flag but no narrower array.
+        for child in result["children"]:
+            self.assertIn("has_narrower", child)
+            self.assertNotIn("narrower", child)
+
+        # Concept 2 should report has_narrower=True (it has Concept 3 as child).
+        concept_2 = next(
+            c for c in result["children"] if c["labels"][0]["value"] == "Concept 2"
         )
-        self.assertEqual(
-            {n["labels"][0]["valuetype_id"] for n in concept_2["narrower"]},
-            {"prefLabel"},
+        self.assertTrue(concept_2["has_narrower"])
+
+    def test_get_leaf_concept_children(self):
+        # Concepts 3-5 have no narrower children.
+        response = self.client.get(
+            reverse(
+                "api-concept-children",
+                kwargs={"concept_id": self.concepts[2].pk},
+            )
         )
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.content)
+        # Concept 3 has Concept 4 as narrower.
+        self.assertEqual(len(result["children"]), 1)
 
     def test_lifecycle_states_endpoint(self):
         response = self.client.get(reverse("api-lingo-lifecycle-states"))
@@ -507,7 +532,7 @@ class ViewTests(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_guide_term_flag_in_concept_tree(self):
-        """Concepts with guide term concept type should be flagged."""
+        """Concepts with guide term concept type should be flagged in children response."""
         guide_concept = self.concepts[1]  # Concept 2
 
         # Add a type tile with guide term type
@@ -524,27 +549,28 @@ class ViewTests(TestCase):
             },
         )
 
-        response = self.client.get(reverse("api-concepts"))
+        # The shallow tree only returns top concepts; guide_term check is done
+        # via the children endpoint for the top concept.
+        response = self.client.get(
+            reverse(
+                "api-concept-children",
+                kwargs={"concept_id": self.concepts[0].pk},
+            )
+        )
         self.assertEqual(response.status_code, 200)
         result = json.loads(response.content)
-        scheme = result["schemes"][0]
-        top = scheme["top_concepts"][0]
-
-        # The top concept (Concept 1) should NOT be a guide term
-        self.assertFalse(top["guide_term"])
+        children = result["children"]
 
         # Find Concept 2 in narrower list -- it should be flagged as guide term
         concept_2 = next(
-            narrower_concept
-            for narrower_concept in top["narrower"]
-            if narrower_concept["labels"][0]["value"] == "Concept 2"
+            child for child in children if child["labels"][0]["value"] == "Concept 2"
         )
         self.assertTrue(concept_2["guide_term"])
 
         # Other narrower concepts should not be guide terms
-        for narrower_concept in top["narrower"]:
-            if narrower_concept["labels"][0]["value"] != "Concept 2":
-                self.assertFalse(narrower_concept["guide_term"])
+        for child in children:
+            if child["labels"][0]["value"] != "Concept 2":
+                self.assertFalse(child["guide_term"])
 
     def test_guide_term_flag_in_search(self):
         """Guide term flag should appear in search results."""
@@ -588,8 +614,17 @@ class ViewTests(TestCase):
         top = scheme["top_concepts"][0]
 
         self.assertFalse(top["guide_term"])
-        for narrower_concept in top["narrower"]:
-            self.assertFalse(narrower_concept["guide_term"])
+
+        # Verify children also have guide_term=False
+        children_response = self.client.get(
+            reverse(
+                "api-concept-children",
+                kwargs={"concept_id": self.concepts[0].pk},
+            )
+        )
+        children_result = json.loads(children_response.content)
+        for child in children_result["children"]:
+            self.assertFalse(child["guide_term"])
 
     @override_settings(LINGO_ALLOW_ANONYMOUS_ACCESS=True)
     def test_anonymous_can_read_concept_trees(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -309,7 +309,9 @@ class ViewTests(TestCase):
 
         # Concept 2 should report has_narrower=True (it has Concept 3 as child).
         concept_2 = next(
-            c for c in result["children"] if c["labels"][0]["value"] == "Concept 2"
+            concept
+            for concept in result["children"]
+            if concept["labels"][0]["value"] == "Concept 2"
         )
         self.assertTrue(concept_2["has_narrower"])
 


### PR DESCRIPTION
Loading the entire tree for large datasets such as AAT results in issues when rendering the hierachy tree.  Thus the rework towards progressive loading.

adds shallow tree, lazy child expansion, concept children/ancestors API endpoints

re: #336 