### PR TITLE
Adds content-negotiated SKOS dereferencing for scheme & concept URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ For developer install instructions, see the [Developer Setup](#developer-setup-f
 
 1. If you don't already have an Arches project, you'll need to create one by following the instructions in the Arches [documentation](http://archesproject.org/documentation/).
 
-2. When your project is ready, add "arches_querysets", "arches_component_lab", "arches_controlled_lists", "arches_lingo", and "pgtrigger" to INSTALLED_APPS **below** the name of your project:
+2. When your project is ready, add "arches_querysets", "arches_vue_components", "arches_controlled_lists", "arches_lingo", and "pgtrigger" to INSTALLED_APPS **below** the name of your project:
     ```
     INSTALLED_APPS = (
         ...
         "my_project_name",
         "arches_querysets",
-        "arches_component_lab",
+        "arches_vue_components",
         "arches_controlled_lists",
         "arches_lingo",
         "pgtrigger",
@@ -78,11 +78,11 @@ For developer install instructions, see the [Developer Setup](#developer-setup-f
     ```
     When enabled, unauthenticated users can browse schemes, concepts, and search results in a read-only mode. When disabled (the default), all users must log in to access any Lingo content. Authenticated users who are not members of the "Lingo Editor" group will still see a read-only experience regardless of this setting.
 
-5. Next ensure arches, arches-component-lab, and arches_lingo are included as dependencies in package.json
+5. Next ensure arches, arches-vue-components, and arches_lingo are included as dependencies in package.json
     ```
     "dependencies": {
         "arches": "archesproject/arches#dev/8.1.x",
-        "arches-component-lab": "archesproject/arches-component-lab#main",
+        "arches-vue-components": "archesproject/arches-vue-components#dev/2.0.x",
         "arches_lingo": "archesproject/arches-lingo#main"
     }
     ```

--- a/arches_lingo/const.py
+++ b/arches_lingo/const.py
@@ -132,6 +132,26 @@ IDENTIFIER_CONTENT_NODE = "bf73e6ba-4888-11ee-8a8d-11afefc4bff7"
 MATCH_STATUS_NODEGROUP = "4cfaaa64-0ed7-11ef-9493-0a58a9feac02"
 MATCH_STATUS_COMPARATE_NODE = "4cfaae24-0ed7-11ef-9493-0a58a9feac02"
 
+# depicting_digital_asset (concept -> image relationships)
+# Internal: resource-instance-list pointing to Digital Object resources.
+DEPICTING_DIGITAL_ASSET_INTERNAL_NODEGROUP = "bf73e628-4888-11ee-8a8d-11afefc4bff7"
+DEPICTING_DIGITAL_ASSET_INTERNAL_NODE = "bf73e628-4888-11ee-8a8d-11afefc4bff7"
+# External: url pointing directly at an image outside of Arches.
+DEPICTING_DIGITAL_ASSET_EXTERNAL_NODEGROUP = "bf73e577-4888-11ee-8a8d-11afefc4bff7"
+DEPICTING_DIGITAL_ASSET_EXTERNAL_NODE = "bf73e577-4888-11ee-8a8d-11afefc4bff7"
+
+### Digital Object Model Nodes & Nodegroups ###
+DIGITAL_OBJECT_GRAPH_ID = "ce57ee93-1f08-11ee-9071-214dbb482912"
+# content (file-list holding the uploaded image file(s))
+DIGITAL_OBJECT_CONTENT_NODEGROUP = "f522c448-1778-11ef-b270-0a58a9feac02"
+DIGITAL_OBJECT_CONTENT_NODE = "f522c448-1778-11ef-b270-0a58a9feac02"
+# name (title)
+DIGITAL_OBJECT_NAME_NODEGROUP = "78fc1ff8-11e8-11ef-9493-0a58a9feac02"
+DIGITAL_OBJECT_NAME_CONTENT_NODE = "95522790-08fc-11f0-9797-b33468cba848"
+# statement (description)
+DIGITAL_OBJECT_STATEMENT_NODEGROUP = "8278e3c2-11e8-11ef-9493-0a58a9feac02"
+DIGITAL_OBJECT_STATEMENT_CONTENT_NODE = "4e995163-08fc-11f0-b111-b33468cba848"
+
 
 # status (lifecycle/status)
 STATUS_NODEGROUP = "152321b6-0f5e-11ef-9493-0a58a9feac02"

--- a/arches_lingo/const.py
+++ b/arches_lingo/const.py
@@ -130,6 +130,7 @@ IDENTIFIER_CONTENT_NODE = "bf73e6ba-4888-11ee-8a8d-11afefc4bff7"
 
 # match_status
 MATCH_STATUS_NODEGROUP = "4cfaaa64-0ed7-11ef-9493-0a58a9feac02"
+MATCH_STATUS_RELATION_NODE = "4cfaad48-0ed7-11ef-9493-0a58a9feac02"
 MATCH_STATUS_COMPARATE_NODE = "4cfaae24-0ed7-11ef-9493-0a58a9feac02"
 
 # depicting_digital_asset (concept -> image relationships)

--- a/arches_lingo/etl_modules/lingo_resource_exporter.py
+++ b/arches_lingo/etl_modules/lingo_resource_exporter.py
@@ -5,7 +5,6 @@ import uuid
 import zipfile
 from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
-from collections import defaultdict
 from datetime import datetime
 from slugify import slugify
 
@@ -29,6 +28,11 @@ from arches.app.tasks import notify_completion
 
 from arches_lingo.utils.concept_builder import ConceptBuilder
 from arches_lingo.utils.skos import SKOSWriter
+from arches_lingo.utils.skos_serializer import (
+    build_resource_uri_map,
+    build_triples_for_resource,
+    collect_referenced_resource_ids,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -46,59 +50,6 @@ details = {
     "slug": "export-lingo-resources",
     "helpsortorder": 0,
     "helptemplate": "export-lingo-resources-help",
-}
-
-"""
-Mapping dict consists of nodegroup aliases as top level key. Their values are dicts where
-the key indicates the component of a triple and the value are node aliases which are used
-to extract data from Arches Queryset TileTrees. There is also an option to define a 
-default predicate if a predicate is not found in the tile tree.
-Some predicates are hardcoded SKOS predicates for specific relationships.
-
-nodegroup_alias: {
-    "predicate": "<predicate_node_alias>" | "<skos_predicate_value>",
-    "object": "<object_node_alias>",
-    "object_language": "<object_language_node_alias>" (optional)
-    "default_predicate": "<default_predicate_value>" (optional)
-}
-"""
-TILE_TREE_TO_TRIPLE_MAPPING = {
-    # Scheme and Concept Mappings:
-    "appellative_status": {
-        "predicate": "appellative_status_ascribed_relation",
-        "object": "appellative_status_ascribed_name_content",
-        "object_language": "appellative_status_ascribed_name_language",
-    },
-    "identifier": {
-        "predicate": "identifier_type",
-        "object": "identifier_content",
-    },
-    "statement": {
-        "predicate": "statement_type",
-        "object": "statement_content",
-        "object_language": "statement_language",
-    },
-    # Concept Mappings:
-    "top_concept_of": {
-        "predicate": "hasTopConcept",  # hardcoded SKOS predicate
-        "object": "top_concept_of",
-    },
-    "part_of_scheme": {
-        "predicate": "inScheme",  # hardcoded SKOS predicate
-        "object": "part_of_scheme",
-    },
-    # Hierarchy
-    "classification_status": {
-        "predicate": "classification_status_ascribed_relation",
-        "object": "classification_status_ascribed_classification",
-        "default_predicate": "broader",
-    },
-    # Associated Concepts
-    "relation_status": {
-        "predicate": "relation_status_ascribed_relation",
-        "object": "relation_status_ascribed_comparate",
-        "default_predicate": "related",
-    },
 }
 
 
@@ -201,39 +152,41 @@ class LingoResourceExporter:
         self.schemes = schemes
         self.concepts = concepts
 
-        scheme_triples = defaultdict(list)
-        for scheme in self.schemes:
-            for nodegroup_alias, tile_trees in scheme.aliased_data._items():
-                if tile_trees:
-                    scheme_triples[scheme.resourceinstanceid].extend(
-                        self.extract_triples_from_aliased_tiles(
-                            nodegroup_alias, tile_trees
-                        )
-                    )
-
-        concept_triples = defaultdict(list)
-        for concept in self.concepts:
-            for nodegroup_alias, tile_trees in concept.aliased_data._items():
-                if tile_trees:
-                    concept_triples[concept.resourceinstanceid].extend(
-                        self.extract_triples_from_aliased_tiles(
-                            nodegroup_alias, tile_trees
-                        )
-                    )
+        scheme_triples = {
+            scheme.resourceinstanceid: build_triples_for_resource(scheme)
+            for scheme in self.schemes
+        }
+        concept_triples = {
+            concept.resourceinstanceid: build_triples_for_resource(concept)
+            for concept in self.concepts
+        }
 
         if len(scheme_triples) == 0 and len(concept_triples) == 0:
             error = _("The thesaurus could not be mapped to triples for export.")
             self._handle_error(error)
             return []
 
+        resource_uri_map = self._build_export_uri_map(scheme_triples, concept_triples)
+
         writer = SKOSWriter()
-        rdf_graph = writer.write_skos_from_triples(scheme_triples, concept_triples)
+        rdf_graph = writer.write_skos_from_triples(
+            scheme_triples, concept_triples, resource_uri_map=resource_uri_map
+        )
         serialized = rdf_graph.serialize(format="pretty-xml")
 
         file_name = self._make_filename("xml")
         if isinstance(serialized, str):
             serialized = serialized.encode("utf-8")
         return [{"name": file_name, "content": serialized}]
+
+    def _build_export_uri_map(self, scheme_triples, concept_triples):
+        """Resolve public URIs for every resource in the export and everything it links to."""
+        subject_ids = {str(resource_id) for resource_id in scheme_triples}
+        subject_ids |= {str(resource_id) for resource_id in concept_triples}
+        referenced_ids = set()
+        for triples in (*scheme_triples.values(), *concept_triples.values()):
+            referenced_ids |= collect_referenced_resource_ids(triples)
+        return build_resource_uri_map(subject_ids | referenced_ids)
 
     def _get_resource_ids_for_export(self, resourceid):
         """
@@ -511,39 +464,6 @@ class LingoResourceExporter:
                 concepts.append(concept)
 
         return schemes, concepts
-
-    def extract_triples_from_aliased_tiles(self, nodegroup_alias, tile_trees):
-        triples = []
-        mapping = TILE_TREE_TO_TRIPLE_MAPPING.get(nodegroup_alias)
-        if mapping is None:
-            logger.error(f"No mapping found for nodegroup alias: {nodegroup_alias}")
-            return []
-        if type(tile_trees) is not list:
-            tile_trees = [tile_trees]
-        for tile_tree in tile_trees:
-            triple = defaultdict(str)
-            for triple_component, node_alias in mapping.items():
-                if node_alias in ["inScheme", "hasTopConcept"]:
-                    # Predicate for concept -> scheme relationship are not stored as a node value
-                    # but instead derived from the relationship itself
-                    triple[triple_component] = node_alias
-                elif (
-                    triple_component == "default_predicate"
-                    and triple["predicate"] is None
-                ):
-                    # Fall back on default predicates for relationships if none was found
-                    triple["predicate"] = node_alias
-                elif triple_component != "default_predicate":
-                    try:
-                        predicate = getattr(tile_tree.aliased_data, node_alias)
-                    except AttributeError:
-                        # Expected when we've directly mapped a relationship
-                        # that won't be wrapped as AliasedData as returned from a queryset
-                        # (e.g. top_concept_of and part_of_scheme during partial hierarchy export)
-                        predicate = tile_tree
-                    triple[triple_component] = predicate
-            triples.append(triple)
-        return triples
 
     def _handle_error(self, error):
         self.load_event.status = "failed"

--- a/arches_lingo/migrations/0004_add_language_widget_mapping.py
+++ b/arches_lingo/migrations/0004_add_language_widget_mapping.py
@@ -1,5 +1,4 @@
 from django.db import migrations
-from arches_component_lab.utils.widget_synchronizer import WidgetSynchronizer
 
 
 class Migration(migrations.Migration):
@@ -7,21 +6,8 @@ class Migration(migrations.Migration):
     dependencies = [
         ("models", "12557_add_language_datatype"),
         ("arches_lingo", "0003_add_languages"),
-        ("arches_component_lab", "0003_add_pk_default"),
     ]
 
-    def forward(apps, schema_editor):
-        WidgetSynchronizer().add_mapping(
-            "language-widget",
-            "arches_component_lab/widgets/LanguageSelectWidget/LanguageSelectWidget.vue",
-        )
-
-    def reverse(apps, schema_editor):
-        Widget = apps.get_model("arches", "Widget")
-        WidgetMapping = apps.get_model("arches_component_lab", "WidgetMapping")
-        lang_widget = Widget.objects.get(name="language-widget")
-        WidgetMapping.objects.filter(widget=lang_widget).delete()
-
     operations = [
-        migrations.RunPython(forward, reverse),
+        migrations.RunPython(migrations.RunPython.noop, migrations.RunPython.noop),
     ]

--- a/arches_lingo/migrations/0018_add_related_image_gin_indexes.py
+++ b/arches_lingo/migrations/0018_add_related_image_gin_indexes.py
@@ -1,0 +1,47 @@
+from django.db import migrations
+
+from arches_lingo.const import (
+    DIGITAL_OBJECT_NAME_CONTENT_NODE,
+    DIGITAL_OBJECT_NAME_NODEGROUP,
+    DIGITAL_OBJECT_STATEMENT_CONTENT_NODE,
+    DIGITAL_OBJECT_STATEMENT_NODEGROUP,
+)
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("arches_lingo", "0017_add_scheme_lock"),
+    ]
+
+    operations = [
+        # digital object name (title)
+        migrations.RunSQL(
+            sql=f"""
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS
+                    tiles_digital_object_name_trgm
+                ON tiles
+                USING GIN (
+                    (tiledata ->> '{DIGITAL_OBJECT_NAME_CONTENT_NODE}')
+                    gin_trgm_ops
+                )
+                WHERE nodegroupid = '{DIGITAL_OBJECT_NAME_NODEGROUP}'::uuid;
+            """,
+            reverse_sql="DROP INDEX IF EXISTS tiles_digital_object_name_trgm;",
+        ),
+        # digital object statement (description)
+        migrations.RunSQL(
+            sql=f"""
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS
+                    tiles_digital_object_statement_trgm
+                ON tiles
+                USING GIN (
+                    (tiledata ->> '{DIGITAL_OBJECT_STATEMENT_CONTENT_NODE}')
+                    gin_trgm_ops
+                )
+                WHERE nodegroupid = '{DIGITAL_OBJECT_STATEMENT_NODEGROUP}'::uuid;
+            """,
+            reverse_sql="DROP INDEX IF EXISTS tiles_digital_object_statement_trgm;",
+        ),
+    ]

--- a/arches_lingo/settings.py
+++ b/arches_lingo/settings.py
@@ -261,7 +261,7 @@ INSTALLED_APPS = (
     "django.contrib.staticfiles",
     "django.contrib.gis",
     "django_hosts",
-    "arches_component_lab",
+    "arches_vue_components",
     "arches_controlled_lists",
     "arches",
     "arches.app.models",

--- a/arches_lingo/src/arches_lingo/api.ts
+++ b/arches_lingo/src/arches_lingo/api.ts
@@ -2,7 +2,7 @@ import arches from "arches";
 import Cookies from "js-cookie";
 import { generateArchesURL } from "@/arches/utils/generate-arches-url.ts";
 
-import type { Language } from "@/arches_component_lab/types";
+import type { Language } from "@/arches_vue_components/types";
 import type {
     AdvancedSearchQuery,
     AdvancedSearchResponse,

--- a/arches_lingo/src/arches_lingo/api.ts
+++ b/arches_lingo/src/arches_lingo/api.ts
@@ -724,7 +724,9 @@ export const importThesaurus = async (file: File, overwriteOption: string) => {
             }
             throw new Error(parsed.message);
         } catch (error) {
-            throw new Error((error as Error).message || response.statusText);
+            throw new Error((error as Error).message || response.statusText, {
+                cause: error,
+            });
         }
     }
 };
@@ -756,7 +758,9 @@ export const exportThesaurus = async (
         }
         throw new Error(parsed.message || parsed.data?.message);
     } catch (error) {
-        throw new Error((error as Error).message || response.statusText);
+        throw new Error((error as Error).message || response.statusText, {
+            cause: error,
+        });
     }
 };
 

--- a/arches_lingo/src/arches_lingo/components/advanced-search/FacetRow.vue
+++ b/arches_lingo/src/arches_lingo/components/advanced-search/FacetRow.vue
@@ -24,6 +24,7 @@ import type {
     AdvancedSearchOptions,
     ConceptSetItem,
     FacetType,
+    ImageAttribute,
     MatchMode,
     SchemeOption,
     SearchCondition,
@@ -67,7 +68,17 @@ const facetTypes = computed<{ label: string; value: FacetType }[]>(() => [
     { label: $gettext("Concept Set"), value: "concept_set" },
     { label: $gettext("Source"), value: "attribution_source" },
     { label: $gettext("Contributor"), value: "attribution_contributor" },
+    { label: $gettext("Related Image"), value: "related_image" },
 ]);
+
+const imageAttributes = computed<{ label: string; value: ImageAttribute }[]>(
+    () => [
+        { label: $gettext("Has an image"), value: "has_image" },
+        { label: $gettext("Image file name"), value: "file_name" },
+        { label: $gettext("Image title"), value: "title" },
+        { label: $gettext("Image description"), value: "description" },
+    ],
+);
 
 const matchModes = computed<{ label: string; value: MatchMode }[]>(() => [
     { label: $gettext("Contains"), value: "contains" },
@@ -360,9 +371,26 @@ const currentMatchMode = computed(
 
 const isExistsMode = computed(() => currentMatchMode.value === "exists");
 
+const currentImageAttribute = computed<ImageAttribute>(
+    () => props.condition.image_attribute || "has_image",
+);
+
+// Image title/file name/description are text-searchable; "has_image" is a
+// boolean existence check and takes no value or match mode.
+const isImageTextAttribute = computed(
+    () =>
+        props.condition.facet === "related_image" &&
+        currentImageAttribute.value !== "has_image",
+);
+
+const showImageAttributeDropdown = computed(
+    () => props.condition.facet === "related_image",
+);
+
 const showValueInput = computed(() => {
     if (isExistsMode.value) return false;
     const facet = props.condition.facet;
+    if (isImageTextAttribute.value) return true;
     return ["label", "note", "match_uri", "uri", "identifier"].includes(facet);
 });
 
@@ -445,6 +473,7 @@ const searchContributorsFilterPlaceholder = $gettext("Search contributors...");
 const selectContributorPlaceholder = $gettext("Select contributor...");
 
 const showMatchMode = computed(() => {
+    if (isImageTextAttribute.value) return true;
     return ["label", "note", "match_uri", "uri", "identifier"].includes(
         props.condition.facet,
     );
@@ -472,6 +501,20 @@ function updateMatchMode(mode: MatchMode) {
     const updated = { ...props.condition, match_mode: mode };
     if (mode === "exists") {
         updated.value = "";
+    }
+    emit("update:condition", updated);
+}
+
+function updateImageAttribute(attribute: ImageAttribute) {
+    const updated: SearchCondition = {
+        ...props.condition,
+        image_attribute: attribute,
+        value: "",
+    };
+    if (attribute === "has_image") {
+        delete updated.match_mode;
+    } else {
+        updated.match_mode = "contains";
     }
     emit("update:condition", updated);
 }
@@ -526,6 +569,17 @@ function toggleCascade() {
             :placeholder="$gettext('Select facet')"
             class="facet-type-dropdown"
             @update:model-value="updateFacet"
+        />
+
+        <!-- Image attribute sub-selector (for the related image facet) -->
+        <Select
+            v-if="showImageAttributeDropdown"
+            :model-value="currentImageAttribute"
+            :options="imageAttributes"
+            option-label="label"
+            option-value="value"
+            class="facet-sub-dropdown"
+            @update:model-value="updateImageAttribute"
         />
 
         <!-- Match mode (for text-based facets) -->

--- a/arches_lingo/src/arches_lingo/components/basic-search/BasicSearch.vue
+++ b/arches_lingo/src/arches_lingo/components/basic-search/BasicSearch.vue
@@ -7,7 +7,6 @@ import {
     ref,
     useTemplateRef,
     watch,
-    withDefaults,
 } from "vue";
 import { useGettext } from "vue3-gettext";
 import { useRouter } from "vue-router";

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
@@ -172,7 +172,7 @@ function extractLabelsFromResource(resource: ResourceInstanceResult): Label[] {
         if (!contentNodeValue) continue;
         const typeNode =
             aliasedData.appellative_status_ascribed_relation?.node_value[0];
-        const typeUri = typeNode?.data.uri;
+        const typeUri = typeNode?.data?.uri;
         for (const [languageId, { value }] of Object.entries(
             contentNodeValue,
         )) {

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
@@ -249,7 +249,9 @@ function extractConceptHeaderData(resource: ResourceInstanceResult) {
     const descriptor = extractDescriptors(resource, selectedLanguage.value);
     const principalUser = resource?.principal_user_display_name ?? undefined;
 
-    const uri = aliased_data?.uri?.aliased_data?.uri_content?.node_value?.url;
+    const uri =
+        aliased_data?.uri?.aliased_data?.uri_content?.display_value ||
+        undefined;
     const partOfScheme =
         aliased_data?.part_of_scheme?.aliased_data?.part_of_scheme;
     const schemeId = partOfScheme?.node_value?.[0]?.resourceId;

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
@@ -232,8 +232,7 @@ const label = computed<Label | undefined>(function () {
 const parentConceptLabelMap = computed<Map<string, Label[]>>(function () {
     const map = new Map<string, Label[]>();
     for (const parent of data.value?.parentConcepts ?? []) {
-        const id = (parent as unknown as { resourceinstanceid?: string })
-            ?.resourceinstanceid;
+        const id = parentConceptId(parent);
 
         if (id) {
             const storeLabels = conceptStore.findConcept(id)?.labels;
@@ -249,16 +248,12 @@ const lifecycleStateLabel = computed(function () {
 });
 
 const partOfSchemeId = computed(function () {
-    return (
-        data.value?.partOfScheme as
-            | { resourceinstanceid?: string }
-            | null
-            | undefined
-    )?.resourceinstanceid;
+    return data.value?.partOfScheme?.node_value?.[0]?.resourceId;
 });
 
 function parentConceptId(parent: unknown): string | undefined {
-    return (parent as { resourceinstanceid?: string })?.resourceinstanceid;
+    return (parent as { details?: { resource_id?: string }[] })?.details?.[0]
+        ?.resource_id;
 }
 
 function extractConceptHeaderData(resource: ResourceInstanceResult) {
@@ -268,19 +263,10 @@ function extractConceptHeaderData(resource: ResourceInstanceResult) {
     const descriptor = extractDescriptors(resource, selectedLanguage.value);
     const principalUser = resource?.principal_user_display_name ?? undefined;
 
-    const uri =
-        (aliased_data?.uri?.aliased_data?.uri_content as unknown as
-            | string
-            | null
-            | undefined) ?? undefined;
+    const uri = aliased_data?.uri?.aliased_data?.uri_content?.node_value;
     const partOfScheme =
         aliased_data?.part_of_scheme?.aliased_data?.part_of_scheme;
-    const schemeId = (
-        partOfScheme as unknown as
-            | { resourceinstanceid?: string }
-            | null
-            | undefined
-    )?.resourceinstanceid;
+    const schemeId = partOfScheme?.node_value?.[0]?.resourceId;
     const matchingScheme = conceptStore.schemes.find(
         (candidateScheme) => candidateScheme.id === schemeId,
     );
@@ -301,10 +287,7 @@ function extractConceptHeaderData(resource: ResourceInstanceResult) {
     const identifier = (aliased_data?.identifier || [])
         .map(
             (tile: Identifier) =>
-                tile?.aliased_data?.identifier_content as unknown as
-                    | string
-                    | null
-                    | undefined,
+                tile?.aliased_data?.identifier_content?.node_value,
         )
         .filter(Boolean)
         .join(", ");

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
@@ -32,6 +32,7 @@ import { useConceptStore } from "@/arches_lingo/stores/useConceptStore.ts";
 import { useLanguageStore } from "@/arches_lingo/stores/useLanguageStore.ts";
 
 import type { Ref } from "vue";
+import type { ResourceInstanceReference } from "@/arches_component_lab/datatypes/resource-instance-list/types.ts";
 import type {
     AppellativeStatus,
     ConceptClassificationStatusAliases,
@@ -40,6 +41,7 @@ import type {
     Identifier,
     ResourceInstanceLifecycleState,
     ResourceInstanceResult,
+    TileData,
 } from "@/arches_lingo/types.ts";
 import type { Label } from "@/arches_controlled_lists/types.ts";
 
@@ -165,27 +167,18 @@ function extractLabelsFromResource(resource: ResourceInstanceResult): Label[] {
     const labels: Label[] = [];
     for (const tile of tiles) {
         const aliasedData = tile.aliased_data;
-        if (!aliasedData) continue;
-        const languageRefs =
-            aliasedData.appellative_status_ascribed_name_language as unknown as
-                | Array<{ uri: string }>
-                | null
-                | undefined;
-        const languageId = languageRefs?.[0]?.uri?.split("/").pop();
-        const contentMap =
-            aliasedData.appellative_status_ascribed_name_content as unknown as
-                | Record<string, { value: string }>
-                | null
-                | undefined;
+        const languageNode =
+            aliasedData.appellative_status_ascribed_name_language
+                ?.node_value[0];
+        const languageId = languageNode?.data.uri.split("/").pop();
+        const contentNodeValue =
+            aliasedData.appellative_status_ascribed_name_content.node_value;
         const value = languageId
-            ? contentMap?.[languageId]?.value
-            : Object.values(contentMap ?? {})[0]?.value;
-        const typeRefs =
-            aliasedData.appellative_status_ascribed_relation as unknown as
-                | Array<{ uri: string }>
-                | null
-                | undefined;
-        const typeUri = typeRefs?.[0]?.uri;
+            ? contentNodeValue?.[languageId]?.value
+            : Object.values(contentNodeValue ?? {})[0]?.value;
+        const typeNode =
+            aliasedData.appellative_status_ascribed_relation?.node_value[0];
+        const typeUri = typeNode?.data.uri;
         if (value && languageId) {
             labels.push({
                 value,
@@ -233,12 +226,9 @@ const parentConceptLabelMap = computed<Map<string, Label[]>>(function () {
     const map = new Map<string, Label[]>();
     for (const parent of data.value?.parentConcepts ?? []) {
         const id = parentConceptId(parent);
-
-        if (id) {
-            const storeLabels = conceptStore.findConcept(id)?.labels;
-            const ancestorLabels = ancestorLabelsById.value.get(id);
-            map.set(id, storeLabels ?? ancestorLabels ?? []);
-        }
+        const storeLabels = conceptStore.findConcept(id)?.labels;
+        const ancestorLabels = ancestorLabelsById.value.get(id);
+        map.set(id, storeLabels ?? ancestorLabels ?? []);
     }
     return map;
 });
@@ -251,9 +241,8 @@ const partOfSchemeId = computed(function () {
     return data.value?.partOfScheme?.node_value?.[0]?.resourceId;
 });
 
-function parentConceptId(parent: unknown): string | undefined {
-    return (parent as { details?: { resource_id?: string }[] })?.details?.[0]
-        ?.resource_id;
+function parentConceptId(parent: ResourceInstanceReference): string {
+    return parent.resourceId;
 }
 
 function extractConceptHeaderData(resource: ResourceInstanceResult) {
@@ -279,15 +268,15 @@ function extractConceptHeaderData(resource: ResourceInstanceResult) {
         ).value;
     }
 
-    const parentConcepts = (aliased_data?.classification_status || []).flatMap(
-        (tile: ConceptClassificationStatusAliases) =>
-            tile?.aliased_data?.classification_status_ascribed_classification ||
-            [],
+    const parentConcepts = (aliased_data?.classification_status ?? []).flatMap(
+        (tile: TileData<ConceptClassificationStatusAliases>) =>
+            tile.aliased_data.classification_status_ascribed_classification
+                .node_value ?? [],
     );
-    const identifier = (aliased_data?.identifier || [])
+    const identifier = (aliased_data?.identifier ?? [])
         .map(
             (tile: Identifier) =>
-                tile?.aliased_data?.identifier_content?.node_value,
+                tile.aliased_data.identifier_content.node_value,
         )
         .filter(Boolean)
         .join(", ");
@@ -408,7 +397,7 @@ function extractConceptHeaderData(resource: ResourceInstanceResult) {
                     </span>
                     <span
                         v-for="parent in data?.parentConcepts"
-                        :key="parentConceptId(parent) ?? ''"
+                        :key="parentConceptId(parent)"
                         class="header-item-value parent-concept"
                     >
                         <RouterLink :to="`/concept/${parentConceptId(parent)}`">
@@ -417,7 +406,7 @@ function extractConceptHeaderData(resource: ResourceInstanceResult) {
                                     {
                                         labels:
                                             parentConceptLabelMap.get(
-                                                parentConceptId(parent) ?? "",
+                                                parentConceptId(parent),
                                             ) ?? [],
                                     },
                                     selectedLanguage.code,

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
@@ -167,19 +167,16 @@ function extractLabelsFromResource(resource: ResourceInstanceResult): Label[] {
     const labels: Label[] = [];
     for (const tile of tiles) {
         const aliasedData = tile.aliased_data;
-        const languageNode =
-            aliasedData.appellative_status_ascribed_name_language
-                ?.node_value[0];
-        const languageId = languageNode?.data.uri.split("/").pop();
         const contentNodeValue =
             aliasedData.appellative_status_ascribed_name_content.node_value;
-        const value = languageId
-            ? contentNodeValue?.[languageId]?.value
-            : Object.values(contentNodeValue ?? {})[0]?.value;
+        if (!contentNodeValue) continue;
         const typeNode =
             aliasedData.appellative_status_ascribed_relation?.node_value[0];
         const typeUri = typeNode?.data.uri;
-        if (value && languageId) {
+        for (const [languageId, { value }] of Object.entries(
+            contentNodeValue,
+        )) {
+            if (!value) continue;
             labels.push({
                 value,
                 language_id: languageId,

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
@@ -249,7 +249,7 @@ function extractConceptHeaderData(resource: ResourceInstanceResult) {
     const descriptor = extractDescriptors(resource, selectedLanguage.value);
     const principalUser = resource?.principal_user_display_name ?? undefined;
 
-    const uri = aliased_data?.uri?.aliased_data?.uri_content?.node_value;
+    const uri = aliased_data?.uri?.aliased_data?.uri_content?.node_value?.url;
     const partOfScheme =
         aliased_data?.part_of_scheme?.aliased_data?.part_of_scheme;
     const schemeId = partOfScheme?.node_value?.[0]?.resourceId;

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
@@ -166,20 +166,26 @@ function extractLabelsFromResource(resource: ResourceInstanceResult): Label[] {
     for (const tile of tiles) {
         const aliasedData = tile.aliased_data;
         if (!aliasedData) continue;
-        const value =
-            aliasedData.appellative_status_ascribed_name_content?.display_value;
-        const termLanguageNode =
-            aliasedData.appellative_status_ascribed_name_language;
-        const termLanguageNodeValue = termLanguageNode?.node_value;
-        let languageId: string | undefined;
-        if (typeof termLanguageNodeValue === "string") {
-            languageId = termLanguageNodeValue;
-        } else {
-            languageId = termLanguageNode?.display_value;
-        }
-        const typeUri =
-            aliasedData.appellative_status_ascribed_relation?.node_value?.[0]
-                ?.uri;
+        const languageRefs =
+            aliasedData.appellative_status_ascribed_name_language as unknown as
+                | Array<{ uri: string }>
+                | null
+                | undefined;
+        const languageId = languageRefs?.[0]?.uri?.split("/").pop();
+        const contentMap =
+            aliasedData.appellative_status_ascribed_name_content as unknown as
+                | Record<string, { value: string }>
+                | null
+                | undefined;
+        const value = languageId
+            ? contentMap?.[languageId]?.value
+            : Object.values(contentMap ?? {})[0]?.value;
+        const typeRefs =
+            aliasedData.appellative_status_ascribed_relation as unknown as
+                | Array<{ uri: string }>
+                | null
+                | undefined;
+        const typeUri = typeRefs?.[0]?.uri;
         if (value && languageId) {
             labels.push({
                 value,
@@ -226,7 +232,8 @@ const label = computed<Label | undefined>(function () {
 const parentConceptLabelMap = computed<Map<string, Label[]>>(function () {
     const map = new Map<string, Label[]>();
     for (const parent of data.value?.parentConcepts ?? []) {
-        const id = parent.details[0]?.resource_id;
+        const id = (parent as unknown as { resourceinstanceid?: string })
+            ?.resourceinstanceid;
 
         if (id) {
             const storeLabels = conceptStore.findConcept(id)?.labels;
@@ -241,6 +248,19 @@ const lifecycleStateLabel = computed(function () {
     return resourceInstanceLifecycleState?.value?.name ?? "--";
 });
 
+const partOfSchemeId = computed(function () {
+    return (
+        data.value?.partOfScheme as
+            | { resourceinstanceid?: string }
+            | null
+            | undefined
+    )?.resourceinstanceid;
+});
+
+function parentConceptId(parent: unknown): string | undefined {
+    return (parent as { resourceinstanceid?: string })?.resourceinstanceid;
+}
+
 function extractConceptHeaderData(resource: ResourceInstanceResult) {
     const aliased_data = resource?.aliased_data;
 
@@ -248,10 +268,19 @@ function extractConceptHeaderData(resource: ResourceInstanceResult) {
     const descriptor = extractDescriptors(resource, selectedLanguage.value);
     const principalUser = resource?.principal_user_display_name ?? undefined;
 
-    const uri = aliased_data?.uri?.aliased_data?.uri_content?.node_value;
+    const uri =
+        (aliased_data?.uri?.aliased_data?.uri_content as unknown as
+            | string
+            | null
+            | undefined) ?? undefined;
     const partOfScheme =
         aliased_data?.part_of_scheme?.aliased_data?.part_of_scheme;
-    const schemeId = partOfScheme?.node_value?.[0]?.resourceId;
+    const schemeId = (
+        partOfScheme as unknown as
+            | { resourceinstanceid?: string }
+            | null
+            | undefined
+    )?.resourceinstanceid;
     const matchingScheme = conceptStore.schemes.find(
         (candidateScheme) => candidateScheme.id === schemeId,
     );
@@ -272,8 +301,12 @@ function extractConceptHeaderData(resource: ResourceInstanceResult) {
     const identifier = (aliased_data?.identifier || [])
         .map(
             (tile: Identifier) =>
-                tile?.aliased_data?.identifier_content?.node_value,
+                tile?.aliased_data?.identifier_content as unknown as
+                    | string
+                    | null
+                    | undefined,
         )
+        .filter(Boolean)
         .join(", ");
 
     data.value = {
@@ -350,13 +383,10 @@ function extractConceptHeaderData(resource: ResourceInstanceResult) {
                         </span>
                         <span class="header-item-value">
                             <RouterLink
-                                v-if="data?.partOfScheme?.node_value"
-                                :to="`/scheme/${data?.partOfScheme?.node_value?.[0]?.resourceId}`"
+                                v-if="data?.partOfScheme"
+                                :to="`/scheme/${partOfSchemeId}`"
                             >
-                                {{
-                                    data?.schemeLabel ||
-                                    data?.partOfScheme?.display_value
-                                }}
+                                {{ data?.schemeLabel }}
                             </RouterLink>
                             <span v-else>--</span>
                         </span>
@@ -395,23 +425,21 @@ function extractConceptHeaderData(resource: ResourceInstanceResult) {
                     </span>
                     <span
                         v-for="parent in data?.parentConcepts"
-                        :key="parent.details[0].resource_id"
+                        :key="parentConceptId(parent) ?? ''"
                         class="header-item-value parent-concept"
                     >
-                        <RouterLink
-                            :to="`/concept/${parent.details[0].resource_id}`"
-                        >
+                        <RouterLink :to="`/concept/${parentConceptId(parent)}`">
                             {{
                                 getItemLabel(
                                     {
                                         labels:
                                             parentConceptLabelMap.get(
-                                                parent.details[0].resource_id,
+                                                parentConceptId(parent) ?? "",
                                             ) ?? [],
                                     },
                                     selectedLanguage.code,
                                     systemLanguage.code,
-                                ).value || parent.details[0].display_value
+                                ).value
                             }}
                         </RouterLink>
                     </span>

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
@@ -178,12 +178,19 @@ function extractLabelsFromResource(resource: ResourceInstanceResult): Label[] {
     const labels: Label[] = [];
     for (const tile of tiles) {
         const aliasedData = tile.aliased_data;
+
+        if (!aliasedData) continue;
+
         const contentNodeValue =
-            aliasedData.appellative_status_ascribed_name_content.node_value;
+            aliasedData.appellative_status_ascribed_name_content?.node_value;
+
         if (!contentNodeValue) continue;
+
         const typeNode =
             aliasedData.appellative_status_ascribed_relation?.node_value?.[0];
+
         const typeUri = typeNode?.data?.uri;
+
         for (const [languageId, { value }] of Object.entries(
             contentNodeValue,
         )) {

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
@@ -182,7 +182,7 @@ function extractLabelsFromResource(resource: ResourceInstanceResult): Label[] {
             aliasedData.appellative_status_ascribed_name_content.node_value;
         if (!contentNodeValue) continue;
         const typeNode =
-            aliasedData.appellative_status_ascribed_relation?.node_value[0];
+            aliasedData.appellative_status_ascribed_relation?.node_value?.[0];
         const typeUri = typeNode?.data?.uri;
         for (const [languageId, { value }] of Object.entries(
             contentNodeValue,

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/ConceptHeader.vue
@@ -34,7 +34,7 @@ import { useConceptStore } from "@/arches_lingo/stores/useConceptStore.ts";
 import { useLanguageStore } from "@/arches_lingo/stores/useLanguageStore.ts";
 
 import type { Ref } from "vue";
-import type { ResourceInstanceReference } from "@/arches_component_lab/datatypes/resource-instance-list/types.ts";
+import type { ResourceInstanceReference } from "@/arches_vue_components/datatypes/resource-instance-list/types.ts";
 import type {
     AppellativeStatus,
     ConceptClassificationStatusAliases,

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/components/ConceptHeaderToolbar.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/components/ConceptHeaderToolbar.vue
@@ -389,8 +389,9 @@ function onReinstateRequested() {
                     :node-alias="CONCEPT_TYPE_NODE_ALIAS"
                     :graph-slug="graphSlug"
                     :mode="EDIT"
-                    :aliased-node-data="
+                    :node-value="
                         conceptTypeTile?.aliased_data?.[CONCEPT_TYPE_NODE_ALIAS]
+                            ?.node_value
                     "
                     :should-show-label="false"
                     class="concept-type-widget"

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/components/ConceptHeaderToolbar.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/components/ConceptHeaderToolbar.vue
@@ -52,6 +52,7 @@ import { useConceptStore } from "@/arches_lingo/stores/useConceptStore.ts";
 import { useUserStore } from "@/arches_lingo/stores/useUserStore.ts";
 
 import type { Ref } from "vue";
+import type { AliasedNodeData } from "@/arches_component_lab/types.ts";
 import type {
     DeleteConceptStrategy,
     ResourceInstanceLifecycleState,
@@ -72,7 +73,7 @@ const props = defineProps<{
     conceptTypeTile:
         | {
               tileid?: string;
-              aliased_data?: Record<string, { node_value?: unknown }>;
+              aliased_data?: Record<string, AliasedNodeData>;
           }
         | undefined;
     isTopConcept: boolean;
@@ -117,15 +118,16 @@ const lifecycleState = computed(function () {
 });
 
 const conceptTypeLabel = computed(function () {
-    const refs = props.conceptTypeTile?.aliased_data?.[
-        CONCEPT_TYPE_NODE_ALIAS
-    ] as Array<{ labels: Array<{ value: string }> }> | null | undefined;
-    return refs?.[0]?.labels?.[0]?.value;
+    const aliasedData =
+        props.conceptTypeTile?.aliased_data?.[CONCEPT_TYPE_NODE_ALIAS];
+    return (aliasedData as { display_value?: string } | undefined)
+        ?.display_value;
 });
 
 const conceptIcon = computed(function () {
     const typeNodeValue =
-        props.conceptTypeTile?.aliased_data?.[CONCEPT_TYPE_NODE_ALIAS];
+        props.conceptTypeTile?.aliased_data?.[CONCEPT_TYPE_NODE_ALIAS]
+            ?.node_value;
     if (isGuideTermType(typeNodeValue)) return GUIDE_TERM_ICON;
     if (isHierarchyNameType(typeNodeValue)) return HIERARCHY_NAME_ICON;
     if (props.isTopConcept) return TOP_CONCEPT_ICON;
@@ -146,11 +148,8 @@ const canDelete = computed(function () {
 });
 
 const schemeId = computed(function () {
-    const partOfScheme =
-        props.concept?.aliased_data?.part_of_scheme?.aliased_data
-            ?.part_of_scheme;
-    return (partOfScheme as { resourceinstanceid?: string } | null | undefined)
-        ?.resourceinstanceid;
+    return props.concept?.aliased_data?.part_of_scheme?.aliased_data
+        ?.part_of_scheme?.node_value?.[0]?.resourceId;
 });
 
 const isSchemeRetired = computed(function () {
@@ -239,15 +238,9 @@ async function onConfirmed(strategy: DeleteConceptStrategy | null) {
     isLoading.value = true;
     try {
         if (dialogMode.value === DELETE) {
-            const partOfScheme =
+            const schemeIdentifier =
                 props.concept.aliased_data?.part_of_scheme?.aliased_data
-                    ?.part_of_scheme;
-            const schemeIdentifier = (
-                partOfScheme as
-                    | { resourceinstanceid?: string }
-                    | null
-                    | undefined
-            )?.resourceinstanceid;
+                    ?.part_of_scheme?.node_value?.[0]?.resourceId;
 
             await deleteConcept(
                 props.concept.resourceinstanceid,
@@ -320,12 +313,9 @@ function openExportDialog() {
 }
 
 function addChild() {
-    const partOfSchemeRef =
+    const schemeId =
         props.concept?.aliased_data?.part_of_scheme?.aliased_data
-            ?.part_of_scheme;
-    const schemeId = (
-        partOfSchemeRef as { resourceinstanceid?: string } | null | undefined
-    )?.resourceinstanceid;
+            ?.part_of_scheme?.node_value?.[0]?.resourceId;
     const parentId = props.resourceInstanceId;
 
     if (!schemeId || !parentId) return;
@@ -395,21 +385,24 @@ function onReinstateRequested() {
                     severity="secondary"
                     class="concept-type-badge"
                 />
-                <GenericWidget
+                <div
                     v-else-if="concept && concept.resourceinstanceid"
-                    :node-alias="CONCEPT_TYPE_NODE_ALIAS"
-                    :graph-slug="graphSlug"
-                    :mode="EDIT"
-                    :value="
-                        conceptTypeTile?.aliased_data?.[
-                            CONCEPT_TYPE_NODE_ALIAS
-                        ] ?? null
-                    "
-                    :should-show-label="false"
                     class="concept-type-widget"
-                    @update:is-loading="isWidgetLoading = $event"
-                    @update:value="onConceptTypeChange"
-                />
+                >
+                    <GenericWidget
+                        :node-alias="CONCEPT_TYPE_NODE_ALIAS"
+                        :graph-slug="graphSlug"
+                        :mode="EDIT"
+                        :aliased-node-data="
+                            conceptTypeTile?.aliased_data?.[
+                                CONCEPT_TYPE_NODE_ALIAS
+                            ] ?? null
+                        "
+                        :should-show-label="false"
+                        @update:is-loading="isWidgetLoading = $event"
+                        @update:value="onConceptTypeChange"
+                    />
+                </div>
             </div>
         </div>
         <div

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/components/ConceptHeaderToolbar.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/components/ConceptHeaderToolbar.vue
@@ -117,16 +117,15 @@ const lifecycleState = computed(function () {
 });
 
 const conceptTypeLabel = computed(function () {
-    const aliasedData =
-        props.conceptTypeTile?.aliased_data?.[CONCEPT_TYPE_NODE_ALIAS];
-    return (aliasedData as { display_value?: string } | undefined)
-        ?.display_value;
+    const refs = props.conceptTypeTile?.aliased_data?.[
+        CONCEPT_TYPE_NODE_ALIAS
+    ] as Array<{ labels: Array<{ value: string }> }> | null | undefined;
+    return refs?.[0]?.labels?.[0]?.value;
 });
 
 const conceptIcon = computed(function () {
     const typeNodeValue =
-        props.conceptTypeTile?.aliased_data?.[CONCEPT_TYPE_NODE_ALIAS]
-            ?.node_value;
+        props.conceptTypeTile?.aliased_data?.[CONCEPT_TYPE_NODE_ALIAS];
     if (isGuideTermType(typeNodeValue)) return GUIDE_TERM_ICON;
     if (isHierarchyNameType(typeNodeValue)) return HIERARCHY_NAME_ICON;
     if (props.isTopConcept) return TOP_CONCEPT_ICON;
@@ -147,8 +146,11 @@ const canDelete = computed(function () {
 });
 
 const schemeId = computed(function () {
-    return props.concept?.aliased_data?.part_of_scheme?.aliased_data
-        ?.part_of_scheme?.node_value?.[0]?.resourceId;
+    const partOfScheme =
+        props.concept?.aliased_data?.part_of_scheme?.aliased_data
+            ?.part_of_scheme;
+    return (partOfScheme as { resourceinstanceid?: string } | null | undefined)
+        ?.resourceinstanceid;
 });
 
 const isSchemeRetired = computed(function () {
@@ -237,9 +239,15 @@ async function onConfirmed(strategy: DeleteConceptStrategy | null) {
     isLoading.value = true;
     try {
         if (dialogMode.value === DELETE) {
-            const schemeIdentifier =
+            const partOfScheme =
                 props.concept.aliased_data?.part_of_scheme?.aliased_data
-                    .part_of_scheme?.node_value?.[0]?.resourceId;
+                    ?.part_of_scheme;
+            const schemeIdentifier = (
+                partOfScheme as
+                    | { resourceinstanceid?: string }
+                    | null
+                    | undefined
+            )?.resourceinstanceid;
 
             await deleteConcept(
                 props.concept.resourceinstanceid,
@@ -312,9 +320,12 @@ function openExportDialog() {
 }
 
 function addChild() {
-    const schemeId =
+    const partOfSchemeRef =
         props.concept?.aliased_data?.part_of_scheme?.aliased_data
-            ?.part_of_scheme?.node_value?.[0]?.resourceId;
+            ?.part_of_scheme;
+    const schemeId = (
+        partOfSchemeRef as { resourceinstanceid?: string } | null | undefined
+    )?.resourceinstanceid;
     const parentId = props.resourceInstanceId;
 
     if (!schemeId || !parentId) return;
@@ -389,9 +400,10 @@ function onReinstateRequested() {
                     :node-alias="CONCEPT_TYPE_NODE_ALIAS"
                     :graph-slug="graphSlug"
                     :mode="EDIT"
-                    :node-value="
-                        conceptTypeTile?.aliased_data?.[CONCEPT_TYPE_NODE_ALIAS]
-                            ?.node_value
+                    :value="
+                        conceptTypeTile?.aliased_data?.[
+                            CONCEPT_TYPE_NODE_ALIAS
+                        ] ?? null
                     "
                     :should-show-label="false"
                     class="concept-type-widget"

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/components/ConceptHeaderToolbar.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptHeader/components/ConceptHeaderToolbar.vue
@@ -9,7 +9,7 @@ import { storeToRefs } from "pinia";
 import Button from "primevue/button";
 import Tag from "primevue/tag";
 
-import GenericWidget from "@/arches_component_lab/generics/GenericWidget/GenericWidget.vue";
+import GenericWidget from "@/arches_vue_components/generics/GenericWidget/GenericWidget.vue";
 
 import DeleteConceptDialog from "@/arches_lingo/components/concept/ConceptHeader/components/DeleteConceptDialog.vue";
 import ExportThesauri from "@/arches_lingo/components/scheme/SchemeHeader/components/ExportThesauri.vue";
@@ -53,7 +53,7 @@ import { useConceptStore } from "@/arches_lingo/stores/useConceptStore.ts";
 import { useUserStore } from "@/arches_lingo/stores/useUserStore.ts";
 
 import type { Ref } from "vue";
-import type { AliasedNodeData } from "@/arches_component_lab/types.ts";
+import type { AliasedNodeData } from "@/arches_vue_components/types.ts";
 import type {
     DeleteConceptStrategy,
     ResourceInstanceLifecycleState,
@@ -215,12 +215,14 @@ function isHierarchyNameType(typeNodeValue: unknown): boolean {
     );
 }
 
-async function onConceptTypeChange(newValue: ReferenceSelectValue) {
+async function onConceptTypeChange(newValue: unknown) {
+    const conceptTypeValue = newValue as ReferenceSelectValue;
+
     try {
         await upsertLingoTile(props.graphSlug, CONCEPT_TYPE_NODE_ALIAS, {
             resourceinstance: props.resourceInstanceId,
             aliased_data: {
-                [CONCEPT_TYPE_NODE_ALIAS]: newValue,
+                [CONCEPT_TYPE_NODE_ALIAS]: conceptTypeValue,
             },
             tileid: props.conceptTypeTile?.tileid,
         });

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptImages/ConceptImages.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptImages/ConceptImages.vue
@@ -9,7 +9,7 @@ import ConceptImagesViewer from "@/arches_lingo/components/concept/ConceptImages
 
 import { EDIT, VIEW } from "@/arches_lingo/constants.ts";
 
-import { fetchTileData } from "@/arches_component_lab/generics/GenericCard/api.ts";
+import { fetchTileData } from "@/arches_vue_components/generics/GenericCard/api.ts";
 import { useResourceStore } from "@/arches_lingo/composables/useResourceStore.ts";
 
 import type { ConceptImages, DataComponentMode } from "@/arches_lingo/types.ts";

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesEditor.vue
@@ -39,7 +39,8 @@ import {
 
 import type { Component, Ref } from "vue";
 import type { FormSubmitEvent } from "@primevue/forms";
-import type { FileListValue } from "@/arches_component_lab/datatypes/file-list/types.ts";
+import type { FileReference } from "@/arches_component_lab/datatypes/file-list/types.ts";
+import type { AliasedNodeData } from "@/arches_component_lab/types.ts";
 
 import type {
     ConceptImages,
@@ -47,7 +48,7 @@ import type {
     DigitalObjectInstanceAliases,
 } from "@/arches_lingo/types.ts";
 
-type PossiblyNewFile = FileListValue & {
+type PossiblyNewFile = FileReference & {
     file?: File;
     name?: string;
     lastModified?: number;
@@ -192,13 +193,13 @@ async function save(e: FormSubmitEvent) {
                 aliased_data: {
                     content: {
                         node_value: [...fileJsonObjects],
-                    } as unknown as FileListValue[],
+                    } as unknown as AliasedNodeData,
                 },
             };
         } else {
             digitalObjectInstanceAliases.content.aliased_data.content = {
                 node_value: [...fileJsonObjects],
-            } as unknown as FileListValue[];
+            } as unknown as AliasedNodeData;
         }
 
         // this fork was requested because the multipartjson parser is unstable
@@ -262,6 +263,8 @@ async function save(e: FormSubmitEvent) {
             }
         }
 
+        await refreshReportSection!(props.componentName);
+
         nextTick(() => {
             const openConceptImagesEditor = new CustomEvent(
                 "openConceptImagesEditor",
@@ -274,8 +277,6 @@ async function save(e: FormSubmitEvent) {
             );
             document.dispatchEvent(openConceptImagesEditor);
         });
-
-        refreshReportSection!(props.componentName);
     } catch (error) {
         toast.add({
             severity: ERROR,
@@ -335,9 +336,9 @@ function resetForm() {
                     node-alias="name_content"
                     graph-slug="digital_object_system"
                     :mode="EDIT"
-                    :aliased-node-data="
+                    :node-value="
                         digitalObjectResource?.aliased_data.name?.aliased_data
-                            .name_content
+                            .name_content?.node_value
                     "
                     class="widget-container column"
                 />
@@ -345,18 +346,18 @@ function resetForm() {
                     node-alias="statement_content"
                     graph-slug="digital_object_system"
                     :mode="EDIT"
-                    :aliased-node-data="
+                    :node-value="
                         digitalObjectResource?.aliased_data.statement
-                            ?.aliased_data.statement_content
+                            ?.aliased_data.statement_content?.node_value
                     "
                     class="widget-container column"
                 />
                 <GenericWidget
                     node-alias="content"
                     graph-slug="digital_object_system"
-                    :aliased-node-data="
+                    :node-value="
                         digitalObjectResource?.aliased_data?.content
-                            ?.aliased_data.content
+                            ?.aliased_data.content?.node_value
                     "
                     :mode="EDIT"
                     :should-show-label="false"

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesEditor.vue
@@ -169,42 +169,45 @@ async function save(e: FormSubmitEvent) {
 
         // files do not respect json.stringify
         const fileJsonObjects =
-            submittedFormData.content.node_value?.map(
-                (file: PossiblyNewFile) => {
-                    if (!file?.file) {
-                        return file;
-                    } else {
-                        return {
-                            name: file.name?.replace(/ /g, "_"),
-                            lastModified: file.lastModified,
-                            size: file.size,
-                            type: file.type,
-                            url: null,
-                            file_id: null,
-                            content: URL.createObjectURL(file?.file),
-                            altText: "Replaceable alt text",
-                        };
-                    }
-                },
-            ) ?? [];
+            (
+                submittedFormData.content as
+                    | PossiblyNewFile[]
+                    | null
+                    | undefined
+            )?.map((file: PossiblyNewFile) => {
+                if (!file?.file) {
+                    return file;
+                } else {
+                    return {
+                        name: file.name?.replace(/ /g, "_"),
+                        lastModified: file.lastModified,
+                        size: file.size,
+                        type: file.type,
+                        url: null,
+                        file_id: null,
+                        content: URL.createObjectURL(file?.file),
+                        altText: "Replaceable alt text",
+                    };
+                }
+            }) ?? [];
 
         if (!digitalObjectInstanceAliases.content) {
             digitalObjectInstanceAliases.content = {
                 aliased_data: {
-                    content: {
-                        node_value: [...fileJsonObjects],
-                    } as unknown as AliasedNodeData,
+                    content: [...fileJsonObjects] as unknown as AliasedNodeData,
                 },
             };
         } else {
-            digitalObjectInstanceAliases.content.aliased_data.content = {
-                node_value: [...fileJsonObjects],
-            } as unknown as AliasedNodeData;
+            digitalObjectInstanceAliases.content.aliased_data.content = [
+                ...fileJsonObjects,
+            ] as unknown as AliasedNodeData;
         }
 
         // this fork was requested because the multipartjson parser is unstable
         // if files go one way, if no files go the traditional way
-        if (submittedFormData.content.node_value?.length) {
+        if (
+            (submittedFormData.content as unknown[] | null | undefined)?.length
+        ) {
             if (digitalObjectResource.value) {
                 digitalObjectResource.value.aliased_data = {
                     ...digitalObjectInstanceAliases,
@@ -336,9 +339,9 @@ function resetForm() {
                     node-alias="name_content"
                     graph-slug="digital_object_system"
                     :mode="EDIT"
-                    :node-value="
+                    :value="
                         digitalObjectResource?.aliased_data.name?.aliased_data
-                            .name_content?.node_value
+                            .name_content ?? null
                     "
                     class="widget-container column"
                 />
@@ -346,18 +349,18 @@ function resetForm() {
                     node-alias="statement_content"
                     graph-slug="digital_object_system"
                     :mode="EDIT"
-                    :node-value="
+                    :value="
                         digitalObjectResource?.aliased_data.statement
-                            ?.aliased_data.statement_content?.node_value
+                            ?.aliased_data.statement_content ?? null
                     "
                     class="widget-container column"
                 />
                 <GenericWidget
                     node-alias="content"
                     graph-slug="digital_object_system"
-                    :node-value="
+                    :value="
                         digitalObjectResource?.aliased_data?.content
-                            ?.aliased_data.content?.node_value
+                            ?.aliased_data.content ?? null
                     "
                     :mode="EDIT"
                     :should-show-label="false"

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesEditor.vue
@@ -39,7 +39,10 @@ import {
 
 import type { Component, Ref } from "vue";
 import type { FormSubmitEvent } from "@primevue/forms";
-import type { FileReference } from "@/arches_component_lab/datatypes/file-list/types.ts";
+import type {
+    FileListAliasedNodeData,
+    FileReference,
+} from "@/arches_component_lab/datatypes/file-list/types.ts";
 
 import type {
     ConceptImages,
@@ -193,13 +196,15 @@ async function save(e: FormSubmitEvent) {
         if (!digitalObjectInstanceAliases.content) {
             digitalObjectInstanceAliases.content = {
                 aliased_data: {
-                    content: [...fileJsonObjects] as unknown as unknown,
+                    content: [
+                        ...fileJsonObjects,
+                    ] as unknown as FileListAliasedNodeData,
                 },
             };
         } else {
             digitalObjectInstanceAliases.content.aliased_data.content = [
                 ...fileJsonObjects,
-            ] as unknown as unknown;
+            ] as unknown as FileListAliasedNodeData;
         }
 
         // this fork was requested because the multipartjson parser is unstable
@@ -334,37 +339,40 @@ function resetForm() {
                 @submit="save"
                 @reset="resetForm"
             >
-                <GenericWidget
-                    node-alias="name_content"
-                    graph-slug="digital_object_system"
-                    :mode="EDIT"
-                    :value="
-                        digitalObjectResource?.aliased_data.name?.aliased_data
-                            .name_content ?? null
-                    "
-                    class="widget-container column"
-                />
-                <GenericWidget
-                    node-alias="statement_content"
-                    graph-slug="digital_object_system"
-                    :mode="EDIT"
-                    :value="
-                        digitalObjectResource?.aliased_data.statement
-                            ?.aliased_data.statement_content ?? null
-                    "
-                    class="widget-container column"
-                />
-                <GenericWidget
-                    node-alias="content"
-                    graph-slug="digital_object_system"
-                    :value="
-                        digitalObjectResource?.aliased_data?.content
-                            ?.aliased_data.content ?? null
-                    "
-                    :mode="EDIT"
-                    :should-show-label="false"
-                    class="widget-container column"
-                />
+                <div class="widget-container column">
+                    <GenericWidget
+                        node-alias="name_content"
+                        graph-slug="digital_object_system"
+                        :mode="EDIT"
+                        :aliased-node-data="
+                            digitalObjectResource?.aliased_data.name
+                                ?.aliased_data.name_content ?? null
+                        "
+                    />
+                </div>
+                <div class="widget-container column">
+                    <GenericWidget
+                        node-alias="statement_content"
+                        graph-slug="digital_object_system"
+                        :mode="EDIT"
+                        :aliased-node-data="
+                            digitalObjectResource?.aliased_data.statement
+                                ?.aliased_data.statement_content ?? null
+                        "
+                    />
+                </div>
+                <div class="widget-container column">
+                    <GenericWidget
+                        node-alias="content"
+                        graph-slug="digital_object_system"
+                        :aliased-node-data="
+                            digitalObjectResource?.aliased_data?.content
+                                ?.aliased_data.content ?? null
+                        "
+                        :mode="EDIT"
+                        :should-show-label="false"
+                    />
+                </div>
             </Form>
         </div>
     </div>

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesEditor.vue
@@ -52,10 +52,6 @@ import type {
 
 type PossiblyNewFile = FileReference & {
     file?: File;
-    name?: string;
-    lastModified?: number;
-    size?: number;
-    type?: string;
 };
 
 const props = defineProps<{
@@ -114,7 +110,7 @@ async function getDigitalObjectInstance(
         resourceInstanceId?: string;
     }>;
     try {
-        if (typedEvent?.detail?.resourceInstanceId === undefined) {
+        if (typedEvent.detail.resourceInstanceId === undefined) {
             digitalObjectResource.value = undefined;
         } else {
             digitalObjectResource.value = await fetchLingoResource(
@@ -177,17 +173,17 @@ async function save(e: FormSubmitEvent) {
                     | null
                     | undefined
             )?.map((file: PossiblyNewFile) => {
-                if (!file?.file) {
+                if (!file.file) {
                     return file;
                 } else {
                     return {
-                        name: file.name?.replace(/ /g, "_"),
+                        name: file.name.replace(/ /g, "_"),
                         lastModified: file.lastModified,
                         size: file.size,
                         type: file.type,
                         url: null,
                         file_id: null,
-                        content: URL.createObjectURL(file?.file),
+                        content: URL.createObjectURL(file.file),
                         altText: "Replaceable alt text",
                     };
                 }
@@ -270,7 +266,7 @@ async function save(e: FormSubmitEvent) {
             }
         }
 
-        await refreshReportSection!(props.componentName);
+        refreshReportSection!(props.componentName);
 
         nextTick(() => {
             const openConceptImagesEditor = new CustomEvent(
@@ -306,7 +302,7 @@ function resetForm() {
             {
                 detail: {
                     resourceInstanceId:
-                        digitalObjectResource?.value?.resourceinstanceid,
+                        digitalObjectResource.value?.resourceinstanceid,
                 },
             },
         );
@@ -366,7 +362,7 @@ function resetForm() {
                         node-alias="content"
                         graph-slug="digital_object_system"
                         :aliased-node-data="
-                            digitalObjectResource?.aliased_data?.content
+                            digitalObjectResource?.aliased_data.content
                                 ?.aliased_data.content ?? null
                         "
                         :mode="EDIT"

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesEditor.vue
@@ -103,12 +103,8 @@ watch(
     (formComponent) => (componentEditorFormRef!.value = formComponent),
 );
 
-async function getDigitalObjectInstance(
-    customEvent: CustomEvent<{ resourceInstanceId?: string }> | Event,
-) {
-    const typedEvent = customEvent as CustomEvent<{
-        resourceInstanceId?: string;
-    }>;
+async function getDigitalObjectInstance(event: Event) {
+    const typedEvent = event as CustomEvent<{ resourceInstanceId?: string }>;
     try {
         if (typedEvent.detail.resourceInstanceId === undefined) {
             digitalObjectResource.value = undefined;
@@ -133,92 +129,61 @@ async function save(e: FormSubmitEvent) {
             Object.entries(e.states).map(([key, state]) => [key, state.value]),
         );
 
-        let digitalObjectInstanceAliases: DigitalObjectInstanceAliases = {};
-
-        if (digitalObjectResource.value) {
-            digitalObjectInstanceAliases =
-                digitalObjectResource.value.aliased_data;
-        }
+        const digitalObjectInstanceAliases: DigitalObjectInstanceAliases =
+            digitalObjectResource.value?.aliased_data ?? {};
 
         if (submittedFormData.name_content) {
-            if (!digitalObjectInstanceAliases.name) {
-                digitalObjectInstanceAliases.name = {
-                    aliased_data: {
-                        name_content: submittedFormData.name_content,
-                    },
-                };
-            } else {
-                digitalObjectInstanceAliases.name.aliased_data.name_content =
-                    submittedFormData.name_content;
-            }
+            digitalObjectInstanceAliases.name = {
+                ...digitalObjectInstanceAliases.name,
+                aliased_data: { name_content: submittedFormData.name_content },
+            };
         }
         if (submittedFormData.statement_content) {
-            if (!digitalObjectInstanceAliases.statement) {
-                digitalObjectInstanceAliases.statement = {
-                    aliased_data: {
-                        statement_content: submittedFormData.statement_content,
-                    },
-                };
-            } else {
-                digitalObjectInstanceAliases.statement.aliased_data.statement_content =
-                    submittedFormData.statement_content;
-            }
+            digitalObjectInstanceAliases.statement = {
+                ...digitalObjectInstanceAliases.statement,
+                aliased_data: {
+                    statement_content: submittedFormData.statement_content,
+                },
+            };
         }
 
         // files do not respect json.stringify
-        const fileJsonObjects =
-            (
-                submittedFormData.content as
-                    | PossiblyNewFile[]
-                    | null
-                    | undefined
-            )?.map((file: PossiblyNewFile) => {
-                if (!file.file) {
-                    return file;
-                } else {
-                    return {
-                        name: file.name.replace(/ /g, "_"),
-                        lastModified: file.lastModified,
-                        size: file.size,
-                        type: file.type,
-                        url: null,
-                        file_id: null,
-                        content: URL.createObjectURL(file.file),
-                        altText: "Replaceable alt text",
-                    };
-                }
-            }) ?? [];
-
-        if (!digitalObjectInstanceAliases.content) {
-            digitalObjectInstanceAliases.content = {
-                aliased_data: {
-                    content: [
-                        ...fileJsonObjects,
-                    ] as unknown as FileListAliasedNodeData,
-                },
+        const files =
+            (submittedFormData.content as
+                | PossiblyNewFile[]
+                | null
+                | undefined) ?? [];
+        const fileJsonObjects = files.map((file) => {
+            if (!file.file) {
+                return file;
+            }
+            return {
+                name: file.name.replace(/ /g, "_"),
+                lastModified: file.lastModified,
+                size: file.size,
+                type: file.type,
+                url: null,
+                file_id: null,
+                content: URL.createObjectURL(file.file),
+                altText: "Replaceable alt text",
             };
-        } else {
-            digitalObjectInstanceAliases.content.aliased_data.content = [
-                ...fileJsonObjects,
-            ] as unknown as FileListAliasedNodeData;
-        }
+        });
+
+        digitalObjectInstanceAliases.content = {
+            ...digitalObjectInstanceAliases.content,
+            aliased_data: {
+                content: fileJsonObjects as unknown as FileListAliasedNodeData,
+            },
+        };
 
         // this fork was requested because the multipartjson parser is unstable
         // if files go one way, if no files go the traditional way
-        if (
-            (submittedFormData.content as unknown[] | null | undefined)?.length
-        ) {
-            if (digitalObjectResource.value) {
-                digitalObjectResource.value.aliased_data = {
-                    ...digitalObjectInstanceAliases,
-                };
-            } else {
-                digitalObjectResource.value = {
-                    aliased_data: {
-                        ...digitalObjectInstanceAliases,
-                    },
-                } as unknown as DigitalObjectInstance;
-            }
+        if (fileJsonObjects.length) {
+            digitalObjectResource.value ??=
+                {} as unknown as DigitalObjectInstance;
+            digitalObjectResource.value.aliased_data = {
+                ...digitalObjectInstanceAliases,
+            };
 
             const formDataForDigitalObject = await createFormDataForFileUpload(
                 digitalObjectResource as Ref<DigitalObjectInstance>,

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesEditor.vue
@@ -40,7 +40,6 @@ import {
 import type { Component, Ref } from "vue";
 import type { FormSubmitEvent } from "@primevue/forms";
 import type { FileReference } from "@/arches_component_lab/datatypes/file-list/types.ts";
-import type { AliasedNodeData } from "@/arches_component_lab/types.ts";
 
 import type {
     ConceptImages,
@@ -194,13 +193,13 @@ async function save(e: FormSubmitEvent) {
         if (!digitalObjectInstanceAliases.content) {
             digitalObjectInstanceAliases.content = {
                 aliased_data: {
-                    content: [...fileJsonObjects] as unknown as AliasedNodeData,
+                    content: [...fileJsonObjects] as unknown as unknown,
                 },
             };
         } else {
             digitalObjectInstanceAliases.content.aliased_data.content = [
                 ...fileJsonObjects,
-            ] as unknown as AliasedNodeData;
+            ] as unknown as unknown;
         }
 
         // this fork was requested because the multipartjson parser is unstable

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesEditor.vue
@@ -148,12 +148,12 @@ async function save(e: FormSubmitEvent) {
         }
 
         // files do not respect json.stringify
-        const files =
+        const fileJsonObjects = (
             (submittedFormData.content as
                 | PossiblyNewFile[]
                 | null
-                | undefined) ?? [];
-        const fileJsonObjects = files.map((file) => {
+                | undefined) ?? []
+        ).map((file) => {
             if (!file.file) {
                 return file;
             }

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesEditor.vue
@@ -158,7 +158,9 @@ async function save(e: FormSubmitEvent) {
         digitalObjectInstanceAliases.content = {
             ...digitalObjectInstanceAliases.content,
             aliased_data: {
-                content: fileJsonObjects as unknown as FileListAliasedNodeData,
+                content: {
+                    node_value: fileJsonObjects,
+                } as unknown as FileListAliasedNodeData,
             },
         };
 

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesEditor.vue
@@ -112,9 +112,13 @@ async function save(e: FormSubmitEvent) {
     isLoading.value = true;
 
     try {
-        const submittedFormData = Object.fromEntries(
-            Object.entries(e.states).map(([key, state]) => [key, state.value]),
-        );
+        const submittedFormData = e.values;
+        const contentFiles =
+            (
+                submittedFormData.content as {
+                    node_value: PossiblyNewFile[] | null;
+                }
+            )?.node_value ?? null;
 
         const digitalObjectInstanceAliases: DigitalObjectInstanceAliases =
             digitalObjectResource.value?.aliased_data ?? {};
@@ -135,12 +139,7 @@ async function save(e: FormSubmitEvent) {
         }
 
         // files do not respect json.stringify
-        const fileJsonObjects = (
-            (submittedFormData.content as
-                | PossiblyNewFile[]
-                | null
-                | undefined) ?? []
-        ).map((file) => {
+        const fileJsonObjects = (contentFiles ?? []).map((file) => {
             if (!file.file) {
                 return file;
             }
@@ -163,10 +162,9 @@ async function save(e: FormSubmitEvent) {
             },
         };
 
-        // if files go one way, if no files go the traditional way
-        const hasNewFiles = (
-            (submittedFormData.content as PossiblyNewFile[]) ?? []
-        ).some((file) => file.file instanceof File);
+        const hasNewFiles = (contentFiles ?? []).some(
+            (file) => file.file instanceof File,
+        );
         if (hasNewFiles) {
             if (digitalObjectResource.value) {
                 digitalObjectResource.value.aliased_data = {
@@ -183,7 +181,7 @@ async function save(e: FormSubmitEvent) {
             const formDataForDigitalObject = await createFormDataForFileUpload(
                 digitalObjectResource as Ref<DigitalObjectInstance>,
                 digitalObjectInstanceAliases,
-                submittedFormData,
+                { ...submittedFormData, content: contentFiles },
             );
             if (digitalObjectResource.value?.resourceinstanceid) {
                 await updateLingoResourceFromForm(

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesEditor.vue
@@ -8,7 +8,7 @@ import { Form } from "@primevue/forms";
 
 import Skeleton from "primevue/skeleton";
 
-import GenericWidget from "@/arches_component_lab/generics/GenericWidget/GenericWidget.vue";
+import GenericWidget from "@/arches_vue_components/generics/GenericWidget/GenericWidget.vue";
 import { DIGITAL_OBJECT_GRAPH_SLUG } from "@/arches_lingo/components/concept/ConceptImages/components/constants.ts";
 import {
     DEFAULT_ERROR_TOAST_LIFE,
@@ -37,7 +37,7 @@ import type { FormSubmitEvent } from "@primevue/forms";
 import type {
     FileListAliasedNodeData,
     FileReference,
-} from "@/arches_component_lab/datatypes/file-list/types.ts";
+} from "@/arches_vue_components/datatypes/file-list/types.ts";
 
 import type {
     ConceptImages,

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesEditor.vue
@@ -303,38 +303,41 @@ function resetForm() {
                 @submit="save"
                 @reset="resetForm"
             >
-                <GenericWidget
-                    node-alias="name_content"
-                    graph-slug="digital_object_system"
-                    :mode="EDIT"
-                    :aliased-node-data="
-                        digitalObjectResource?.aliased_data.name?.aliased_data
-                            .name_content ?? null
-                    "
-                    class="widget-container column"
-                />
-                <GenericWidget
-                    node-alias="statement_content"
-                    graph-slug="digital_object_system"
-                    :mode="EDIT"
-                    :aliased-node-data="
-                        digitalObjectResource?.aliased_data.statement
-                            ?.aliased_data.statement_content ?? null
-                    "
-                    :render-context="MULTILINE_RENDER_CONTEXT"
-                    class="widget-container column"
-                />
-                <GenericWidget
-                    node-alias="content"
-                    graph-slug="digital_object_system"
-                    :aliased-node-data="
-                        digitalObjectResource?.aliased_data?.content
-                            ?.aliased_data.content ?? null
-                    "
-                    :mode="EDIT"
-                    :should-show-label="false"
-                    class="widget-container column"
-                />
+                <div class="widget-container column">
+                    <GenericWidget
+                        node-alias="name_content"
+                        graph-slug="digital_object_system"
+                        :mode="EDIT"
+                        :aliased-node-data="
+                            digitalObjectResource?.aliased_data.name
+                                ?.aliased_data.name_content ?? null
+                        "
+                    />
+                </div>
+                <div class="widget-container column">
+                    <GenericWidget
+                        node-alias="statement_content"
+                        graph-slug="digital_object_system"
+                        :mode="EDIT"
+                        :aliased-node-data="
+                            digitalObjectResource?.aliased_data.statement
+                                ?.aliased_data.statement_content ?? null
+                        "
+                        :render-context="MULTILINE_RENDER_CONTEXT"
+                    />
+                </div>
+                <div class="widget-container column">
+                    <GenericWidget
+                        node-alias="content"
+                        graph-slug="digital_object_system"
+                        :aliased-node-data="
+                            digitalObjectResource?.aliased_data?.content
+                                ?.aliased_data.content ?? null
+                        "
+                        :mode="EDIT"
+                        :should-show-label="false"
+                    />
+                </div>
             </Form>
         </div>
     </div>

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesViewer.vue
@@ -263,9 +263,9 @@ function modifyResource(resourceInstanceId?: string) {
                                 class="image-title"
                                 graph-slug="digital_object_system"
                                 :mode="VIEW"
-                                :aliased-node-data="
+                                :node-value="
                                     resource.aliased_data.name?.aliased_data
-                                        .name_content
+                                        .name_content?.node_value
                                 "
                             />
                         </label>
@@ -298,8 +298,9 @@ function modifyResource(resourceInstanceId?: string) {
                     <GenericWidget
                         node-alias="content"
                         graph-slug="digital_object_system"
-                        :aliased-node-data="
+                        :node-value="
                             resource.aliased_data.content?.aliased_data.content
+                                ?.node_value
                         "
                         :mode="VIEW"
                         :should-show-label="false"
@@ -309,9 +310,9 @@ function modifyResource(resourceInstanceId?: string) {
                             node-alias="statement_content"
                             graph-slug="digital_object_system"
                             :mode="VIEW"
-                            :aliased-node-data="
+                            :node-value="
                                 resource.aliased_data.statement?.aliased_data
-                                    .statement_content
+                                    .statement_content?.node_value
                             "
                         />
                     </div>

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesViewer.vue
@@ -87,12 +87,10 @@ const confirm = useConfirm();
 onMounted(async () => {
     if (props.tileData) {
         try {
-            const digitalObjectInstances = (
-                props.tileData.aliased_data
-                    .depicting_digital_asset_internal as unknown as Array<{
-                    resourceinstanceid: string;
-                }> | null
-            )?.map((resource) => resource.resourceinstanceid);
+            const digitalObjectInstances =
+                props.tileData.aliased_data.depicting_digital_asset_internal.node_value
+                    ?.map((ref) => ref.resourceId)
+                    .filter(Boolean);
             if (digitalObjectInstances) {
                 resources.value = await fetchLingoResourcesBatch(
                     "digital_object_system",
@@ -131,23 +129,14 @@ function confirmDelete(removedResourceInstanceId: string) {
                 if (
                     depictingDigitalAssetInternalData?.depicting_digital_asset_internal
                 ) {
-                    const filtered = (
-                        depictingDigitalAssetInternalData.depicting_digital_asset_internal as unknown as Array<{
-                            resourceinstanceid: string;
-                        }>
-                    )
-                        .filter(
-                            (assetReference) =>
-                                assetReference.resourceinstanceid !==
-                                removedResourceInstanceId,
-                        )
-                        .map((r) => ({
-                            resourceId: r.resourceinstanceid,
-                            ontologyProperty: "",
-                            inverseOntologyProperty: "",
-                        }));
-                    depictingDigitalAssetInternalData.depicting_digital_asset_internal =
-                        filtered as unknown;
+                    const currentNodeValue =
+                        depictingDigitalAssetInternalData
+                            .depicting_digital_asset_internal.node_value ?? [];
+                    depictingDigitalAssetInternalData.depicting_digital_asset_internal.node_value =
+                        currentNodeValue.filter(
+                            (ref) =>
+                                ref.resourceId !== removedResourceInstanceId,
+                        );
                     resources.value = resources.value?.filter(
                         (resource) =>
                             resource.resourceinstanceid !==
@@ -271,16 +260,17 @@ function modifyResource(resourceInstanceId?: string) {
                             for="concept-image"
                             class="image-title-label"
                         >
-                            <GenericWidget
-                                node-alias="name_content"
-                                class="image-title"
-                                graph-slug="digital_object_system"
-                                :mode="VIEW"
-                                :value="
-                                    resource.aliased_data.name?.aliased_data
-                                        .name_content ?? null
-                                "
-                            />
+                            <div class="image-title">
+                                <GenericWidget
+                                    node-alias="name_content"
+                                    graph-slug="digital_object_system"
+                                    :mode="VIEW"
+                                    :aliased-node-data="
+                                        resource.aliased_data.name?.aliased_data
+                                            .name_content ?? null
+                                    "
+                                />
+                            </div>
                         </label>
                         <div
                             v-if="isEditor"
@@ -311,7 +301,7 @@ function modifyResource(resourceInstanceId?: string) {
                     <GenericWidget
                         node-alias="content"
                         graph-slug="digital_object_system"
-                        :value="
+                        :aliased-node-data="
                             resource.aliased_data.content?.aliased_data
                                 .content ?? null
                         "
@@ -323,7 +313,7 @@ function modifyResource(resourceInstanceId?: string) {
                             node-alias="statement_content"
                             graph-slug="digital_object_system"
                             :mode="VIEW"
-                            :value="
+                            :aliased-node-data="
                                 resource.aliased_data.statement?.aliased_data
                                     .statement_content ?? null
                             "

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesViewer.vue
@@ -87,10 +87,12 @@ const confirm = useConfirm();
 onMounted(async () => {
     if (props.tileData) {
         try {
-            const digitalObjectInstances =
-                props.tileData.aliased_data.depicting_digital_asset_internal?.node_value?.map(
-                    (resource) => resource.resourceId,
-                );
+            const digitalObjectInstances = (
+                props.tileData.aliased_data
+                    .depicting_digital_asset_internal as unknown as Array<{
+                    resourceinstanceid: string;
+                }> | null
+            )?.map((resource) => resource.resourceinstanceid);
             if (digitalObjectInstances) {
                 resources.value = await fetchLingoResourcesBatch(
                     "digital_object_system",
@@ -129,12 +131,23 @@ function confirmDelete(removedResourceInstanceId: string) {
                 if (
                     depictingDigitalAssetInternalData?.depicting_digital_asset_internal
                 ) {
-                    depictingDigitalAssetInternalData.depicting_digital_asset_internal.node_value =
-                        depictingDigitalAssetInternalData.depicting_digital_asset_internal.node_value.filter(
+                    const filtered = (
+                        depictingDigitalAssetInternalData.depicting_digital_asset_internal as unknown as Array<{
+                            resourceinstanceid: string;
+                        }>
+                    )
+                        .filter(
                             (assetReference) =>
-                                assetReference.resourceId !==
+                                assetReference.resourceinstanceid !==
                                 removedResourceInstanceId,
-                        );
+                        )
+                        .map((r) => ({
+                            resourceId: r.resourceinstanceid,
+                            ontologyProperty: "",
+                            inverseOntologyProperty: "",
+                        }));
+                    depictingDigitalAssetInternalData.depicting_digital_asset_internal =
+                        filtered as unknown;
                     resources.value = resources.value?.filter(
                         (resource) =>
                             resource.resourceinstanceid !==
@@ -263,9 +276,9 @@ function modifyResource(resourceInstanceId?: string) {
                                 class="image-title"
                                 graph-slug="digital_object_system"
                                 :mode="VIEW"
-                                :node-value="
+                                :value="
                                     resource.aliased_data.name?.aliased_data
-                                        .name_content?.node_value
+                                        .name_content ?? null
                                 "
                             />
                         </label>
@@ -298,9 +311,9 @@ function modifyResource(resourceInstanceId?: string) {
                     <GenericWidget
                         node-alias="content"
                         graph-slug="digital_object_system"
-                        :node-value="
-                            resource.aliased_data.content?.aliased_data.content
-                                ?.node_value
+                        :value="
+                            resource.aliased_data.content?.aliased_data
+                                .content ?? null
                         "
                         :mode="VIEW"
                         :should-show-label="false"
@@ -310,9 +323,9 @@ function modifyResource(resourceInstanceId?: string) {
                             node-alias="statement_content"
                             graph-slug="digital_object_system"
                             :mode="VIEW"
-                            :node-value="
+                            :value="
                                 resource.aliased_data.statement?.aliased_data
-                                    .statement_content?.node_value
+                                    .statement_content ?? null
                             "
                         />
                     </div>

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/ConceptImagesViewer.vue
@@ -10,7 +10,7 @@ import Skeleton from "primevue/skeleton";
 import Tag from "primevue/tag";
 import { useConfirm } from "primevue/useconfirm";
 
-import GenericWidget from "@/arches_component_lab/generics/GenericWidget/GenericWidget.vue";
+import GenericWidget from "@/arches_vue_components/generics/GenericWidget/GenericWidget.vue";
 
 import { DANGER, SECONDARY, VIEW } from "@/arches_lingo/constants.ts";
 import { useConceptImagesEditorStore } from "@/arches_lingo/stores/useConceptImagesEditorStore.ts";
@@ -23,7 +23,7 @@ import type {
     ConceptInstance,
     DigitalObjectInstance,
 } from "@/arches_lingo/types.ts";
-import type { FileListAliasedNodeData } from "@/arches_component_lab/datatypes/file-list/types.ts";
+import type { FileListAliasedNodeData } from "@/arches_vue_components/datatypes/file-list/types.ts";
 import {
     fetchLingoResourcePartial,
     fetchLingoResourcesBatch,

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/utils.ts
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/utils.ts
@@ -55,28 +55,29 @@ export async function addDigitalObjectToConceptImageCollection(
             conceptDigitalObjectRelationshipList.aliased_data.depicting_digital_asset_internal =
                 {
                     aliased_data: {
-                        depicting_digital_asset_internal: {
-                            display_value: "",
-                            node_value: [],
-                            details: [],
-                        },
+                        depicting_digital_asset_internal: [],
                     },
                 };
         }
 
-        if (
-            !conceptDigitalObjectRelationshipList?.aliased_data
-                .depicting_digital_asset_internal?.aliased_data
-                .depicting_digital_asset_internal.node_value
-        ) {
-            conceptDigitalObjectRelationshipList.aliased_data.depicting_digital_asset_internal.aliased_data.depicting_digital_asset_internal.node_value =
-                [];
+        const depictingList = conceptDigitalObjectRelationshipList.aliased_data
+            .depicting_digital_asset_internal?.aliased_data
+            ?.depicting_digital_asset_internal as unknown as Array<{
+            resourceId: string;
+        }> | null;
+        if (!depictingList) {
+            conceptDigitalObjectRelationshipList.aliased_data.depicting_digital_asset_internal!.aliased_data.depicting_digital_asset_internal =
+                [] as unknown;
         }
-        conceptDigitalObjectRelationshipList.aliased_data.depicting_digital_asset_internal.aliased_data.depicting_digital_asset_internal.node_value.push(
-            {
-                resourceId: digitalObjectResource.resourceinstanceid,
-            },
-        );
+        (
+            conceptDigitalObjectRelationshipList.aliased_data
+                .depicting_digital_asset_internal!.aliased_data
+                .depicting_digital_asset_internal as unknown as Array<{
+                resourceId: string;
+            }>
+        ).push({
+            resourceId: digitalObjectResource.resourceinstanceid,
+        });
         await updateLingoResource(
             conceptGraphSlug,
             conceptResourceInstanceId,
@@ -109,8 +110,14 @@ export async function createFormDataForFileUpload(
             }),
         );
     }
-    for (const file of submittedFormData.content.node_value) {
-        formData.append(`file-list_${digitalObjectContentNodeId}`, file.file);
+    for (const file of (submittedFormData.content as Array<{ file?: File }>) ??
+        []) {
+        if (file.file) {
+            formData.append(
+                `file-list_${digitalObjectContentNodeId}`,
+                file.file,
+            );
+        }
     }
     return formData;
 }

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/utils.ts
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/utils.ts
@@ -7,6 +7,7 @@ import {
 } from "@/arches_lingo/api.ts";
 import { DIGITAL_OBJECT_GRAPH_SLUG } from "@/arches_lingo/components/concept/ConceptImages/components/constants.ts";
 import { type Ref, toRaw } from "vue";
+import type { ResourceInstanceListAliasedNodeData } from "@/arches_component_lab/datatypes/resource-instance-list/types.ts";
 import type {
     ConceptInstance,
     DigitalObjectInstance,
@@ -40,50 +41,56 @@ export async function addDigitalObjectToConceptImageCollection(
     conceptDigitalObjectRelationshipNodegroupAlias: string,
     conceptResourceInstanceId?: string,
 ) {
-    if (conceptResourceInstanceId && digitalObjectResource.resourceinstanceid) {
-        const conceptDigitalObjectRelationshipList =
-            (await fetchLingoResourcePartial(
-                conceptGraphSlug,
-                conceptResourceInstanceId,
-                conceptDigitalObjectRelationshipNodegroupAlias,
-            )) as ConceptInstance;
+    if (
+        !conceptResourceInstanceId ||
+        !digitalObjectResource.resourceinstanceid
+    ) {
+        return;
+    }
 
-        if (
-            !conceptDigitalObjectRelationshipList.aliased_data
-                .depicting_digital_asset_internal
-        ) {
-            conceptDigitalObjectRelationshipList.aliased_data.depicting_digital_asset_internal =
-                {
-                    aliased_data: {
-                        depicting_digital_asset_internal: [],
-                    },
-                };
-        }
-
-        const depictingList = conceptDigitalObjectRelationshipList.aliased_data
-            .depicting_digital_asset_internal?.aliased_data
-            ?.depicting_digital_asset_internal as unknown as Array<{
-            resourceId: string;
-        }> | null;
-        if (!depictingList) {
-            conceptDigitalObjectRelationshipList.aliased_data.depicting_digital_asset_internal!.aliased_data.depicting_digital_asset_internal =
-                [] as unknown;
-        }
-        (
-            conceptDigitalObjectRelationshipList.aliased_data
-                .depicting_digital_asset_internal!.aliased_data
-                .depicting_digital_asset_internal as unknown as Array<{
-                resourceId: string;
-            }>
-        ).push({
-            resourceId: digitalObjectResource.resourceinstanceid,
-        });
-        await updateLingoResource(
+    const conceptDigitalObjectRelationshipList =
+        (await fetchLingoResourcePartial(
             conceptGraphSlug,
             conceptResourceInstanceId,
-            conceptDigitalObjectRelationshipList,
-        );
+            conceptDigitalObjectRelationshipNodegroupAlias,
+        )) as ConceptInstance;
+
+    if (
+        !conceptDigitalObjectRelationshipList.aliased_data
+            .depicting_digital_asset_internal
+    ) {
+        conceptDigitalObjectRelationshipList.aliased_data.depicting_digital_asset_internal =
+            {
+                aliased_data: {
+                    depicting_digital_asset_internal: {
+                        display_value: "",
+                        node_value: [],
+                        details: [],
+                    } as ResourceInstanceListAliasedNodeData,
+                },
+            };
     }
+
+    const depictingNodeData =
+        conceptDigitalObjectRelationshipList.aliased_data
+            .depicting_digital_asset_internal.aliased_data
+            .depicting_digital_asset_internal;
+
+    depictingNodeData.node_value = [
+        ...(depictingNodeData.node_value ?? []),
+        {
+            resourceId: digitalObjectResource.resourceinstanceid,
+            ontologyProperty: "",
+            inverseOntologyProperty: "",
+            resourceXresourceId: "",
+        },
+    ];
+
+    await updateLingoResource(
+        conceptGraphSlug,
+        conceptResourceInstanceId,
+        conceptDigitalObjectRelationshipList,
+    );
 }
 
 export async function createFormDataForFileUpload(

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/utils.ts
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/utils.ts
@@ -1,4 +1,4 @@
-import { fetchCardXNodeXWidgetData } from "@/arches_component_lab/generics/GenericWidget/api.ts";
+import { useWidgetConfigStore } from "@/arches_component_lab/stores/useWidgetConfigStore.ts";
 import {
     createLingoResource,
     createLingoResourceFromForm,
@@ -94,7 +94,7 @@ export async function createFormDataForFileUpload(
 ): Promise<FormData> {
     const formData = new FormData();
 
-    const cardXNodeXWidgetData = await fetchCardXNodeXWidgetData(
+    const cardXNodeXWidgetData = await useWidgetConfigStore().fetchWidgetConfig(
         DIGITAL_OBJECT_GRAPH_SLUG,
         "content",
     );

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/utils.ts
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptImages/components/utils.ts
@@ -1,6 +1,6 @@
 import arches from "arches";
 
-import { useWidgetConfigStore } from "@/arches_component_lab/stores/useWidgetConfigStore.ts";
+import { useWidgetConfigStore } from "@/arches_vue_components/stores/useWidgetConfigStore.ts";
 import {
     createLingoResource,
     createLingoResourceFromForm,
@@ -9,7 +9,7 @@ import {
 } from "@/arches_lingo/api.ts";
 import { DIGITAL_OBJECT_GRAPH_SLUG } from "@/arches_lingo/components/concept/ConceptImages/components/constants.ts";
 import { type Ref, toRaw } from "vue";
-import type { ResourceInstanceListAliasedNodeData } from "@/arches_component_lab/datatypes/resource-instance-list/types.ts";
+import type { ResourceInstanceListAliasedNodeData } from "@/arches_vue_components/datatypes/resource-instance-list/types.ts";
 import type {
     ConceptInstance,
     DigitalObjectInstance,

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptLabel/ConceptLabel.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptLabel/ConceptLabel.vue
@@ -9,7 +9,7 @@ import ConceptLabelViewer from "@/arches_lingo/components/concept/ConceptLabel/c
 
 import { EDIT, VIEW } from "@/arches_lingo/constants.ts";
 
-import { fetchTileData } from "@/arches_component_lab/generics/GenericCard/api.ts";
+import { fetchTileData } from "@/arches_vue_components/generics/GenericCard/api.ts";
 import { useResourceStore } from "@/arches_lingo/composables/useResourceStore.ts";
 
 import type {

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptLabel/components/ConceptLabelEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptLabel/components/ConceptLabelEditor.vue
@@ -91,9 +91,8 @@ async function save(e: FormSubmitEvent) {
             props.tileId,
         );
 
+        await refreshReportSection!(props.componentName);
         openEditor!(props.componentName, updatedTileId);
-
-        refreshReportSection!(props.componentName);
         refreshSchemeHierarchy!();
     } catch (error) {
         toast.add({
@@ -135,9 +134,10 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_name_content"
-                    :aliased-node-data="
+                    :node-value="
                         props.tileData?.aliased_data
                             ?.appellative_status_ascribed_name_content
+                            ?.node_value
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -145,9 +145,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_relation"
-                    :aliased-node-data="
+                    :node-value="
                         props.tileData?.aliased_data
-                            ?.appellative_status_ascribed_relation
+                            ?.appellative_status_ascribed_relation?.node_value
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -155,9 +155,10 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_name_language"
-                    :aliased-node-data="
+                    :node-value="
                         props.tileData?.aliased_data
                             ?.appellative_status_ascribed_name_language
+                            ?.node_value
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -166,18 +167,20 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="appellative_status_timespan_begin_of_the_begin"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data
                                 ?.appellative_status_timespan_begin_of_the_begin
+                                ?.node_value
                         "
                         :mode="EDIT"
                     />
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="appellative_status_timespan_end_of_the_end"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data
                                 ?.appellative_status_timespan_end_of_the_end
+                                ?.node_value
                         "
                         :mode="EDIT"
                     />
@@ -185,8 +188,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_status"
-                    :aliased-node-data="
+                    :node-value="
                         props.tileData?.aliased_data?.appellative_status_status
+                            ?.node_value
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -194,9 +198,10 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_data_assignment_actor"
-                    :aliased-node-data="
+                    :node-value="
                         props.tileData?.aliased_data
                             ?.appellative_status_data_assignment_actor
+                            ?.node_value
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -204,9 +209,10 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_data_assignment_object_used"
-                    :aliased-node-data="
+                    :node-value="
                         props.tileData?.aliased_data
                             ?.appellative_status_data_assignment_object_used
+                            ?.node_value
                     "
                     :mode="EDIT"
                     class="widget-container column"

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptLabel/components/ConceptLabelEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptLabel/components/ConceptLabelEditor.vue
@@ -134,10 +134,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_name_content"
-                    :node-value="
+                    :value="
                         props.tileData?.aliased_data
-                            ?.appellative_status_ascribed_name_content
-                            ?.node_value
+                            ?.appellative_status_ascribed_name_content ?? null
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -145,9 +144,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_relation"
-                    :node-value="
+                    :value="
                         props.tileData?.aliased_data
-                            ?.appellative_status_ascribed_relation?.node_value
+                            ?.appellative_status_ascribed_relation ?? null
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -155,10 +154,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_name_language"
-                    :node-value="
+                    :value="
                         props.tileData?.aliased_data
-                            ?.appellative_status_ascribed_name_language
-                            ?.node_value
+                            ?.appellative_status_ascribed_name_language ?? null
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -167,20 +165,20 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="appellative_status_timespan_begin_of_the_begin"
-                        :node-value="
+                        :value="
                             props.tileData?.aliased_data
-                                ?.appellative_status_timespan_begin_of_the_begin
-                                ?.node_value
+                                ?.appellative_status_timespan_begin_of_the_begin ??
+                            null
                         "
                         :mode="EDIT"
                     />
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="appellative_status_timespan_end_of_the_end"
-                        :node-value="
+                        :value="
                             props.tileData?.aliased_data
-                                ?.appellative_status_timespan_end_of_the_end
-                                ?.node_value
+                                ?.appellative_status_timespan_end_of_the_end ??
+                            null
                         "
                         :mode="EDIT"
                     />
@@ -188,9 +186,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_status"
-                    :node-value="
-                        props.tileData?.aliased_data?.appellative_status_status
-                            ?.node_value
+                    :value="
+                        props.tileData?.aliased_data
+                            ?.appellative_status_status ?? null
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -198,10 +196,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_data_assignment_actor"
-                    :node-value="
+                    :value="
                         props.tileData?.aliased_data
-                            ?.appellative_status_data_assignment_actor
-                            ?.node_value
+                            ?.appellative_status_data_assignment_actor ?? null
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -209,10 +206,10 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_data_assignment_object_used"
-                    :node-value="
+                    :value="
                         props.tileData?.aliased_data
-                            ?.appellative_status_data_assignment_object_used
-                            ?.node_value
+                            ?.appellative_status_data_assignment_object_used ??
+                        null
                     "
                     :mode="EDIT"
                     class="widget-container column"

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptLabel/components/ConceptLabelEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptLabel/components/ConceptLabelEditor.vue
@@ -131,36 +131,41 @@ async function save(e: FormSubmitEvent) {
                 ref="form"
                 @submit="save"
             >
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="appellative_status_ascribed_name_content"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data
-                            ?.appellative_status_ascribed_name_content ?? null
-                    "
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="appellative_status_ascribed_relation"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data
-                            ?.appellative_status_ascribed_relation ?? null
-                    "
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="appellative_status_ascribed_name_language"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data
-                            ?.appellative_status_ascribed_name_language ?? null
-                    "
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="appellative_status_ascribed_name_content"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data
+                                ?.appellative_status_ascribed_name_content ??
+                            null
+                        "
+                        :mode="EDIT"
+                    />
+                </div>
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="appellative_status_ascribed_relation"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data
+                                ?.appellative_status_ascribed_relation ?? null
+                        "
+                        :mode="EDIT"
+                    />
+                </div>
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="appellative_status_ascribed_name_language"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data
+                                ?.appellative_status_ascribed_name_language ??
+                            null
+                        "
+                        :mode="EDIT"
+                    />
+                </div>
                 <div class="widget-container">
                     <GenericWidget
                         :graph-slug="props.graphSlug"
@@ -183,37 +188,41 @@ async function save(e: FormSubmitEvent) {
                         :mode="EDIT"
                     />
                 </div>
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="appellative_status_status"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data
-                            ?.appellative_status_status ?? null
-                    "
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="appellative_status_data_assignment_actor"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data
-                            ?.appellative_status_data_assignment_actor ?? null
-                    "
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="appellative_status_data_assignment_object_used"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data
-                            ?.appellative_status_data_assignment_object_used ??
-                        null
-                    "
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="appellative_status_status"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data
+                                ?.appellative_status_status ?? null
+                        "
+                        :mode="EDIT"
+                    />
+                </div>
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="appellative_status_data_assignment_actor"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data
+                                ?.appellative_status_data_assignment_actor ??
+                            null
+                        "
+                        :mode="EDIT"
+                    />
+                </div>
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="appellative_status_data_assignment_object_used"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data
+                                ?.appellative_status_data_assignment_object_used ??
+                            null
+                        "
+                        :mode="EDIT"
+                    />
+                </div>
             </Form>
         </div>
     </div>

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptLabel/components/ConceptLabelEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptLabel/components/ConceptLabelEditor.vue
@@ -134,7 +134,7 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_name_content"
-                    :value="
+                    :aliased-node-data="
                         props.tileData?.aliased_data
                             ?.appellative_status_ascribed_name_content ?? null
                     "
@@ -144,7 +144,7 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_relation"
-                    :value="
+                    :aliased-node-data="
                         props.tileData?.aliased_data
                             ?.appellative_status_ascribed_relation ?? null
                     "
@@ -154,7 +154,7 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_name_language"
-                    :value="
+                    :aliased-node-data="
                         props.tileData?.aliased_data
                             ?.appellative_status_ascribed_name_language ?? null
                     "
@@ -165,7 +165,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="appellative_status_timespan_begin_of_the_begin"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data
                                 ?.appellative_status_timespan_begin_of_the_begin ??
                             null
@@ -175,7 +175,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="appellative_status_timespan_end_of_the_end"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data
                                 ?.appellative_status_timespan_end_of_the_end ??
                             null
@@ -186,7 +186,7 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_status"
-                    :value="
+                    :aliased-node-data="
                         props.tileData?.aliased_data
                             ?.appellative_status_status ?? null
                     "
@@ -196,7 +196,7 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_data_assignment_actor"
-                    :value="
+                    :aliased-node-data="
                         props.tileData?.aliased_data
                             ?.appellative_status_data_assignment_actor ?? null
                     "
@@ -206,7 +206,7 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_data_assignment_object_used"
-                    :value="
+                    :aliased-node-data="
                         props.tileData?.aliased_data
                             ?.appellative_status_data_assignment_object_used ??
                         null

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptLabel/components/ConceptLabelEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptLabel/components/ConceptLabelEditor.vue
@@ -9,7 +9,7 @@ import { Form } from "@primevue/forms";
 
 import Skeleton from "primevue/skeleton";
 
-import GenericWidget from "@/arches_component_lab/generics/GenericWidget/GenericWidget.vue";
+import GenericWidget from "@/arches_vue_components/generics/GenericWidget/GenericWidget.vue";
 
 import { createOrUpdateConcept } from "@/arches_lingo/utils.ts";
 

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptLabel/components/ConceptLabelViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptLabel/components/ConceptLabelViewer.vue
@@ -56,10 +56,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
     type: $gettext("Type"),
     noRecords: $gettext("No concept labels were found."),
     sortFields: {
-        name: "aliased_data.appellative_status_ascribed_name_content.display_value",
-        type: "aliased_data.appellative_status_ascribed_relation.display_value",
-        language:
-            "aliased_data.appellative_status_ascribed_name_language.display_value",
+        name: "aliased_data.appellative_status_ascribed_name_content",
+        type: "aliased_data.appellative_status_ascribed_relation",
+        language: "aliased_data.appellative_status_ascribed_name_language",
     },
 }));
 </script>
@@ -110,10 +109,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_name_content"
-                    :node-value="
+                    :value="
                         rowData.aliased_data
-                            .appellative_status_ascribed_name_content
-                            ?.node_value
+                            .appellative_status_ascribed_name_content ?? null
                     "
                     :mode="VIEW"
                     :should-show-label="false"
@@ -123,9 +121,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_relation"
-                    :node-value="
+                    :value="
                         rowData.aliased_data
-                            .appellative_status_ascribed_relation?.node_value
+                            .appellative_status_ascribed_relation ?? null
                     "
                     :mode="VIEW"
                     :should-show-label="false"
@@ -135,10 +133,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_name_language"
-                    :node-value="
+                    :value="
                         rowData.aliased_data
-                            .appellative_status_ascribed_name_language
-                            ?.node_value
+                            .appellative_status_ascribed_name_language ?? null
                     "
                     :mode="VIEW"
                     :should-show-label="false"
@@ -148,20 +145,19 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_data_assignment_object_used"
-                    :node-value="
+                    :value="
                         rowData.aliased_data
-                            .appellative_status_data_assignment_object_used
-                            ?.node_value
+                            .appellative_status_data_assignment_object_used ??
+                        null
                     "
                     :mode="VIEW"
                 />
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_data_assignment_actor"
-                    :node-value="
+                    :value="
                         rowData.aliased_data
-                            .appellative_status_data_assignment_actor
-                            ?.node_value
+                            .appellative_status_data_assignment_actor ?? null
                     "
                     :mode="VIEW"
                 />

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptLabel/components/ConceptLabelViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptLabel/components/ConceptLabelViewer.vue
@@ -56,9 +56,10 @@ const metaStringLabel = computed<MetaStringText>(() => ({
     type: $gettext("Type"),
     noRecords: $gettext("No concept labels were found."),
     sortFields: {
-        name: "aliased_data.appellative_status_ascribed_name_content",
-        type: "aliased_data.appellative_status_ascribed_relation",
-        language: "aliased_data.appellative_status_ascribed_name_language",
+        name: "aliased_data.appellative_status_ascribed_name_content.display_value",
+        type: "aliased_data.appellative_status_ascribed_relation.display_value",
+        language:
+            "aliased_data.appellative_status_ascribed_name_language.display_value",
     },
 }));
 </script>
@@ -109,7 +110,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_name_content"
-                    :value="
+                    :aliased-node-data="
                         rowData.aliased_data
                             .appellative_status_ascribed_name_content ?? null
                     "
@@ -121,7 +122,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_relation"
-                    :value="
+                    :aliased-node-data="
                         rowData.aliased_data
                             .appellative_status_ascribed_relation ?? null
                     "
@@ -133,7 +134,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_name_language"
-                    :value="
+                    :aliased-node-data="
                         rowData.aliased_data
                             .appellative_status_ascribed_name_language ?? null
                     "
@@ -145,7 +146,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_data_assignment_object_used"
-                    :value="
+                    :aliased-node-data="
                         rowData.aliased_data
                             .appellative_status_data_assignment_object_used ??
                         null
@@ -155,7 +156,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_data_assignment_actor"
-                    :value="
+                    :aliased-node-data="
                         rowData.aliased_data
                             .appellative_status_data_assignment_actor ?? null
                     "

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptLabel/components/ConceptLabelViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptLabel/components/ConceptLabelViewer.vue
@@ -110,9 +110,10 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_name_content"
-                    :aliased-node-data="
+                    :node-value="
                         rowData.aliased_data
                             .appellative_status_ascribed_name_content
+                            ?.node_value
                     "
                     :mode="VIEW"
                     :should-show-label="false"
@@ -122,9 +123,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_relation"
-                    :aliased-node-data="
+                    :node-value="
                         rowData.aliased_data
-                            .appellative_status_ascribed_relation
+                            .appellative_status_ascribed_relation?.node_value
                     "
                     :mode="VIEW"
                     :should-show-label="false"
@@ -134,9 +135,10 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_name_language"
-                    :aliased-node-data="
+                    :node-value="
                         rowData.aliased_data
                             .appellative_status_ascribed_name_language
+                            ?.node_value
                     "
                     :mode="VIEW"
                     :should-show-label="false"
@@ -146,18 +148,20 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_data_assignment_object_used"
-                    :aliased-node-data="
+                    :node-value="
                         rowData.aliased_data
                             .appellative_status_data_assignment_object_used
+                            ?.node_value
                     "
                     :mode="VIEW"
                 />
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_data_assignment_actor"
-                    :aliased-node-data="
+                    :node-value="
                         rowData.aliased_data
                             .appellative_status_data_assignment_actor
+                            ?.node_value
                     "
                     :mode="VIEW"
                 />

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptLabel/components/ConceptLabelViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptLabel/components/ConceptLabelViewer.vue
@@ -6,7 +6,7 @@ import Button from "primevue/button";
 import Tag from "primevue/tag";
 
 import MetaStringViewer from "@/arches_lingo/components/generic/MetaStringViewer.vue";
-import GenericWidget from "@/arches_component_lab/generics/GenericWidget/GenericWidget.vue";
+import GenericWidget from "@/arches_vue_components/generics/GenericWidget/GenericWidget.vue";
 
 import { VIEW } from "@/arches_lingo/constants.ts";
 import { useUserStore } from "@/arches_lingo/stores/useUserStore.ts";

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptMatch/ConceptMatch.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptMatch/ConceptMatch.vue
@@ -9,7 +9,7 @@ import ConceptMatchViewer from "@/arches_lingo/components/concept/ConceptMatch/c
 
 import { EDIT, VIEW } from "@/arches_lingo/constants.ts";
 
-import { fetchTileData } from "@/arches_component_lab/generics/GenericCard/api.ts";
+import { fetchTileData } from "@/arches_vue_components/generics/GenericCard/api.ts";
 import { useResourceStore } from "@/arches_lingo/composables/useResourceStore.ts";
 
 import type {

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptMatch/components/ConceptMatchEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptMatch/components/ConceptMatchEditor.vue
@@ -91,9 +91,8 @@ async function save(e: FormSubmitEvent) {
             props.tileId,
         );
 
+        await refreshReportSection!(props.componentName);
         openEditor!(props.componentName, updatedTileId);
-
-        refreshReportSection!(props.componentName);
     } catch (error) {
         toast.add({
             severity: ERROR,
@@ -134,9 +133,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_ascribed_comparate"
-                    :aliased-node-data="
+                    :node-value="
                         props.tileData?.aliased_data
-                            .match_status_ascribed_comparate
+                            .match_status_ascribed_comparate?.node_value
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -144,9 +143,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_ascribed_relation"
-                    :aliased-node-data="
+                    :node-value="
                         props.tileData?.aliased_data
-                            .match_status_ascribed_relation
+                            .match_status_ascribed_relation?.node_value
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -154,8 +153,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_status"
-                    :aliased-node-data="
+                    :node-value="
                         props.tileData?.aliased_data.match_status_status
+                            ?.node_value
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -164,18 +164,20 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="match_status_timespan_begin_of_the_begin"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data
                                 .match_status_timespan_begin_of_the_begin
+                                ?.node_value
                         "
                         :mode="EDIT"
                     />
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="match_status_timespan_end_of_the_end"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data
                                 .match_status_timespan_end_of_the_end
+                                ?.node_value
                         "
                         :mode="EDIT"
                     />
@@ -183,9 +185,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_data_assignment_actor"
-                    :aliased-node-data="
+                    :node-value="
                         props.tileData?.aliased_data
-                            .match_status_data_assignment_actor
+                            .match_status_data_assignment_actor?.node_value
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -193,9 +195,10 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_data_assignment_object_used"
-                    :aliased-node-data="
+                    :node-value="
                         props.tileData?.aliased_data
                             .match_status_data_assignment_object_used
+                            ?.node_value
                     "
                     :mode="EDIT"
                     class="widget-container column"

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptMatch/components/ConceptMatchEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptMatch/components/ConceptMatchEditor.vue
@@ -133,9 +133,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_ascribed_comparate"
-                    :node-value="
+                    :value="
                         props.tileData?.aliased_data
-                            .match_status_ascribed_comparate?.node_value
+                            .match_status_ascribed_comparate ?? null
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -143,9 +143,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_ascribed_relation"
-                    :node-value="
+                    :value="
                         props.tileData?.aliased_data
-                            .match_status_ascribed_relation?.node_value
+                            .match_status_ascribed_relation ?? null
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -153,9 +153,8 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_status"
-                    :node-value="
-                        props.tileData?.aliased_data.match_status_status
-                            ?.node_value
+                    :value="
+                        props.tileData?.aliased_data.match_status_status ?? null
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -164,20 +163,19 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="match_status_timespan_begin_of_the_begin"
-                        :node-value="
+                        :value="
                             props.tileData?.aliased_data
-                                .match_status_timespan_begin_of_the_begin
-                                ?.node_value
+                                .match_status_timespan_begin_of_the_begin ??
+                            null
                         "
                         :mode="EDIT"
                     />
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="match_status_timespan_end_of_the_end"
-                        :node-value="
+                        :value="
                             props.tileData?.aliased_data
-                                .match_status_timespan_end_of_the_end
-                                ?.node_value
+                                .match_status_timespan_end_of_the_end ?? null
                         "
                         :mode="EDIT"
                     />
@@ -185,9 +183,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_data_assignment_actor"
-                    :node-value="
+                    :value="
                         props.tileData?.aliased_data
-                            .match_status_data_assignment_actor?.node_value
+                            .match_status_data_assignment_actor ?? null
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -195,10 +193,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_data_assignment_object_used"
-                    :node-value="
+                    :value="
                         props.tileData?.aliased_data
-                            .match_status_data_assignment_object_used
-                            ?.node_value
+                            .match_status_data_assignment_object_used ?? null
                     "
                     :mode="EDIT"
                     class="widget-container column"

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptMatch/components/ConceptMatchEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptMatch/components/ConceptMatchEditor.vue
@@ -130,35 +130,39 @@ async function save(e: FormSubmitEvent) {
                 ref="form"
                 @submit="save"
             >
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="match_status_ascribed_comparate"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data
-                            .match_status_ascribed_comparate ?? null
-                    "
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="match_status_ascribed_relation"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data
-                            .match_status_ascribed_relation ?? null
-                    "
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="match_status_status"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data.match_status_status ?? null
-                    "
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="match_status_ascribed_comparate"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data
+                                .match_status_ascribed_comparate ?? null
+                        "
+                        :mode="EDIT"
+                    />
+                </div>
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="match_status_ascribed_relation"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data
+                                .match_status_ascribed_relation ?? null
+                        "
+                        :mode="EDIT"
+                    />
+                </div>
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="match_status_status"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data.match_status_status ??
+                            null
+                        "
+                        :mode="EDIT"
+                    />
+                </div>
                 <div class="widget-container">
                     <GenericWidget
                         :graph-slug="props.graphSlug"
@@ -180,26 +184,29 @@ async function save(e: FormSubmitEvent) {
                         :mode="EDIT"
                     />
                 </div>
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="match_status_data_assignment_actor"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data
-                            .match_status_data_assignment_actor ?? null
-                    "
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="match_status_data_assignment_object_used"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data
-                            .match_status_data_assignment_object_used ?? null
-                    "
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="match_status_data_assignment_actor"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data
+                                .match_status_data_assignment_actor ?? null
+                        "
+                        :mode="EDIT"
+                    />
+                </div>
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="match_status_data_assignment_object_used"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data
+                                .match_status_data_assignment_object_used ??
+                            null
+                        "
+                        :mode="EDIT"
+                    />
+                </div>
             </Form>
         </div>
     </div>

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptMatch/components/ConceptMatchEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptMatch/components/ConceptMatchEditor.vue
@@ -133,7 +133,7 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_ascribed_comparate"
-                    :value="
+                    :aliased-node-data="
                         props.tileData?.aliased_data
                             .match_status_ascribed_comparate ?? null
                     "
@@ -143,7 +143,7 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_ascribed_relation"
-                    :value="
+                    :aliased-node-data="
                         props.tileData?.aliased_data
                             .match_status_ascribed_relation ?? null
                     "
@@ -153,7 +153,7 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_status"
-                    :value="
+                    :aliased-node-data="
                         props.tileData?.aliased_data.match_status_status ?? null
                     "
                     :mode="EDIT"
@@ -163,7 +163,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="match_status_timespan_begin_of_the_begin"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data
                                 .match_status_timespan_begin_of_the_begin ??
                             null
@@ -173,7 +173,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="match_status_timespan_end_of_the_end"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data
                                 .match_status_timespan_end_of_the_end ?? null
                         "
@@ -183,7 +183,7 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_data_assignment_actor"
-                    :value="
+                    :aliased-node-data="
                         props.tileData?.aliased_data
                             .match_status_data_assignment_actor ?? null
                     "
@@ -193,7 +193,7 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_data_assignment_object_used"
-                    :value="
+                    :aliased-node-data="
                         props.tileData?.aliased_data
                             .match_status_data_assignment_object_used ?? null
                     "

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptMatch/components/ConceptMatchEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptMatch/components/ConceptMatchEditor.vue
@@ -9,7 +9,7 @@ import { Form } from "@primevue/forms";
 
 import Skeleton from "primevue/skeleton";
 
-import GenericWidget from "@/arches_component_lab/generics/GenericWidget/GenericWidget.vue";
+import GenericWidget from "@/arches_vue_components/generics/GenericWidget/GenericWidget.vue";
 
 import { createOrUpdateConcept } from "@/arches_lingo/utils.ts";
 

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptMatch/components/ConceptMatchViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptMatch/components/ConceptMatchViewer.vue
@@ -76,15 +76,18 @@ const metaStringLabel = computed<MetaStringText>(() => ({
     type: $gettext("Related URI"),
     noRecords: $gettext("No matched concepts were found."),
     sortFields: {
-        name: "aliased_data.match_status_ascribed_relation.display_value",
-        type: "aliased_data.match_status_ascribed_comparate.display_value",
+        name: "aliased_data.match_status_ascribed_relation",
+        type: "aliased_data.match_status_ascribed_comparate",
     },
 }));
 
 function matchedConceptURIIsLink(rowData: ConceptMatchStatus): boolean {
-    const uri = rowData.aliased_data.match_status_ascribed_comparate
-        .display_value as string;
-    return uri.startsWith("http");
+    const uri = rowData.aliased_data
+        .match_status_ascribed_comparate as unknown as
+        | string
+        | null
+        | undefined;
+    return Boolean(uri?.startsWith("http"));
 }
 </script>
 
@@ -132,9 +135,9 @@ function matchedConceptURIIsLink(rowData: ConceptMatchStatus): boolean {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_ascribed_relation"
-                    :node-value="
-                        rowData.aliased_data.match_status_ascribed_relation
-                            ?.node_value
+                    :value="
+                        rowData.aliased_data.match_status_ascribed_relation ??
+                        null
                     "
                     :mode="VIEW"
                     :should-show-label="false"
@@ -144,42 +147,38 @@ function matchedConceptURIIsLink(rowData: ConceptMatchStatus): boolean {
                 <Button
                     v-if="matchedConceptURIIsLink(rowData)"
                     :label="
-                        rowData.aliased_data.match_status_ascribed_comparate
-                            .display_value
+                        rowData.aliased_data
+                            .match_status_ascribed_comparate as unknown as string
                     "
                     variant="link"
                     as="a"
                     :href="
-                        rowData.aliased_data.match_status_ascribed_comparate
-                            .display_value
+                        rowData.aliased_data
+                            .match_status_ascribed_comparate as unknown as string
                     "
                     target="_blank"
                     rel="noopener"
                 ></Button>
                 <span v-else>
-                    {{
-                        rowData.aliased_data.match_status_ascribed_comparate
-                            .display_value
-                    }}
+                    {{ rowData.aliased_data.match_status_ascribed_comparate }}
                 </span>
             </template>
             <template #drawer="{ rowData }">
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_data_assignment_actor"
-                    :node-value="
-                        rowData.aliased_data.match_status_data_assignment_actor
-                            ?.node_value
+                    :value="
+                        rowData.aliased_data
+                            .match_status_data_assignment_actor ?? null
                     "
                     :mode="VIEW"
                 />
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_data_assignment_object_used"
-                    :node-value="
+                    :value="
                         rowData.aliased_data
-                            .match_status_data_assignment_object_used
-                            ?.node_value
+                            .match_status_data_assignment_object_used ?? null
                     "
                     :mode="VIEW"
                 />

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptMatch/components/ConceptMatchViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptMatch/components/ConceptMatchViewer.vue
@@ -82,12 +82,11 @@ const metaStringLabel = computed<MetaStringText>(() => ({
 }));
 
 function matchedConceptURIIsLink(rowData: ConceptMatchStatus): boolean {
-    const uri = rowData.aliased_data
-        .match_status_ascribed_comparate as unknown as
-        | string
-        | null
-        | undefined;
-    return Boolean(uri?.startsWith("http"));
+    return Boolean(
+        rowData.aliased_data.match_status_ascribed_comparate?.display_value?.startsWith(
+            "http",
+        ),
+    );
 }
 </script>
 
@@ -147,20 +146,23 @@ function matchedConceptURIIsLink(rowData: ConceptMatchStatus): boolean {
                 <Button
                     v-if="matchedConceptURIIsLink(rowData)"
                     :label="
-                        rowData.aliased_data
-                            .match_status_ascribed_comparate as unknown as string
+                        rowData.aliased_data.match_status_ascribed_comparate
+                            ?.display_value
                     "
                     variant="link"
                     as="a"
                     :href="
-                        rowData.aliased_data
-                            .match_status_ascribed_comparate as unknown as string
+                        rowData.aliased_data.match_status_ascribed_comparate
+                            ?.display_value
                     "
                     target="_blank"
                     rel="noopener"
                 ></Button>
                 <span v-else>
-                    {{ rowData.aliased_data.match_status_ascribed_comparate }}
+                    {{
+                        rowData.aliased_data.match_status_ascribed_comparate
+                            ?.display_value
+                    }}
                 </span>
             </template>
             <template #drawer="{ rowData }">

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptMatch/components/ConceptMatchViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptMatch/components/ConceptMatchViewer.vue
@@ -76,8 +76,8 @@ const metaStringLabel = computed<MetaStringText>(() => ({
     type: $gettext("Related URI"),
     noRecords: $gettext("No matched concepts were found."),
     sortFields: {
-        name: "aliased_data.match_status_ascribed_relation",
-        type: "aliased_data.match_status_ascribed_comparate",
+        name: "aliased_data.match_status_ascribed_relation.display_value",
+        type: "aliased_data.match_status_ascribed_comparate.display_value",
     },
 }));
 
@@ -135,7 +135,7 @@ function matchedConceptURIIsLink(rowData: ConceptMatchStatus): boolean {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_ascribed_relation"
-                    :value="
+                    :aliased-node-data="
                         rowData.aliased_data.match_status_ascribed_relation ??
                         null
                     "
@@ -167,7 +167,7 @@ function matchedConceptURIIsLink(rowData: ConceptMatchStatus): boolean {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_data_assignment_actor"
-                    :value="
+                    :aliased-node-data="
                         rowData.aliased_data
                             .match_status_data_assignment_actor ?? null
                     "
@@ -176,7 +176,7 @@ function matchedConceptURIIsLink(rowData: ConceptMatchStatus): boolean {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_data_assignment_object_used"
-                    :value="
+                    :aliased-node-data="
                         rowData.aliased_data
                             .match_status_data_assignment_object_used ?? null
                     "

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptMatch/components/ConceptMatchViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptMatch/components/ConceptMatchViewer.vue
@@ -132,8 +132,9 @@ function matchedConceptURIIsLink(rowData: ConceptMatchStatus): boolean {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_ascribed_relation"
-                    :aliased-node-data="
+                    :node-value="
                         rowData.aliased_data.match_status_ascribed_relation
+                            ?.node_value
                     "
                     :mode="VIEW"
                     :should-show-label="false"
@@ -166,17 +167,19 @@ function matchedConceptURIIsLink(rowData: ConceptMatchStatus): boolean {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_data_assignment_actor"
-                    :aliased-node-data="
+                    :node-value="
                         rowData.aliased_data.match_status_data_assignment_actor
+                            ?.node_value
                     "
                     :mode="VIEW"
                 />
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="match_status_data_assignment_object_used"
-                    :aliased-node-data="
+                    :node-value="
                         rowData.aliased_data
                             .match_status_data_assignment_object_used
+                            ?.node_value
                     "
                     :mode="VIEW"
                 />

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptMatch/components/ConceptMatchViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptMatch/components/ConceptMatchViewer.vue
@@ -7,7 +7,7 @@ import Button from "primevue/button";
 import Tag from "primevue/tag";
 
 import MetaStringViewer from "@/arches_lingo/components/generic/MetaStringViewer.vue";
-import GenericWidget from "@/arches_component_lab/generics/GenericWidget/GenericWidget.vue";
+import GenericWidget from "@/arches_vue_components/generics/GenericWidget/GenericWidget.vue";
 
 import { resolveConceptURI } from "@/arches_lingo/api.ts";
 import { VIEW } from "@/arches_lingo/constants.ts";

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptNote/ConceptNote.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptNote/ConceptNote.vue
@@ -9,7 +9,7 @@ import ConceptNoteViewer from "@/arches_lingo/components/concept/ConceptNote/com
 
 import { EDIT, VIEW } from "@/arches_lingo/constants.ts";
 
-import { fetchTileData } from "@/arches_component_lab/generics/GenericCard/api.ts";
+import { fetchTileData } from "@/arches_vue_components/generics/GenericCard/api.ts";
 import { useResourceStore } from "@/arches_lingo/composables/useResourceStore.ts";
 
 import type {

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptNote/components/ConceptNoteEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptNote/components/ConceptNoteEditor.vue
@@ -133,33 +133,38 @@ async function save(e: FormSubmitEvent) {
                 ref="form"
                 @submit="save"
             >
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="statement_content"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data.statement_content ?? null
-                    "
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="statement_type"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data.statement_type ?? null
-                    "
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="statement_language"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data.statement_language ?? null
-                    "
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="statement_content"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data.statement_content ??
+                            null
+                        "
+                        :mode="EDIT"
+                    />
+                </div>
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="statement_type"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data.statement_type ?? null
+                        "
+                        :mode="EDIT"
+                    />
+                </div>
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="statement_language"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data.statement_language ??
+                            null
+                        "
+                        :mode="EDIT"
+                    />
+                </div>
                 <div class="widget-container">
                     <GenericWidget
                         :graph-slug="props.graphSlug"
@@ -182,26 +187,28 @@ async function save(e: FormSubmitEvent) {
                         :mode="EDIT"
                     />
                 </div>
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="statement_data_assignment_actor"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data
-                            .statement_data_assignment_actor ?? null
-                    "
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="statement_data_assignment_object_used"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data
-                            .statement_data_assignment_object_used ?? null
-                    "
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="statement_data_assignment_actor"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data
+                                .statement_data_assignment_actor ?? null
+                        "
+                        :mode="EDIT"
+                    />
+                </div>
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="statement_data_assignment_object_used"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data
+                                .statement_data_assignment_object_used ?? null
+                        "
+                        :mode="EDIT"
+                    />
+                </div>
             </Form>
         </div>
     </div>

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptNote/components/ConceptNoteEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptNote/components/ConceptNoteEditor.vue
@@ -94,9 +94,8 @@ async function save(e: FormSubmitEvent) {
             props.tileId,
         );
 
+        await refreshReportSection!(props.componentName);
         openEditor!(props.componentName, updatedTileId);
-
-        refreshReportSection!(props.componentName);
     } catch (error) {
         toast.add({
             severity: ERROR,
@@ -137,8 +136,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="statement_content"
-                    :aliased-node-data="
+                    :node-value="
                         props.tileData?.aliased_data.statement_content
+                            ?.node_value
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -146,8 +146,8 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="statement_type"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data.statement_type
+                    :node-value="
+                        props.tileData?.aliased_data.statement_type?.node_value
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -155,8 +155,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="statement_language"
-                    :aliased-node-data="
+                    :node-value="
                         props.tileData?.aliased_data.statement_language
+                            ?.node_value
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -165,18 +166,20 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="statement_data_assignment_timespan_begin_of_the_begin"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data
                                 .statement_data_assignment_timespan_begin_of_the_begin
+                                ?.node_value
                         "
                         :mode="EDIT"
                     />
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="statement_data_assignment_timespan_end_of_the_end"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data
                                 .statement_data_assignment_timespan_end_of_the_end
+                                ?.node_value
                         "
                         :mode="EDIT"
                     />
@@ -184,9 +187,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="statement_data_assignment_actor"
-                    :aliased-node-data="
+                    :node-value="
                         props.tileData?.aliased_data
-                            .statement_data_assignment_actor
+                            .statement_data_assignment_actor?.node_value
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -194,9 +197,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="statement_data_assignment_object_used"
-                    :aliased-node-data="
+                    :node-value="
                         props.tileData?.aliased_data
-                            .statement_data_assignment_object_used
+                            .statement_data_assignment_object_used?.node_value
                     "
                     :mode="EDIT"
                     class="widget-container column"

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptNote/components/ConceptNoteEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptNote/components/ConceptNoteEditor.vue
@@ -136,7 +136,7 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="statement_content"
-                    :value="
+                    :aliased-node-data="
                         props.tileData?.aliased_data.statement_content ?? null
                     "
                     :mode="EDIT"
@@ -145,14 +145,16 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="statement_type"
-                    :value="props.tileData?.aliased_data.statement_type ?? null"
+                    :aliased-node-data="
+                        props.tileData?.aliased_data.statement_type ?? null
+                    "
                     :mode="EDIT"
                     class="widget-container column"
                 />
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="statement_language"
-                    :value="
+                    :aliased-node-data="
                         props.tileData?.aliased_data.statement_language ?? null
                     "
                     :mode="EDIT"
@@ -162,7 +164,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="statement_data_assignment_timespan_begin_of_the_begin"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data
                                 .statement_data_assignment_timespan_begin_of_the_begin ??
                             null
@@ -172,7 +174,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="statement_data_assignment_timespan_end_of_the_end"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data
                                 .statement_data_assignment_timespan_end_of_the_end ??
                             null
@@ -183,7 +185,7 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="statement_data_assignment_actor"
-                    :value="
+                    :aliased-node-data="
                         props.tileData?.aliased_data
                             .statement_data_assignment_actor ?? null
                     "
@@ -193,7 +195,7 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="statement_data_assignment_object_used"
-                    :value="
+                    :aliased-node-data="
                         props.tileData?.aliased_data
                             .statement_data_assignment_object_used ?? null
                     "

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptNote/components/ConceptNoteEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptNote/components/ConceptNoteEditor.vue
@@ -136,9 +136,8 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="statement_content"
-                    :node-value="
-                        props.tileData?.aliased_data.statement_content
-                            ?.node_value
+                    :value="
+                        props.tileData?.aliased_data.statement_content ?? null
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -146,18 +145,15 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="statement_type"
-                    :node-value="
-                        props.tileData?.aliased_data.statement_type?.node_value
-                    "
+                    :value="props.tileData?.aliased_data.statement_type ?? null"
                     :mode="EDIT"
                     class="widget-container column"
                 />
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="statement_language"
-                    :node-value="
-                        props.tileData?.aliased_data.statement_language
-                            ?.node_value
+                    :value="
+                        props.tileData?.aliased_data.statement_language ?? null
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -166,20 +162,20 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="statement_data_assignment_timespan_begin_of_the_begin"
-                        :node-value="
+                        :value="
                             props.tileData?.aliased_data
-                                .statement_data_assignment_timespan_begin_of_the_begin
-                                ?.node_value
+                                .statement_data_assignment_timespan_begin_of_the_begin ??
+                            null
                         "
                         :mode="EDIT"
                     />
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="statement_data_assignment_timespan_end_of_the_end"
-                        :node-value="
+                        :value="
                             props.tileData?.aliased_data
-                                .statement_data_assignment_timespan_end_of_the_end
-                                ?.node_value
+                                .statement_data_assignment_timespan_end_of_the_end ??
+                            null
                         "
                         :mode="EDIT"
                     />
@@ -187,9 +183,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="statement_data_assignment_actor"
-                    :node-value="
+                    :value="
                         props.tileData?.aliased_data
-                            .statement_data_assignment_actor?.node_value
+                            .statement_data_assignment_actor ?? null
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -197,9 +193,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="statement_data_assignment_object_used"
-                    :node-value="
+                    :value="
                         props.tileData?.aliased_data
-                            .statement_data_assignment_object_used?.node_value
+                            .statement_data_assignment_object_used ?? null
                     "
                     :mode="EDIT"
                     class="widget-container column"

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptNote/components/ConceptNoteEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptNote/components/ConceptNoteEditor.vue
@@ -9,7 +9,7 @@ import { Form } from "@primevue/forms";
 
 import Skeleton from "primevue/skeleton";
 
-import GenericWidget from "@/arches_component_lab/generics/GenericWidget/GenericWidget.vue";
+import GenericWidget from "@/arches_vue_components/generics/GenericWidget/GenericWidget.vue";
 import { createOrUpdateConcept } from "@/arches_lingo/utils.ts";
 
 import {

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptNote/components/ConceptNoteEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptNote/components/ConceptNoteEditor.vue
@@ -133,34 +133,39 @@ async function save(e: FormSubmitEvent) {
                 ref="form"
                 @submit="save"
             >
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="statement_content"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data.statement_content ?? null
-                    "
-                    :render-context="MULTILINE_RENDER_CONTEXT"
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="statement_type"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data.statement_type ?? null
-                    "
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="statement_language"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data.statement_language ?? null
-                    "
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="statement_content"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data.statement_content ??
+                            null
+                        "
+                        :render-context="MULTILINE_RENDER_CONTEXT"
+                        :mode="EDIT"
+                    />
+                </div>
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="statement_type"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data.statement_type ?? null
+                        "
+                        :mode="EDIT"
+                    />
+                </div>
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="statement_language"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data.statement_language ??
+                            null
+                        "
+                        :mode="EDIT"
+                    />
+                </div>
                 <div class="widget-container">
                     <GenericWidget
                         :graph-slug="props.graphSlug"

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptNote/components/ConceptNoteViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptNote/components/ConceptNoteViewer.vue
@@ -69,9 +69,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
     type: $gettext("Type"),
     noRecords: $gettext("No concept notes were found."),
     sortFields: {
-        name: "aliased_data.statement_content.display_value",
-        type: "aliased_data.statement_type.display_value",
-        language: "aliased_data.statement_language.display_value",
+        name: "aliased_data.statement_content",
+        type: "aliased_data.statement_type",
+        language: "aliased_data.statement_language",
     },
 }));
 </script>
@@ -120,9 +120,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_content"
                     :graph-slug="props.graphSlug"
-                    :node-value="
-                        rowData.aliased_data.statement_content?.node_value
-                    "
+                    :value="rowData.aliased_data.statement_content ?? null"
                     :mode="VIEW"
                     :should-show-label="false"
                 />
@@ -131,9 +129,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_type"
                     :graph-slug="props.graphSlug"
-                    :node-value="
-                        rowData.aliased_data.statement_type?.node_value
-                    "
+                    :value="rowData.aliased_data.statement_type ?? null"
                     :mode="VIEW"
                     :should-show-label="false"
                 />
@@ -142,9 +138,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_language"
                     :graph-slug="props.graphSlug"
-                    :node-value="
-                        rowData.aliased_data.statement_language?.node_value
-                    "
+                    :value="rowData.aliased_data.statement_language ?? null"
                     :mode="VIEW"
                     :should-show-label="false"
                 />
@@ -153,18 +147,18 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_data_assignment_object_used"
                     :graph-slug="props.graphSlug"
-                    :node-value="
+                    :value="
                         rowData.aliased_data
-                            .statement_data_assignment_object_used?.node_value
+                            .statement_data_assignment_object_used ?? null
                     "
                     :mode="VIEW"
                 />
                 <GenericWidget
                     node-alias="statement_data_assignment_actor"
                     :graph-slug="props.graphSlug"
-                    :node-value="
-                        rowData.aliased_data.statement_data_assignment_actor
-                            ?.node_value
+                    :value="
+                        rowData.aliased_data.statement_data_assignment_actor ??
+                        null
                     "
                     :mode="VIEW"
                 />

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptNote/components/ConceptNoteViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptNote/components/ConceptNoteViewer.vue
@@ -120,7 +120,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_content"
                     :graph-slug="props.graphSlug"
-                    :aliased-node-data="rowData.aliased_data.statement_content"
+                    :node-value="
+                        rowData.aliased_data.statement_content?.node_value
+                    "
                     :mode="VIEW"
                     :should-show-label="false"
                 />
@@ -129,7 +131,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_type"
                     :graph-slug="props.graphSlug"
-                    :aliased-node-data="rowData.aliased_data.statement_type"
+                    :node-value="
+                        rowData.aliased_data.statement_type?.node_value
+                    "
                     :mode="VIEW"
                     :should-show-label="false"
                 />
@@ -138,7 +142,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_language"
                     :graph-slug="props.graphSlug"
-                    :aliased-node-data="rowData.aliased_data.statement_language"
+                    :node-value="
+                        rowData.aliased_data.statement_language?.node_value
+                    "
                     :mode="VIEW"
                     :should-show-label="false"
                 />
@@ -147,17 +153,18 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_data_assignment_object_used"
                     :graph-slug="props.graphSlug"
-                    :aliased-node-data="
+                    :node-value="
                         rowData.aliased_data
-                            .statement_data_assignment_object_used
+                            .statement_data_assignment_object_used?.node_value
                     "
                     :mode="VIEW"
                 />
                 <GenericWidget
                     node-alias="statement_data_assignment_actor"
                     :graph-slug="props.graphSlug"
-                    :aliased-node-data="
+                    :node-value="
                         rowData.aliased_data.statement_data_assignment_actor
+                            ?.node_value
                     "
                     :mode="VIEW"
                 />

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptNote/components/ConceptNoteViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptNote/components/ConceptNoteViewer.vue
@@ -69,9 +69,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
     type: $gettext("Type"),
     noRecords: $gettext("No concept notes were found."),
     sortFields: {
-        name: "aliased_data.statement_content",
-        type: "aliased_data.statement_type",
-        language: "aliased_data.statement_language",
+        name: "aliased_data.statement_content.display_value",
+        type: "aliased_data.statement_type.display_value",
+        language: "aliased_data.statement_language.display_value",
     },
 }));
 </script>
@@ -120,7 +120,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_content"
                     :graph-slug="props.graphSlug"
-                    :value="rowData.aliased_data.statement_content ?? null"
+                    :aliased-node-data="
+                        rowData.aliased_data.statement_content ?? null
+                    "
                     :mode="VIEW"
                     :should-show-label="false"
                 />
@@ -129,7 +131,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_type"
                     :graph-slug="props.graphSlug"
-                    :value="rowData.aliased_data.statement_type ?? null"
+                    :aliased-node-data="
+                        rowData.aliased_data.statement_type ?? null
+                    "
                     :mode="VIEW"
                     :should-show-label="false"
                 />
@@ -138,7 +142,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_language"
                     :graph-slug="props.graphSlug"
-                    :value="rowData.aliased_data.statement_language ?? null"
+                    :aliased-node-data="
+                        rowData.aliased_data.statement_language ?? null
+                    "
                     :mode="VIEW"
                     :should-show-label="false"
                 />
@@ -147,7 +153,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_data_assignment_object_used"
                     :graph-slug="props.graphSlug"
-                    :value="
+                    :aliased-node-data="
                         rowData.aliased_data
                             .statement_data_assignment_object_used ?? null
                     "
@@ -156,7 +162,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_data_assignment_actor"
                     :graph-slug="props.graphSlug"
-                    :value="
+                    :aliased-node-data="
                         rowData.aliased_data.statement_data_assignment_actor ??
                         null
                     "

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptNote/components/ConceptNoteViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptNote/components/ConceptNoteViewer.vue
@@ -6,7 +6,7 @@ import Button from "primevue/button";
 import Tag from "primevue/tag";
 
 import MetaStringViewer from "@/arches_lingo/components/generic/MetaStringViewer.vue";
-import GenericWidget from "@/arches_component_lab/generics/GenericWidget/GenericWidget.vue";
+import GenericWidget from "@/arches_vue_components/generics/GenericWidget/GenericWidget.vue";
 
 import { VIEW } from "@/arches_lingo/constants.ts";
 import { useUserStore } from "@/arches_lingo/stores/useUserStore.ts";

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/ConceptRelationship.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/ConceptRelationship.vue
@@ -113,7 +113,6 @@ async function getSectionValue() {
             "
             :tile-id="props.tileId"
             :scheme="schemeId"
-            :exclude="false"
         />
     </template>
 </template>

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/ConceptRelationship.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/ConceptRelationship.vue
@@ -9,7 +9,7 @@ import ConceptRelationshipViewer from "@/arches_lingo/components/concept/Concept
 
 import { EDIT, VIEW } from "@/arches_lingo/constants.ts";
 
-import { fetchTileData } from "@/arches_component_lab/generics/GenericCard/api.ts";
+import { fetchTileData } from "@/arches_vue_components/generics/GenericCard/api.ts";
 import { fetchConceptRelationships } from "@/arches_lingo/api.ts";
 
 import type {

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/components/ConceptRelationshipEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/components/ConceptRelationshipEditor.vue
@@ -144,26 +144,28 @@ async function save(e: FormSubmitEvent) {
                     :scheme="props.scheme"
                     :mode="EDIT"
                 />
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="relation_status_ascribed_relation"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data
-                            .relation_status_ascribed_relation ?? null
-                    "
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="relation_status_status"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data.relation_status_status ??
-                        null
-                    "
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="relation_status_ascribed_relation"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data
+                                .relation_status_ascribed_relation ?? null
+                        "
+                        :mode="EDIT"
+                    />
+                </div>
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="relation_status_status"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data
+                                .relation_status_status ?? null
+                        "
+                        :mode="EDIT"
+                    />
+                </div>
                 <div class="widget-container">
                     <GenericWidget
                         :graph-slug="props.graphSlug"
@@ -185,26 +187,29 @@ async function save(e: FormSubmitEvent) {
                         :mode="EDIT"
                     />
                 </div>
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="relation_status_data_assignment_actor"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data
-                            .relation_status_data_assignment_actor ?? null
-                    "
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
-                <GenericWidget
-                    :graph-slug="props.graphSlug"
-                    node-alias="relation_status_data_assignment_object_used"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data
-                            .relation_status_data_assignment_object_used ?? null
-                    "
-                    :mode="EDIT"
-                    class="widget-container column"
-                />
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="relation_status_data_assignment_actor"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data
+                                .relation_status_data_assignment_actor ?? null
+                        "
+                        :mode="EDIT"
+                    />
+                </div>
+                <div class="widget-container column">
+                    <GenericWidget
+                        :graph-slug="props.graphSlug"
+                        node-alias="relation_status_data_assignment_object_used"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data
+                                .relation_status_data_assignment_object_used ??
+                            null
+                        "
+                        :mode="EDIT"
+                    />
+                </div>
             </Form>
         </div>
     </div>

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/components/ConceptRelationshipEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/components/ConceptRelationshipEditor.vue
@@ -94,9 +94,8 @@ async function save(e: FormSubmitEvent) {
             props.tileId,
         );
 
+        await refreshReportSection!(props.componentName);
         openEditor!(props.componentName, updatedTileId);
-
-        refreshReportSection!(props.componentName);
     } catch (error) {
         toast.add({
             severity: ERROR,
@@ -138,9 +137,9 @@ async function save(e: FormSubmitEvent) {
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_ascribed_comparate"
                     :resource-instance-id="props.resourceInstanceId"
-                    :aliased-node-data="
+                    :node-value="
                         props.tileData?.aliased_data
-                            .relation_status_ascribed_comparate
+                            .relation_status_ascribed_comparate?.node_value
                     "
                     :scheme="props.scheme"
                     :mode="EDIT"
@@ -148,9 +147,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_ascribed_relation"
-                    :aliased-node-data="
+                    :node-value="
                         props.tileData?.aliased_data
-                            .relation_status_ascribed_relation
+                            .relation_status_ascribed_relation?.node_value
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -158,8 +157,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_status"
-                    :aliased-node-data="
+                    :node-value="
                         props.tileData?.aliased_data.relation_status_status
+                            ?.node_value
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -168,18 +168,20 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="relation_status_timespan_begin_of_the_begin"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data
                                 .relation_status_timespan_begin_of_the_begin
+                                ?.node_value
                         "
                         :mode="EDIT"
                     />
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="relation_status_timespan_end_of_the_end"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data
                                 .relation_status_timespan_end_of_the_end
+                                ?.node_value
                         "
                         :mode="EDIT"
                     />
@@ -187,9 +189,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_data_assignment_actor"
-                    :aliased-node-data="
+                    :node-value="
                         props.tileData?.aliased_data
-                            .relation_status_data_assignment_actor
+                            .relation_status_data_assignment_actor?.node_value
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -197,9 +199,10 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_data_assignment_object_used"
-                    :aliased-node-data="
+                    :node-value="
                         props.tileData?.aliased_data
                             .relation_status_data_assignment_object_used
+                            ?.node_value
                     "
                     :mode="EDIT"
                     class="widget-container column"

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/components/ConceptRelationshipEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/components/ConceptRelationshipEditor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, inject, ref, useTemplateRef, watch } from "vue";
+import { inject, ref, useTemplateRef, watch } from "vue";
 
 import { useRoute, useRouter } from "vue-router";
 import { useGettext } from "vue3-gettext";
@@ -53,13 +53,6 @@ const onSaveSettled = inject<() => void>("onSaveSettled");
 
 const formRef = useTemplateRef("form");
 const isSaving = ref(false);
-
-const comparateNodeValue = computed(function () {
-    return (
-        props.tileData?.aliased_data.relation_status_ascribed_comparate
-            ?.node_value ?? null
-    );
-});
 
 watch(
     () => formRef.value,
@@ -144,7 +137,10 @@ async function save(e: FormSubmitEvent) {
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_ascribed_comparate"
                     :resource-instance-id="props.resourceInstanceId"
-                    :value="comparateNodeValue"
+                    :aliased-node-data="
+                        props.tileData?.aliased_data
+                            .relation_status_ascribed_comparate ?? null
+                    "
                     :scheme="props.scheme"
                     :mode="EDIT"
                 />

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/components/ConceptRelationshipEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/components/ConceptRelationshipEditor.vue
@@ -23,7 +23,6 @@ import {
 import type { Component, Ref } from "vue";
 import type { FormSubmitEvent } from "@primevue/forms";
 import type { ConceptRelationStatus } from "@/arches_lingo/types.ts";
-import type { ResourceInstanceReference } from "@/arches_component_lab/datatypes/resource-instance-list/types";
 
 const props = defineProps<{
     tileData: ConceptRelationStatus | undefined;
@@ -56,8 +55,10 @@ const formRef = useTemplateRef("form");
 const isSaving = ref(false);
 
 const comparateNodeValue = computed(function () {
-    return (props.tileData?.aliased_data.relation_status_ascribed_comparate ??
-        null) as ResourceInstanceReference[] | null;
+    return (
+        props.tileData?.aliased_data.relation_status_ascribed_comparate
+            ?.node_value ?? null
+    );
 });
 
 watch(

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/components/ConceptRelationshipEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/components/ConceptRelationshipEditor.vue
@@ -150,7 +150,7 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_ascribed_relation"
-                    :value="
+                    :aliased-node-data="
                         props.tileData?.aliased_data
                             .relation_status_ascribed_relation ?? null
                     "
@@ -160,7 +160,7 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_status"
-                    :value="
+                    :aliased-node-data="
                         props.tileData?.aliased_data.relation_status_status ??
                         null
                     "
@@ -171,7 +171,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="relation_status_timespan_begin_of_the_begin"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data
                                 .relation_status_timespan_begin_of_the_begin ??
                             null
@@ -181,7 +181,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="relation_status_timespan_end_of_the_end"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data
                                 .relation_status_timespan_end_of_the_end ?? null
                         "
@@ -191,7 +191,7 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_data_assignment_actor"
-                    :value="
+                    :aliased-node-data="
                         props.tileData?.aliased_data
                             .relation_status_data_assignment_actor ?? null
                     "
@@ -201,7 +201,7 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_data_assignment_object_used"
-                    :value="
+                    :aliased-node-data="
                         props.tileData?.aliased_data
                             .relation_status_data_assignment_object_used ?? null
                     "

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/components/ConceptRelationshipEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/components/ConceptRelationshipEditor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { inject, ref, useTemplateRef, watch } from "vue";
+import { computed, inject, ref, useTemplateRef, watch } from "vue";
 
 import { useRoute, useRouter } from "vue-router";
 import { useGettext } from "vue3-gettext";
@@ -23,6 +23,7 @@ import {
 import type { Component, Ref } from "vue";
 import type { FormSubmitEvent } from "@primevue/forms";
 import type { ConceptRelationStatus } from "@/arches_lingo/types.ts";
+import type { ResourceInstanceReference } from "@/arches_component_lab/datatypes/resource-instance-list/types";
 
 const props = defineProps<{
     tileData: ConceptRelationStatus | undefined;
@@ -53,6 +54,11 @@ const onSaveSettled = inject<() => void>("onSaveSettled");
 
 const formRef = useTemplateRef("form");
 const isSaving = ref(false);
+
+const comparateNodeValue = computed(function () {
+    return (props.tileData?.aliased_data.relation_status_ascribed_comparate ??
+        null) as ResourceInstanceReference[] | null;
+});
 
 watch(
     () => formRef.value,
@@ -137,19 +143,16 @@ async function save(e: FormSubmitEvent) {
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_ascribed_comparate"
                     :resource-instance-id="props.resourceInstanceId"
-                    :node-value="
-                        props.tileData?.aliased_data
-                            .relation_status_ascribed_comparate?.node_value
-                    "
+                    :value="comparateNodeValue"
                     :scheme="props.scheme"
                     :mode="EDIT"
                 />
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_ascribed_relation"
-                    :node-value="
+                    :value="
                         props.tileData?.aliased_data
-                            .relation_status_ascribed_relation?.node_value
+                            .relation_status_ascribed_relation ?? null
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -157,9 +160,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_status"
-                    :node-value="
-                        props.tileData?.aliased_data.relation_status_status
-                            ?.node_value
+                    :value="
+                        props.tileData?.aliased_data.relation_status_status ??
+                        null
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -168,20 +171,19 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="relation_status_timespan_begin_of_the_begin"
-                        :node-value="
+                        :value="
                             props.tileData?.aliased_data
-                                .relation_status_timespan_begin_of_the_begin
-                                ?.node_value
+                                .relation_status_timespan_begin_of_the_begin ??
+                            null
                         "
                         :mode="EDIT"
                     />
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="relation_status_timespan_end_of_the_end"
-                        :node-value="
+                        :value="
                             props.tileData?.aliased_data
-                                .relation_status_timespan_end_of_the_end
-                                ?.node_value
+                                .relation_status_timespan_end_of_the_end ?? null
                         "
                         :mode="EDIT"
                     />
@@ -189,9 +191,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_data_assignment_actor"
-                    :node-value="
+                    :value="
                         props.tileData?.aliased_data
-                            .relation_status_data_assignment_actor?.node_value
+                            .relation_status_data_assignment_actor ?? null
                     "
                     :mode="EDIT"
                     class="widget-container column"
@@ -199,10 +201,9 @@ async function save(e: FormSubmitEvent) {
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_data_assignment_object_used"
-                    :node-value="
+                    :value="
                         props.tileData?.aliased_data
-                            .relation_status_data_assignment_object_used
-                            ?.node_value
+                            .relation_status_data_assignment_object_used ?? null
                     "
                     :mode="EDIT"
                     class="widget-container column"

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/components/ConceptRelationshipEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/components/ConceptRelationshipEditor.vue
@@ -9,7 +9,7 @@ import { Form } from "@primevue/forms";
 
 import Skeleton from "primevue/skeleton";
 
-import GenericWidget from "@/arches_component_lab/generics/GenericWidget/GenericWidget.vue";
+import GenericWidget from "@/arches_vue_components/generics/GenericWidget/GenericWidget.vue";
 import ConceptResourceSelectWidget from "@/arches_lingo/components/widgets/ConceptResourceSelectWidget/ConceptResourceSelectWidget.vue";
 
 import { createOrUpdateConcept } from "@/arches_lingo/utils.ts";

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/components/ConceptRelationshipViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/components/ConceptRelationshipViewer.vue
@@ -128,8 +128,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_ascribed_relation"
-                    :aliased-node-data="
+                    :node-value="
                         rowData.aliased_data.relation_status_ascribed_relation
+                            ?.node_value
                     "
                     :mode="VIEW"
                     :should-show-label="false"
@@ -139,8 +140,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <ConceptResourceSelectWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_ascribed_comparate"
-                    :aliased-node-data="
+                    :node-value="
                         rowData.aliased_data.relation_status_ascribed_comparate
+                            ?.node_value
                     "
                     :mode="VIEW"
                     :should-show-label="false"
@@ -150,17 +152,18 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_data_assignment_actor"
-                    :aliased-node-data="
+                    :node-value="
                         rowData.aliased_data
-                            .relation_status_data_assignment_actor
+                            .relation_status_data_assignment_actor?.node_value
                     "
                     :mode="VIEW"
                 />
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_data_assignment_object_used"
-                    :aliased-node-data="
+                    :node-value="
                         rowData.relation_status_data_assignment_object_used
+                            ?.node_value
                     "
                     :mode="VIEW"
                 />

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/components/ConceptRelationshipViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/components/ConceptRelationshipViewer.vue
@@ -76,10 +76,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
     type: $gettext("Related Concept"),
     noRecords: $gettext("No associated concepts were found."),
     sortFields: {
-        name: "aliased_data.relation_status_ascribed_comparate.display_value",
-        type: "aliased_data.relation_status_ascribed_relation.display_value",
-        language:
-            "aliased_data.relation_status_ascribed_comparate.display_value",
+        name: "aliased_data.relation_status_ascribed_comparate",
+        type: "aliased_data.relation_status_ascribed_relation",
+        language: "aliased_data.relation_status_ascribed_comparate",
     },
 }));
 </script>
@@ -128,9 +127,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_ascribed_relation"
-                    :node-value="
-                        rowData.aliased_data.relation_status_ascribed_relation
-                            ?.node_value
+                    :value="
+                        rowData.aliased_data
+                            .relation_status_ascribed_relation ?? null
                     "
                     :mode="VIEW"
                     :should-show-label="false"
@@ -140,9 +139,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <ConceptResourceSelectWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_ascribed_comparate"
-                    :node-value="
-                        rowData.aliased_data.relation_status_ascribed_comparate
-                            ?.node_value
+                    :value="
+                        rowData.aliased_data
+                            .relation_status_ascribed_comparate ?? null
                     "
                     :mode="VIEW"
                     :should-show-label="false"
@@ -152,18 +151,18 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_data_assignment_actor"
-                    :node-value="
+                    :value="
                         rowData.aliased_data
-                            .relation_status_data_assignment_actor?.node_value
+                            .relation_status_data_assignment_actor ?? null
                     "
                     :mode="VIEW"
                 />
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_data_assignment_object_used"
-                    :node-value="
-                        rowData.relation_status_data_assignment_object_used
-                            ?.node_value
+                    :value="
+                        rowData.aliased_data
+                            .relation_status_data_assignment_object_used ?? null
                     "
                     :mode="VIEW"
                 />

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/components/ConceptRelationshipViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/components/ConceptRelationshipViewer.vue
@@ -76,9 +76,10 @@ const metaStringLabel = computed<MetaStringText>(() => ({
     type: $gettext("Related Concept"),
     noRecords: $gettext("No associated concepts were found."),
     sortFields: {
-        name: "aliased_data.relation_status_ascribed_comparate",
-        type: "aliased_data.relation_status_ascribed_relation",
-        language: "aliased_data.relation_status_ascribed_comparate",
+        name: "aliased_data.relation_status_ascribed_comparate.display_value",
+        type: "aliased_data.relation_status_ascribed_relation.display_value",
+        language:
+            "aliased_data.relation_status_ascribed_comparate.display_value",
     },
 }));
 </script>
@@ -127,7 +128,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_ascribed_relation"
-                    :value="
+                    :aliased-node-data="
                         rowData.aliased_data
                             .relation_status_ascribed_relation ?? null
                     "
@@ -139,7 +140,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <ConceptResourceSelectWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_ascribed_comparate"
-                    :value="
+                    :aliased-node-data="
                         rowData.aliased_data
                             .relation_status_ascribed_comparate ?? null
                     "
@@ -151,7 +152,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_data_assignment_actor"
-                    :value="
+                    :aliased-node-data="
                         rowData.aliased_data
                             .relation_status_data_assignment_actor ?? null
                     "
@@ -160,7 +161,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="relation_status_data_assignment_object_used"
-                    :value="
+                    :aliased-node-data="
                         rowData.aliased_data
                             .relation_status_data_assignment_object_used ?? null
                     "

--- a/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/components/ConceptRelationshipViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/ConceptRelationship/components/ConceptRelationshipViewer.vue
@@ -6,7 +6,7 @@ import Button from "primevue/button";
 import Tag from "primevue/tag";
 
 import MetaStringViewer from "@/arches_lingo/components/generic/MetaStringViewer.vue";
-import GenericWidget from "@/arches_component_lab/generics/GenericWidget/GenericWidget.vue";
+import GenericWidget from "@/arches_vue_components/generics/GenericWidget/GenericWidget.vue";
 import ConceptResourceSelectWidget from "@/arches_lingo/components/widgets/ConceptResourceSelectWidget/ConceptResourceSelectWidget.vue";
 
 import { VIEW } from "@/arches_lingo/constants.ts";

--- a/arches_lingo/src/arches_lingo/components/concept/HierarchicalPosition/HierarchicalPosition.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/HierarchicalPosition/HierarchicalPosition.vue
@@ -109,11 +109,16 @@ watch(
                 const pathLength = datum.searchResults.length;
                 const parentId = datum.searchResults[pathLength - 2]?.id;
                 if (!parentId) continue;
-                const match = tileData.value?.find((tile) =>
-                    tile.aliased_data.classification_status_ascribed_classification.node_value?.some(
-                        (nodeValue) => nodeValue.resourceId === parentId,
-                    ),
-                );
+                const match = tileData.value?.find((tile) => {
+                    const refs = tile.aliased_data
+                        .classification_status_ascribed_classification as Array<{
+                        resourceinstanceid: string;
+                    }> | null;
+                    return refs?.some(
+                        (nodeValue) =>
+                            nodeValue.resourceinstanceid === parentId,
+                    );
+                });
                 if (match) datum.tileid = match.tileid;
             }
         } catch (error) {

--- a/arches_lingo/src/arches_lingo/components/concept/HierarchicalPosition/HierarchicalPosition.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/HierarchicalPosition/HierarchicalPosition.vue
@@ -110,13 +110,11 @@ watch(
                 const parentId = datum.searchResults[pathLength - 2]?.id;
                 if (!parentId) continue;
                 const match = tileData.value?.find((tile) => {
-                    const refs = tile.aliased_data
-                        .classification_status_ascribed_classification as Array<{
-                        resourceinstanceid: string;
-                    }> | null;
-                    return refs?.some(
-                        (nodeValue) =>
-                            nodeValue.resourceinstanceid === parentId,
+                    const nodeData =
+                        tile.aliased_data
+                            .classification_status_ascribed_classification;
+                    return nodeData?.node_value?.some(
+                        (nodeValue) => nodeValue.resourceId === parentId,
                     );
                 });
                 if (match) datum.tileid = match.tileid;

--- a/arches_lingo/src/arches_lingo/components/concept/HierarchicalPosition/HierarchicalPosition.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/HierarchicalPosition/HierarchicalPosition.vue
@@ -9,7 +9,7 @@ import HierarchicalPositionEditor from "@/arches_lingo/components/concept/Hierar
 
 import { EDIT, VIEW } from "@/arches_lingo/constants.ts";
 
-import { fetchTileData } from "@/arches_component_lab/generics/GenericCard/api.ts";
+import { fetchTileData } from "@/arches_vue_components/generics/GenericCard/api.ts";
 import { fetchConceptAncestorPaths } from "@/arches_lingo/api.ts";
 import { useResourceStore } from "@/arches_lingo/composables/useResourceStore.ts";
 

--- a/arches_lingo/src/arches_lingo/components/concept/HierarchicalPosition/components/HierarchicalPositionEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/HierarchicalPosition/components/HierarchicalPositionEditor.vue
@@ -101,13 +101,13 @@ async function save(e: FormSubmitEvent) {
             updatedTileId = updatedConcept.tileid;
         }
 
-        openEditor!(props.componentName, updatedTileId);
         refreshSchemeHierarchy!();
+        await refreshReportSection!(props.componentName);
+        openEditor!(props.componentName, updatedTileId);
     } catch (error) {
         console.error(error);
     } finally {
         isSaving.value = false;
-        refreshReportSection!(props.componentName);
         onSaveSettled?.();
     }
 }
@@ -135,9 +135,10 @@ async function save(e: FormSubmitEvent) {
                 <ConceptResourceSelectWidget
                     :graph-slug="props.graphSlug"
                     node-alias="classification_status_ascribed_classification"
-                    :aliased-node-data="
+                    :node-value="
                         props.tileData?.aliased_data
                             .classification_status_ascribed_classification
+                            ?.node_value
                     "
                     :mode="EDIT"
                     :scheme="props.scheme"

--- a/arches_lingo/src/arches_lingo/components/concept/HierarchicalPosition/components/HierarchicalPositionEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/HierarchicalPosition/components/HierarchicalPositionEditor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { inject, ref, useTemplateRef, watch } from "vue";
+import { computed, inject, ref, useTemplateRef, watch } from "vue";
 import { useGettext } from "vue3-gettext";
 
 import { useRouter } from "vue-router";
@@ -15,6 +15,7 @@ import { EDIT } from "@/arches_lingo/constants.ts";
 import type { Component, Ref } from "vue";
 import type { FormSubmitEvent } from "@primevue/forms";
 import type { ConceptClassificationStatus } from "@/arches_lingo/types.ts";
+import type { ResourceInstanceReference } from "@/arches_component_lab/datatypes/resource-instance-list/types";
 
 const { $gettext } = useGettext();
 
@@ -46,6 +47,13 @@ const onSaveSettled = inject<() => void>("onSaveSettled");
 
 const formRef = useTemplateRef("form");
 const isSaving = ref(false);
+
+const classificationNodeValue = computed(function () {
+    return (props.tileData?.aliased_data
+        .classification_status_ascribed_classification ?? null) as
+        | ResourceInstanceReference[]
+        | null;
+});
 
 watch(
     () => formRef.value,
@@ -135,11 +143,7 @@ async function save(e: FormSubmitEvent) {
                 <ConceptResourceSelectWidget
                     :graph-slug="props.graphSlug"
                     node-alias="classification_status_ascribed_classification"
-                    :node-value="
-                        props.tileData?.aliased_data
-                            .classification_status_ascribed_classification
-                            ?.node_value
-                    "
+                    :value="classificationNodeValue"
                     :mode="EDIT"
                     :scheme="props.scheme"
                 />

--- a/arches_lingo/src/arches_lingo/components/concept/HierarchicalPosition/components/HierarchicalPositionEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/HierarchicalPosition/components/HierarchicalPositionEditor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, inject, ref, useTemplateRef, watch } from "vue";
+import { inject, ref, useTemplateRef, watch } from "vue";
 import { useGettext } from "vue3-gettext";
 
 import { useRouter } from "vue-router";
@@ -46,13 +46,6 @@ const onSaveSettled = inject<() => void>("onSaveSettled");
 
 const formRef = useTemplateRef("form");
 const isSaving = ref(false);
-
-const classificationNodeValue = computed(function () {
-    return (
-        props.tileData?.aliased_data
-            .classification_status_ascribed_classification?.node_value ?? null
-    );
-});
 
 watch(
     () => formRef.value,
@@ -142,7 +135,11 @@ async function save(e: FormSubmitEvent) {
                 <ConceptResourceSelectWidget
                     :graph-slug="props.graphSlug"
                     node-alias="classification_status_ascribed_classification"
-                    :value="classificationNodeValue"
+                    :aliased-node-data="
+                        props.tileData?.aliased_data
+                            .classification_status_ascribed_classification ??
+                        null
+                    "
                     :mode="EDIT"
                     :scheme="props.scheme"
                 />

--- a/arches_lingo/src/arches_lingo/components/concept/HierarchicalPosition/components/HierarchicalPositionEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/HierarchicalPosition/components/HierarchicalPositionEditor.vue
@@ -15,7 +15,6 @@ import { EDIT } from "@/arches_lingo/constants.ts";
 import type { Component, Ref } from "vue";
 import type { FormSubmitEvent } from "@primevue/forms";
 import type { ConceptClassificationStatus } from "@/arches_lingo/types.ts";
-import type { ResourceInstanceReference } from "@/arches_component_lab/datatypes/resource-instance-list/types";
 
 const { $gettext } = useGettext();
 
@@ -49,10 +48,10 @@ const formRef = useTemplateRef("form");
 const isSaving = ref(false);
 
 const classificationNodeValue = computed(function () {
-    return (props.tileData?.aliased_data
-        .classification_status_ascribed_classification ?? null) as
-        | ResourceInstanceReference[]
-        | null;
+    return (
+        props.tileData?.aliased_data
+            .classification_status_ascribed_classification?.node_value ?? null
+    );
 });
 
 watch(

--- a/arches_lingo/src/arches_lingo/components/concept/HierarchicalPosition/components/HierarchicalPositionEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/concept/HierarchicalPosition/components/HierarchicalPositionEditor.vue
@@ -37,6 +37,9 @@ const componentEditorFormRef = inject<Ref<Component | null>>(
 
 const closeEditor = inject<() => void>("closeEditor");
 
+const refreshReportSection = inject<(componentName: string) => void>(
+    "refreshReportSection",
+);
 const refreshSchemeHierarchy = inject<() => void>("refreshSchemeHierarchy");
 const onSaveSettled = inject<() => void>("onSaveSettled");
 
@@ -93,6 +96,7 @@ async function save(e: FormSubmitEvent) {
         console.error(error);
     } finally {
         isSaving.value = false;
+        refreshReportSection!(props.componentName);
         onSaveSettled?.();
     }
 }

--- a/arches_lingo/src/arches_lingo/components/dashboard/MissingTranslationsPanel.vue
+++ b/arches_lingo/src/arches_lingo/components/dashboard/MissingTranslationsPanel.vue
@@ -13,7 +13,7 @@ import { routeNames } from "@/arches_lingo/routes.ts";
 import { getItemLabel } from "@/arches_controlled_lists/utils.ts";
 import { useLanguageStore } from "@/arches_lingo/stores/useLanguageStore.ts";
 
-import type { Language } from "@/arches_component_lab/types.ts";
+import type { Language } from "@/arches_vue_components/types.ts";
 import type { MissingTranslationsResponse } from "@/arches_lingo/types/dashboard.ts";
 import type { SearchResultItem } from "@/arches_lingo/types.ts";
 

--- a/arches_lingo/src/arches_lingo/components/generic/ResourceNameCard/ResourceNameCard.vue
+++ b/arches_lingo/src/arches_lingo/components/generic/ResourceNameCard/ResourceNameCard.vue
@@ -5,10 +5,8 @@ import Message from "primevue/message";
 import Skeleton from "primevue/skeleton";
 
 import GenericCardEditor from "@/arches_component_lab/generics/GenericCard/components/GenericCardEditor.vue";
-import {
-    fetchTileData,
-    fetchCardXNodeXWidgetDataFromNodeGroup,
-} from "@/arches_component_lab/generics/GenericCard/api.ts";
+import { fetchTileData } from "@/arches_component_lab/generics/GenericCard/api.ts";
+import { useWidgetConfigStore } from "@/arches_component_lab/stores/useWidgetConfigStore.ts";
 
 import { EDIT } from "@/arches_component_lab/widgets/constants.ts";
 
@@ -68,7 +66,10 @@ watchEffect(async () => {
 
     try {
         const cardXNodeXWidgetDataPromise =
-            fetchCardXNodeXWidgetDataFromNodeGroup(graphSlug, nodegroupAlias);
+            useWidgetConfigStore().fetchNodegroupWidgetConfigs(
+                graphSlug,
+                nodegroupAlias,
+            );
 
         aliasedTileData.value = await fetchTileData(
             graphSlug,

--- a/arches_lingo/src/arches_lingo/components/generic/ResourceNameCard/ResourceNameCard.vue
+++ b/arches_lingo/src/arches_lingo/components/generic/ResourceNameCard/ResourceNameCard.vue
@@ -4,17 +4,17 @@ import { inject, reactive, ref, useTemplateRef, watch, watchEffect } from "vue";
 import Message from "primevue/message";
 import Skeleton from "primevue/skeleton";
 
-import GenericCardEditor from "@/arches_component_lab/generics/GenericCard/components/GenericCardEditor.vue";
-import { fetchTileData } from "@/arches_component_lab/generics/GenericCard/api.ts";
-import { useWidgetConfigStore } from "@/arches_component_lab/stores/useWidgetConfigStore.ts";
+import GenericCardEditor from "@/arches_vue_components/generics/GenericCard/components/GenericCardEditor.vue";
+import { fetchTileData } from "@/arches_vue_components/generics/GenericCard/api.ts";
+import { useNodegroupWidgetConfigStore } from "@/arches_vue_components/stores/useNodegroupWidgetConfigStore.ts";
 
-import { EDIT } from "@/arches_component_lab/widgets/constants.ts";
+import { EDIT } from "@/arches_vue_components/widgets/constants.ts";
 
 import type { Ref } from "vue";
 import type {
     AliasedTileData,
     CardXNodeXWidgetData,
-} from "@/arches_component_lab/types.ts";
+} from "@/arches_vue_components/types.ts";
 
 const { graphSlug, nodegroupAlias, resourceInstanceId, tileId } = defineProps<{
     graphSlug: string;
@@ -66,7 +66,7 @@ watchEffect(async () => {
 
     try {
         const cardXNodeXWidgetDataPromise =
-            useWidgetConfigStore().fetchNodegroupWidgetConfigs(
+            useNodegroupWidgetConfigStore().fetchNodegroupWidgetConfigs(
                 graphSlug,
                 nodegroupAlias,
             );

--- a/arches_lingo/src/arches_lingo/components/header/PageHeader/components/NotificationsInteraction/components/NotificationsPanel.vue
+++ b/arches_lingo/src/arches_lingo/components/header/PageHeader/components/NotificationsInteraction/components/NotificationsPanel.vue
@@ -22,8 +22,7 @@ const shouldShowNotificationsPanel = defineModel(
         default: false,
     },
 );
-const notifications = defineModel("notifications", {
-    type: Array as () => Notification[],
+const notifications = defineModel<Notification[]>("notifications", {
     default: () => [],
 });
 const showUnreadOnly = defineModel("showUnreadOnly", {

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeHeader/SchemeHeader.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeHeader/SchemeHeader.vue
@@ -238,8 +238,10 @@ const defaultSchemeURITemplate = computed(() => {
 });
 
 const schemeUri = computed(() => {
-    return scheme.value?.aliased_data?.uri?.aliased_data?.uri_content
-        ?.node_value;
+    return scheme.value?.aliased_data?.uri?.aliased_data?.uri_content as
+        | string
+        | null
+        | undefined;
 });
 
 onMounted(async () => {

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeHeader/SchemeHeader.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeHeader/SchemeHeader.vue
@@ -238,10 +238,8 @@ const defaultSchemeURITemplate = computed(() => {
 });
 
 const schemeUri = computed(() => {
-    return scheme.value?.aliased_data?.uri?.aliased_data?.uri_content as
-        | string
-        | null
-        | undefined;
+    return scheme.value?.aliased_data?.uri?.aliased_data?.uri_content
+        ?.node_value?.url as string | null | undefined;
 });
 
 onMounted(async () => {

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeHeader/SchemeHeader.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeHeader/SchemeHeader.vue
@@ -238,8 +238,10 @@ const defaultSchemeURITemplate = computed(() => {
 });
 
 const schemeUri = computed(() => {
-    return scheme.value?.aliased_data?.uri?.aliased_data?.uri_content
-        ?.node_value?.url as string | null | undefined;
+    return (
+        scheme.value?.aliased_data?.uri?.aliased_data?.uri_content
+            ?.display_value || null
+    );
 });
 
 onMounted(async () => {

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeLabel/SchemeLabel.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeLabel/SchemeLabel.vue
@@ -9,7 +9,7 @@ import SchemeLabelViewer from "@/arches_lingo/components/scheme/SchemeLabel/comp
 
 import { EDIT, VIEW } from "@/arches_lingo/constants.ts";
 
-import { fetchTileData } from "@/arches_component_lab/generics/GenericCard/api.ts";
+import { fetchTileData } from "@/arches_vue_components/generics/GenericCard/api.ts";
 import { useResourceStore } from "@/arches_lingo/composables/useResourceStore.ts";
 
 import type {

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeLabel/components/SchemeLabelEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeLabel/components/SchemeLabelEditor.vue
@@ -110,9 +110,8 @@ async function save(e: FormSubmitEvent) {
             updatedTileId = updatedTile.tileid;
         }
 
+        await refreshReportSection!(props.componentName);
         openEditor!(props.componentName, updatedTileId);
-
-        refreshReportSection!(props.componentName);
         refreshSchemeHierarchy!();
     } catch (error) {
         toast.add({
@@ -154,9 +153,10 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="appellative_status_ascribed_name_content"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data
                                 .appellative_status_ascribed_name_content
+                                ?.node_value
                         "
                         :mode="EDIT"
                     />
@@ -165,9 +165,10 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="appellative_status_ascribed_relation"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data
                                 .appellative_status_ascribed_relation
+                                ?.node_value
                         "
                         :mode="EDIT"
                     />
@@ -176,9 +177,10 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="appellative_status_ascribed_name_language"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data
                                 .appellative_status_ascribed_name_language
+                                ?.node_value
                         "
                         :mode="EDIT"
                     />
@@ -187,9 +189,10 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="appellative_status_data_assignment_actor"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data
                                 ?.appellative_status_data_assignment_actor
+                                ?.node_value
                         "
                         :mode="EDIT"
                     />
@@ -198,9 +201,10 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="appellative_status_data_assignment_object_used"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data
                                 ?.appellative_status_data_assignment_object_used
+                                ?.node_value
                         "
                         :mode="EDIT"
                     />

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeLabel/components/SchemeLabelEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeLabel/components/SchemeLabelEditor.vue
@@ -153,10 +153,10 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="appellative_status_ascribed_name_content"
-                        :node-value="
+                        :value="
                             props.tileData?.aliased_data
-                                .appellative_status_ascribed_name_content
-                                ?.node_value
+                                .appellative_status_ascribed_name_content ??
+                            null
                         "
                         :mode="EDIT"
                     />
@@ -165,10 +165,9 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="appellative_status_ascribed_relation"
-                        :node-value="
+                        :value="
                             props.tileData?.aliased_data
-                                .appellative_status_ascribed_relation
-                                ?.node_value
+                                .appellative_status_ascribed_relation ?? null
                         "
                         :mode="EDIT"
                     />
@@ -177,10 +176,10 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="appellative_status_ascribed_name_language"
-                        :node-value="
+                        :value="
                             props.tileData?.aliased_data
-                                .appellative_status_ascribed_name_language
-                                ?.node_value
+                                .appellative_status_ascribed_name_language ??
+                            null
                         "
                         :mode="EDIT"
                     />
@@ -189,10 +188,10 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="appellative_status_data_assignment_actor"
-                        :node-value="
+                        :value="
                             props.tileData?.aliased_data
-                                ?.appellative_status_data_assignment_actor
-                                ?.node_value
+                                ?.appellative_status_data_assignment_actor ??
+                            null
                         "
                         :mode="EDIT"
                     />
@@ -201,10 +200,10 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="appellative_status_data_assignment_object_used"
-                        :node-value="
+                        :value="
                             props.tileData?.aliased_data
-                                ?.appellative_status_data_assignment_object_used
-                                ?.node_value
+                                ?.appellative_status_data_assignment_object_used ??
+                            null
                         "
                         :mode="EDIT"
                     />

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeLabel/components/SchemeLabelEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeLabel/components/SchemeLabelEditor.vue
@@ -153,7 +153,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="appellative_status_ascribed_name_content"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data
                                 .appellative_status_ascribed_name_content ??
                             null
@@ -165,7 +165,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="appellative_status_ascribed_relation"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data
                                 .appellative_status_ascribed_relation ?? null
                         "
@@ -176,7 +176,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="appellative_status_ascribed_name_language"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data
                                 .appellative_status_ascribed_name_language ??
                             null
@@ -188,7 +188,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="appellative_status_data_assignment_actor"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data
                                 ?.appellative_status_data_assignment_actor ??
                             null
@@ -200,7 +200,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="appellative_status_data_assignment_object_used"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data
                                 ?.appellative_status_data_assignment_object_used ??
                             null

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeLabel/components/SchemeLabelEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeLabel/components/SchemeLabelEditor.vue
@@ -9,7 +9,7 @@ import { Form } from "@primevue/forms";
 
 import Skeleton from "primevue/skeleton";
 
-import GenericWidget from "@/arches_component_lab/generics/GenericWidget/GenericWidget.vue";
+import GenericWidget from "@/arches_vue_components/generics/GenericWidget/GenericWidget.vue";
 
 import { createLingoResource, upsertLingoTile } from "@/arches_lingo/api.ts";
 

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeLabel/components/SchemeLabelViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeLabel/components/SchemeLabelViewer.vue
@@ -67,10 +67,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
     type: $gettext("Type"),
     noRecords: $gettext("No scheme labels were found."),
     sortFields: {
-        name: "aliased_data.appellative_status_ascribed_name_content.display_value",
-        type: "aliased_data.appellative_status_ascribed_relation.display_value",
-        language:
-            "aliased_data.appellative_status_ascribed_name_language.display_value",
+        name: "aliased_data.appellative_status_ascribed_name_content",
+        type: "aliased_data.appellative_status_ascribed_relation",
+        language: "aliased_data.appellative_status_ascribed_name_language",
     },
 }));
 </script>
@@ -119,10 +118,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_name_content"
-                    :node-value="
+                    :value="
                         rowData.aliased_data
-                            .appellative_status_ascribed_name_content
-                            ?.node_value
+                            .appellative_status_ascribed_name_content ?? null
                     "
                     :mode="VIEW"
                     :should-show-label="false"
@@ -132,9 +130,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_relation"
-                    :node-value="
+                    :value="
                         rowData.aliased_data
-                            .appellative_status_ascribed_relation?.node_value
+                            .appellative_status_ascribed_relation ?? null
                     "
                     :mode="VIEW"
                     :should-show-label="false"
@@ -144,10 +142,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_name_language"
-                    :node-value="
+                    :value="
                         rowData.aliased_data
-                            .appellative_status_ascribed_name_language
-                            ?.node_value
+                            .appellative_status_ascribed_name_language ?? null
                     "
                     :mode="VIEW"
                     :should-show-label="false"
@@ -157,20 +154,19 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_data_assignment_object_used"
-                    :node-value="
+                    :value="
                         rowData.aliased_data
-                            .appellative_status_data_assignment_object_used
-                            ?.node_value
+                            .appellative_status_data_assignment_object_used ??
+                        null
                     "
                     :mode="VIEW"
                 />
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_data_assignment_actor"
-                    :node-value="
+                    :value="
                         rowData.aliased_data
-                            .appellative_status_data_assignment_actor
-                            ?.node_value
+                            .appellative_status_data_assignment_actor ?? null
                     "
                     :mode="VIEW"
                 />

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeLabel/components/SchemeLabelViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeLabel/components/SchemeLabelViewer.vue
@@ -67,9 +67,10 @@ const metaStringLabel = computed<MetaStringText>(() => ({
     type: $gettext("Type"),
     noRecords: $gettext("No scheme labels were found."),
     sortFields: {
-        name: "aliased_data.appellative_status_ascribed_name_content",
-        type: "aliased_data.appellative_status_ascribed_relation",
-        language: "aliased_data.appellative_status_ascribed_name_language",
+        name: "aliased_data.appellative_status_ascribed_name_content.display_value",
+        type: "aliased_data.appellative_status_ascribed_relation.display_value",
+        language:
+            "aliased_data.appellative_status_ascribed_name_language.display_value",
     },
 }));
 </script>
@@ -118,7 +119,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_name_content"
-                    :value="
+                    :aliased-node-data="
                         rowData.aliased_data
                             .appellative_status_ascribed_name_content ?? null
                     "
@@ -130,7 +131,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_relation"
-                    :value="
+                    :aliased-node-data="
                         rowData.aliased_data
                             .appellative_status_ascribed_relation ?? null
                     "
@@ -142,7 +143,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_name_language"
-                    :value="
+                    :aliased-node-data="
                         rowData.aliased_data
                             .appellative_status_ascribed_name_language ?? null
                     "
@@ -154,7 +155,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_data_assignment_object_used"
-                    :value="
+                    :aliased-node-data="
                         rowData.aliased_data
                             .appellative_status_data_assignment_object_used ??
                         null
@@ -164,7 +165,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_data_assignment_actor"
-                    :value="
+                    :aliased-node-data="
                         rowData.aliased_data
                             .appellative_status_data_assignment_actor ?? null
                     "

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeLabel/components/SchemeLabelViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeLabel/components/SchemeLabelViewer.vue
@@ -119,9 +119,10 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_name_content"
-                    :aliased-node-data="
+                    :node-value="
                         rowData.aliased_data
                             .appellative_status_ascribed_name_content
+                            ?.node_value
                     "
                     :mode="VIEW"
                     :should-show-label="false"
@@ -131,9 +132,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_relation"
-                    :aliased-node-data="
+                    :node-value="
                         rowData.aliased_data
-                            .appellative_status_ascribed_relation
+                            .appellative_status_ascribed_relation?.node_value
                     "
                     :mode="VIEW"
                     :should-show-label="false"
@@ -143,9 +144,10 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_ascribed_name_language"
-                    :aliased-node-data="
+                    :node-value="
                         rowData.aliased_data
                             .appellative_status_ascribed_name_language
+                            ?.node_value
                     "
                     :mode="VIEW"
                     :should-show-label="false"
@@ -155,18 +157,20 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_data_assignment_object_used"
-                    :aliased-node-data="
+                    :node-value="
                         rowData.aliased_data
                             .appellative_status_data_assignment_object_used
+                            ?.node_value
                     "
                     :mode="VIEW"
                 />
                 <GenericWidget
                     :graph-slug="props.graphSlug"
                     node-alias="appellative_status_data_assignment_actor"
-                    :aliased-node-data="
+                    :node-value="
                         rowData.aliased_data
                             .appellative_status_data_assignment_actor
+                            ?.node_value
                     "
                     :mode="VIEW"
                 />

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeLabel/components/SchemeLabelViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeLabel/components/SchemeLabelViewer.vue
@@ -7,7 +7,7 @@ import Tag from "primevue/tag";
 
 import MetaStringViewer from "@/arches_lingo/components/generic/MetaStringViewer.vue";
 
-import GenericWidget from "@/arches_component_lab/generics/GenericWidget/GenericWidget.vue";
+import GenericWidget from "@/arches_vue_components/generics/GenericWidget/GenericWidget.vue";
 
 import { VIEW } from "@/arches_lingo/constants.ts";
 import { useUserStore } from "@/arches_lingo/stores/useUserStore.ts";

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeLicense/SchemeLicense.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeLicense/SchemeLicense.vue
@@ -9,7 +9,7 @@ import SchemeLicenseEditor from "@/arches_lingo/components/scheme/SchemeLicense/
 
 import { EDIT, VIEW } from "@/arches_lingo/constants.ts";
 
-import { fetchTileData } from "@/arches_component_lab/generics/GenericCard/api.ts";
+import { fetchTileData } from "@/arches_vue_components/generics/GenericCard/api.ts";
 import { useResourceStore } from "@/arches_lingo/composables/useResourceStore.ts";
 
 import type { DataComponentMode, SchemeRights } from "@/arches_lingo/types";

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeLicense/components/SchemeLicenseEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeLicense/components/SchemeLicenseEditor.vue
@@ -167,10 +167,9 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         node-alias="right_statement_content"
                         :graph-slug="props.graphSlug"
-                        :node-value="
+                        :value="
                             props.tileData?.aliased_data.right_statement
-                                ?.aliased_data.right_statement_content
-                                ?.node_value
+                                ?.aliased_data.right_statement_content ?? null
                         "
                         :mode="EDIT"
                     />
@@ -179,9 +178,9 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         node-alias="right_statement_type"
                         :graph-slug="props.graphSlug"
-                        :node-value="
+                        :value="
                             props.tileData?.aliased_data.right_statement
-                                ?.aliased_data.right_statement_type?.node_value
+                                ?.aliased_data.right_statement_type ?? null
                         "
                         :mode="EDIT"
                     />
@@ -190,10 +189,9 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         node-alias="right_statement_language"
                         :graph-slug="props.graphSlug"
-                        :node-value="
+                        :value="
                             props.tileData?.aliased_data.right_statement
-                                ?.aliased_data.right_statement_language
-                                ?.node_value
+                                ?.aliased_data.right_statement_language ?? null
                         "
                         :mode="EDIT"
                     />
@@ -202,9 +200,8 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         node-alias="right_holder"
                         :graph-slug="props.graphSlug"
-                        :node-value="
-                            props.tileData?.aliased_data.right_holder
-                                ?.node_value
+                        :value="
+                            props.tileData?.aliased_data.right_holder ?? null
                         "
                         :mode="EDIT"
                     />
@@ -213,9 +210,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         node-alias="right_type"
                         :graph-slug="props.graphSlug"
-                        :node-value="
-                            props.tileData?.aliased_data.right_type?.node_value
-                        "
+                        :value="props.tileData?.aliased_data.right_type ?? null"
                         :mode="EDIT"
                     />
                 </div>

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeLicense/components/SchemeLicenseEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeLicense/components/SchemeLicenseEditor.vue
@@ -125,9 +125,8 @@ async function save(e: FormSubmitEvent) {
             updatedTileId = updatedTile.tileid;
         }
 
+        await refreshReportSection!(props.componentName);
         openEditor!(props.componentName, updatedTileId);
-
-        refreshReportSection!(props.componentName);
     } catch (error) {
         toast.add({
             severity: ERROR,
@@ -168,9 +167,10 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         node-alias="right_statement_content"
                         :graph-slug="props.graphSlug"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data.right_statement
                                 ?.aliased_data.right_statement_content
+                                ?.node_value
                         "
                         :mode="EDIT"
                     />
@@ -179,9 +179,9 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         node-alias="right_statement_type"
                         :graph-slug="props.graphSlug"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data.right_statement
-                                ?.aliased_data.right_statement_type
+                                ?.aliased_data.right_statement_type?.node_value
                         "
                         :mode="EDIT"
                     />
@@ -190,9 +190,10 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         node-alias="right_statement_language"
                         :graph-slug="props.graphSlug"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data.right_statement
                                 ?.aliased_data.right_statement_language
+                                ?.node_value
                         "
                         :mode="EDIT"
                     />
@@ -201,8 +202,9 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         node-alias="right_holder"
                         :graph-slug="props.graphSlug"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data.right_holder
+                                ?.node_value
                         "
                         :mode="EDIT"
                     />
@@ -211,8 +213,8 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         node-alias="right_type"
                         :graph-slug="props.graphSlug"
-                        :aliased-node-data="
-                            props.tileData?.aliased_data.right_type
+                        :node-value="
+                            props.tileData?.aliased_data.right_type?.node_value
                         "
                         :mode="EDIT"
                     />

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeLicense/components/SchemeLicenseEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeLicense/components/SchemeLicenseEditor.vue
@@ -167,7 +167,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         node-alias="right_statement_content"
                         :graph-slug="props.graphSlug"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data.right_statement
                                 ?.aliased_data.right_statement_content ?? null
                         "
@@ -178,7 +178,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         node-alias="right_statement_type"
                         :graph-slug="props.graphSlug"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data.right_statement
                                 ?.aliased_data.right_statement_type ?? null
                         "
@@ -189,7 +189,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         node-alias="right_statement_language"
                         :graph-slug="props.graphSlug"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data.right_statement
                                 ?.aliased_data.right_statement_language ?? null
                         "
@@ -200,7 +200,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         node-alias="right_holder"
                         :graph-slug="props.graphSlug"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data.right_holder ?? null
                         "
                         :mode="EDIT"
@@ -210,7 +210,9 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         node-alias="right_type"
                         :graph-slug="props.graphSlug"
-                        :value="props.tileData?.aliased_data.right_type ?? null"
+                        :aliased-node-data="
+                            props.tileData?.aliased_data.right_type ?? null
+                        "
                         :mode="EDIT"
                     />
                 </div>

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeLicense/components/SchemeLicenseEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeLicense/components/SchemeLicenseEditor.vue
@@ -16,7 +16,7 @@ import { Form } from "@primevue/forms";
 
 import Skeleton from "primevue/skeleton";
 
-import GenericWidget from "@/arches_component_lab/generics/GenericWidget/GenericWidget.vue";
+import GenericWidget from "@/arches_vue_components/generics/GenericWidget/GenericWidget.vue";
 
 import { createLingoResource, upsertLingoTile } from "@/arches_lingo/api.ts";
 

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeLicense/components/SchemeLicenseViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeLicense/components/SchemeLicenseViewer.vue
@@ -112,17 +112,13 @@ const buttonIcon = computed(() => {
                 <GenericWidget
                     node-alias="right_holder"
                     :graph-slug="props.graphSlug"
-                    :node-value="
-                        props.tileData?.aliased_data.right_holder?.node_value
-                    "
+                    :value="props.tileData?.aliased_data.right_holder ?? null"
                     :mode="VIEW"
                 />
                 <GenericWidget
                     node-alias="right_type"
                     :graph-slug="props.graphSlug"
-                    :node-value="
-                        props.tileData?.aliased_data.right_type?.node_value
-                    "
+                    :value="props.tileData?.aliased_data.right_type ?? null"
                     :mode="VIEW"
                 />
             </div>
@@ -137,29 +133,27 @@ const buttonIcon = computed(() => {
                     <GenericWidget
                         node-alias="right_statement_content"
                         :graph-slug="props.graphSlug"
-                        :node-value="
+                        :value="
                             props.tileData?.aliased_data.right_statement
-                                ?.aliased_data?.right_statement_content
-                                ?.node_value
+                                ?.aliased_data?.right_statement_content ?? null
                         "
                         :mode="VIEW"
                     />
                     <GenericWidget
                         node-alias="right_statement_language"
                         :graph-slug="props.graphSlug"
-                        :node-value="
+                        :value="
                             props.tileData?.aliased_data.right_statement
-                                ?.aliased_data.right_statement_language
-                                ?.node_value
+                                ?.aliased_data.right_statement_language ?? null
                         "
                         :mode="VIEW"
                     />
                     <GenericWidget
                         node-alias="right_statement_type"
                         :graph-slug="props.graphSlug"
-                        :node-value="
+                        :value="
                             props.tileData?.aliased_data.right_statement
-                                ?.aliased_data.right_statement_type?.node_value
+                                ?.aliased_data.right_statement_type ?? null
                         "
                         :mode="VIEW"
                     />

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeLicense/components/SchemeLicenseViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeLicense/components/SchemeLicenseViewer.vue
@@ -112,13 +112,17 @@ const buttonIcon = computed(() => {
                 <GenericWidget
                     node-alias="right_holder"
                     :graph-slug="props.graphSlug"
-                    :value="props.tileData?.aliased_data.right_holder ?? null"
+                    :aliased-node-data="
+                        props.tileData?.aliased_data.right_holder ?? null
+                    "
                     :mode="VIEW"
                 />
                 <GenericWidget
                     node-alias="right_type"
                     :graph-slug="props.graphSlug"
-                    :value="props.tileData?.aliased_data.right_type ?? null"
+                    :aliased-node-data="
+                        props.tileData?.aliased_data.right_type ?? null
+                    "
                     :mode="VIEW"
                 />
             </div>
@@ -133,7 +137,7 @@ const buttonIcon = computed(() => {
                     <GenericWidget
                         node-alias="right_statement_content"
                         :graph-slug="props.graphSlug"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data.right_statement
                                 ?.aliased_data?.right_statement_content ?? null
                         "
@@ -142,7 +146,7 @@ const buttonIcon = computed(() => {
                     <GenericWidget
                         node-alias="right_statement_language"
                         :graph-slug="props.graphSlug"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data.right_statement
                                 ?.aliased_data.right_statement_language ?? null
                         "
@@ -151,7 +155,7 @@ const buttonIcon = computed(() => {
                     <GenericWidget
                         node-alias="right_statement_type"
                         :graph-slug="props.graphSlug"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data.right_statement
                                 ?.aliased_data.right_statement_type ?? null
                         "

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeLicense/components/SchemeLicenseViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeLicense/components/SchemeLicenseViewer.vue
@@ -112,15 +112,17 @@ const buttonIcon = computed(() => {
                 <GenericWidget
                     node-alias="right_holder"
                     :graph-slug="props.graphSlug"
-                    :aliased-node-data="
-                        props.tileData?.aliased_data.right_holder
+                    :node-value="
+                        props.tileData?.aliased_data.right_holder?.node_value
                     "
                     :mode="VIEW"
                 />
                 <GenericWidget
                     node-alias="right_type"
                     :graph-slug="props.graphSlug"
-                    :aliased-node-data="props.tileData?.aliased_data.right_type"
+                    :node-value="
+                        props.tileData?.aliased_data.right_type?.node_value
+                    "
                     :mode="VIEW"
                 />
             </div>
@@ -135,27 +137,29 @@ const buttonIcon = computed(() => {
                     <GenericWidget
                         node-alias="right_statement_content"
                         :graph-slug="props.graphSlug"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data.right_statement
                                 ?.aliased_data?.right_statement_content
+                                ?.node_value
                         "
                         :mode="VIEW"
                     />
                     <GenericWidget
                         node-alias="right_statement_language"
                         :graph-slug="props.graphSlug"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data.right_statement
                                 ?.aliased_data.right_statement_language
+                                ?.node_value
                         "
                         :mode="VIEW"
                     />
                     <GenericWidget
                         node-alias="right_statement_type"
                         :graph-slug="props.graphSlug"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data.right_statement
-                                ?.aliased_data.right_statement_type
+                                ?.aliased_data.right_statement_type?.node_value
                         "
                         :mode="VIEW"
                     />

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeLicense/components/SchemeLicenseViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeLicense/components/SchemeLicenseViewer.vue
@@ -4,7 +4,7 @@ import { useGettext } from "vue3-gettext";
 
 import Button from "primevue/button";
 
-import GenericWidget from "@/arches_component_lab/generics/GenericWidget/GenericWidget.vue";
+import GenericWidget from "@/arches_vue_components/generics/GenericWidget/GenericWidget.vue";
 
 import { VIEW } from "@/arches_lingo/constants.ts";
 import { useUserStore } from "@/arches_lingo/stores/useUserStore.ts";

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeNamespace/SchemeNamespace.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeNamespace/SchemeNamespace.vue
@@ -9,7 +9,7 @@ import SchemeNamespaceViewer from "@/arches_lingo/components/scheme/SchemeNamesp
 
 import { EDIT, VIEW } from "@/arches_lingo/constants.ts";
 
-import { fetchTileData } from "@/arches_component_lab/generics/GenericCard/api.ts";
+import { fetchTileData } from "@/arches_vue_components/generics/GenericCard/api.ts";
 import { useResourceStore } from "@/arches_lingo/composables/useResourceStore.ts";
 
 import type {

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeNamespace/components/SchemeNamespaceEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeNamespace/components/SchemeNamespaceEditor.vue
@@ -152,7 +152,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         node-alias="namespace_name"
                         :graph-slug="props.graphSlug"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data.namespace_name ?? null
                         "
                         :mode="EDIT"

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeNamespace/components/SchemeNamespaceEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeNamespace/components/SchemeNamespaceEditor.vue
@@ -152,9 +152,8 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         node-alias="namespace_name"
                         :graph-slug="props.graphSlug"
-                        :node-value="
-                            props.tileData?.aliased_data.namespace_name
-                                ?.node_value
+                        :value="
+                            props.tileData?.aliased_data.namespace_name ?? null
                         "
                         :mode="EDIT"
                     />

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeNamespace/components/SchemeNamespaceEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeNamespace/components/SchemeNamespaceEditor.vue
@@ -114,9 +114,8 @@ async function save(e: FormSubmitEvent) {
             updatedTileId = updatedTile.tileid;
         }
 
+        await refreshReportSection!(props.componentName);
         openEditor!(props.componentName, updatedTileId);
-
-        refreshReportSection!(props.componentName);
     } catch (error) {
         toast.add({
             severity: ERROR,
@@ -153,8 +152,9 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         node-alias="namespace_name"
                         :graph-slug="props.graphSlug"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data.namespace_name
+                                ?.node_value
                         "
                         :mode="EDIT"
                     />

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeNamespace/components/SchemeNamespaceEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeNamespace/components/SchemeNamespaceEditor.vue
@@ -16,7 +16,7 @@ import { Form } from "@primevue/forms";
 
 import Skeleton from "primevue/skeleton";
 
-import GenericWidget from "@/arches_component_lab/generics/GenericWidget/GenericWidget.vue";
+import GenericWidget from "@/arches_vue_components/generics/GenericWidget/GenericWidget.vue";
 
 import { createLingoResource, upsertLingoTile } from "@/arches_lingo/api.ts";
 

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeNamespace/components/SchemeNamespaceViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeNamespace/components/SchemeNamespaceViewer.vue
@@ -103,7 +103,7 @@ const buttonLabel = computed(() => {
             v-if="props.tileData"
             node-alias="namespace_name"
             :graph-slug="props.graphSlug"
-            :node-value="props.tileData.aliased_data.namespace_name?.node_value"
+            :value="props.tileData.aliased_data.namespace_name ?? null"
             :mode="VIEW"
         />
         <div

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeNamespace/components/SchemeNamespaceViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeNamespace/components/SchemeNamespaceViewer.vue
@@ -103,7 +103,7 @@ const buttonLabel = computed(() => {
             v-if="props.tileData"
             node-alias="namespace_name"
             :graph-slug="props.graphSlug"
-            :aliased-node-data="props.tileData.aliased_data.namespace_name"
+            :node-value="props.tileData.aliased_data.namespace_name?.node_value"
             :mode="VIEW"
         />
         <div

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeNamespace/components/SchemeNamespaceViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeNamespace/components/SchemeNamespaceViewer.vue
@@ -103,7 +103,9 @@ const buttonLabel = computed(() => {
             v-if="props.tileData"
             node-alias="namespace_name"
             :graph-slug="props.graphSlug"
-            :value="props.tileData.aliased_data.namespace_name ?? null"
+            :aliased-node-data="
+                props.tileData.aliased_data.namespace_name ?? null
+            "
             :mode="VIEW"
         />
         <div

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeNamespace/components/SchemeNamespaceViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeNamespace/components/SchemeNamespaceViewer.vue
@@ -4,7 +4,7 @@ import { useGettext } from "vue3-gettext";
 
 import Button from "primevue/button";
 
-import GenericWidget from "@/arches_component_lab/generics/GenericWidget/GenericWidget.vue";
+import GenericWidget from "@/arches_vue_components/generics/GenericWidget/GenericWidget.vue";
 
 import { VIEW } from "@/arches_lingo/constants.ts";
 import { useUserStore } from "@/arches_lingo/stores/useUserStore.ts";

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeNote/SchemeNote.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeNote/SchemeNote.vue
@@ -9,7 +9,7 @@ import SchemeNoteViewer from "@/arches_lingo/components/scheme/SchemeNote/compon
 
 import { EDIT, VIEW } from "@/arches_lingo/constants.ts";
 
-import { fetchTileData } from "@/arches_component_lab/generics/GenericCard/api.ts";
+import { fetchTileData } from "@/arches_vue_components/generics/GenericCard/api.ts";
 import { useResourceStore } from "@/arches_lingo/composables/useResourceStore.ts";
 
 import type {

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeNote/components/SchemeNoteEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeNote/components/SchemeNoteEditor.vue
@@ -151,9 +151,9 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="statement_content"
-                        :node-value="
-                            props.tileData?.aliased_data?.statement_content
-                                ?.node_value
+                        :value="
+                            props.tileData?.aliased_data?.statement_content ??
+                            null
                         "
                         :mode="EDIT"
                     />
@@ -162,9 +162,8 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="statement_type"
-                        :node-value="
-                            props.tileData?.aliased_data?.statement_type
-                                ?.node_value
+                        :value="
+                            props.tileData?.aliased_data?.statement_type ?? null
                         "
                         :mode="EDIT"
                     />
@@ -173,9 +172,9 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="statement_language"
-                        :node-value="
-                            props.tileData?.aliased_data?.statement_language
-                                ?.node_value
+                        :value="
+                            props.tileData?.aliased_data?.statement_language ??
+                            null
                         "
                         :mode="EDIT"
                     />
@@ -184,9 +183,9 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="statement_data_assignment_actor"
-                        :node-value="
+                        :value="
                             props.tileData?.aliased_data
-                                ?.statement_data_assignment_actor?.node_value
+                                ?.statement_data_assignment_actor ?? null
                         "
                         :mode="EDIT"
                     />
@@ -195,10 +194,9 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="statement_data_assignment_object_used"
-                        :node-value="
+                        :value="
                             props.tileData?.aliased_data
-                                ?.statement_data_assignment_object_used
-                                ?.node_value
+                                ?.statement_data_assignment_object_used ?? null
                         "
                         :mode="EDIT"
                     />

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeNote/components/SchemeNoteEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeNote/components/SchemeNoteEditor.vue
@@ -109,9 +109,8 @@ async function save(e: FormSubmitEvent) {
             updatedTileId = updatedTile.tileid;
         }
 
+        await refreshReportSection!(props.componentName);
         openEditor!(props.componentName, updatedTileId);
-
-        refreshReportSection!(props.componentName);
     } catch (error) {
         toast.add({
             severity: ERROR,
@@ -152,8 +151,9 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="statement_content"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data?.statement_content
+                                ?.node_value
                         "
                         :mode="EDIT"
                     />
@@ -162,8 +162,9 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="statement_type"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data?.statement_type
+                                ?.node_value
                         "
                         :mode="EDIT"
                     />
@@ -172,8 +173,9 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="statement_language"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data?.statement_language
+                                ?.node_value
                         "
                         :mode="EDIT"
                     />
@@ -182,9 +184,9 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="statement_data_assignment_actor"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data
-                                ?.statement_data_assignment_actor
+                                ?.statement_data_assignment_actor?.node_value
                         "
                         :mode="EDIT"
                     />
@@ -193,9 +195,10 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="statement_data_assignment_object_used"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data
                                 ?.statement_data_assignment_object_used
+                                ?.node_value
                         "
                         :mode="EDIT"
                     />

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeNote/components/SchemeNoteEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeNote/components/SchemeNoteEditor.vue
@@ -151,7 +151,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="statement_content"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data?.statement_content ??
                             null
                         "
@@ -162,7 +162,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="statement_type"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data?.statement_type ?? null
                         "
                         :mode="EDIT"
@@ -172,7 +172,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="statement_language"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data?.statement_language ??
                             null
                         "
@@ -183,7 +183,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="statement_data_assignment_actor"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data
                                 ?.statement_data_assignment_actor ?? null
                         "
@@ -194,7 +194,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         :graph-slug="props.graphSlug"
                         node-alias="statement_data_assignment_object_used"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data
                                 ?.statement_data_assignment_object_used ?? null
                         "

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeNote/components/SchemeNoteEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeNote/components/SchemeNoteEditor.vue
@@ -9,7 +9,7 @@ import { Form } from "@primevue/forms";
 
 import Skeleton from "primevue/skeleton";
 
-import GenericWidget from "@/arches_component_lab/generics/GenericWidget/GenericWidget.vue";
+import GenericWidget from "@/arches_vue_components/generics/GenericWidget/GenericWidget.vue";
 import { createLingoResource, upsertLingoTile } from "@/arches_lingo/api.ts";
 
 import {

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeNote/components/SchemeNoteViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeNote/components/SchemeNoteViewer.vue
@@ -120,7 +120,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_content"
                     :graph-slug="props.graphSlug"
-                    :aliased-node-data="rowData.aliased_data.statement_content"
+                    :node-value="
+                        rowData.aliased_data.statement_content?.node_value
+                    "
                     :mode="VIEW"
                     :should-show-label="false"
                 />
@@ -129,7 +131,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_type"
                     :graph-slug="props.graphSlug"
-                    :aliased-node-data="rowData.aliased_data.statement_type"
+                    :node-value="
+                        rowData.aliased_data.statement_type?.node_value
+                    "
                     :mode="VIEW"
                     :should-show-label="false"
                 />
@@ -138,7 +142,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_language"
                     :graph-slug="props.graphSlug"
-                    :aliased-node-data="rowData.aliased_data.statement_language"
+                    :node-value="
+                        rowData.aliased_data.statement_language?.node_value
+                    "
                     :mode="VIEW"
                     :should-show-label="false"
                 />
@@ -147,17 +153,18 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_data_assignment_object_used"
                     :graph-slug="props.graphSlug"
-                    :aliased-node-data="
+                    :node-value="
                         rowData.aliased_data
-                            .statement_data_assignment_object_used
+                            .statement_data_assignment_object_used?.node_value
                     "
                     :mode="VIEW"
                 />
                 <GenericWidget
                     node-alias="statement_data_assignment_actor"
                     :graph-slug="props.graphSlug"
-                    :aliased-node-data="
+                    :node-value="
                         rowData.aliased_data.statement_data_assignment_actor
+                            ?.node_value
                     "
                     :mode="VIEW"
                 />

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeNote/components/SchemeNoteViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeNote/components/SchemeNoteViewer.vue
@@ -69,9 +69,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
     type: $gettext("Type"),
     noRecords: $gettext("No scheme notes were found."),
     sortFields: {
-        name: "aliased_data.statement_content.display_value",
-        type: "aliased_data.statement_type.display_value",
-        language: "aliased_data.statement_language.display_value",
+        name: "aliased_data.statement_content",
+        type: "aliased_data.statement_type",
+        language: "aliased_data.statement_language",
     },
 }));
 </script>
@@ -120,9 +120,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_content"
                     :graph-slug="props.graphSlug"
-                    :node-value="
-                        rowData.aliased_data.statement_content?.node_value
-                    "
+                    :value="rowData.aliased_data.statement_content ?? null"
                     :mode="VIEW"
                     :should-show-label="false"
                 />
@@ -131,9 +129,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_type"
                     :graph-slug="props.graphSlug"
-                    :node-value="
-                        rowData.aliased_data.statement_type?.node_value
-                    "
+                    :value="rowData.aliased_data.statement_type ?? null"
                     :mode="VIEW"
                     :should-show-label="false"
                 />
@@ -142,9 +138,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_language"
                     :graph-slug="props.graphSlug"
-                    :node-value="
-                        rowData.aliased_data.statement_language?.node_value
-                    "
+                    :value="rowData.aliased_data.statement_language ?? null"
                     :mode="VIEW"
                     :should-show-label="false"
                 />
@@ -153,18 +147,18 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_data_assignment_object_used"
                     :graph-slug="props.graphSlug"
-                    :node-value="
+                    :value="
                         rowData.aliased_data
-                            .statement_data_assignment_object_used?.node_value
+                            .statement_data_assignment_object_used ?? null
                     "
                     :mode="VIEW"
                 />
                 <GenericWidget
                     node-alias="statement_data_assignment_actor"
                     :graph-slug="props.graphSlug"
-                    :node-value="
-                        rowData.aliased_data.statement_data_assignment_actor
-                            ?.node_value
+                    :value="
+                        rowData.aliased_data.statement_data_assignment_actor ??
+                        null
                     "
                     :mode="VIEW"
                 />

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeNote/components/SchemeNoteViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeNote/components/SchemeNoteViewer.vue
@@ -69,9 +69,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
     type: $gettext("Type"),
     noRecords: $gettext("No scheme notes were found."),
     sortFields: {
-        name: "aliased_data.statement_content",
-        type: "aliased_data.statement_type",
-        language: "aliased_data.statement_language",
+        name: "aliased_data.statement_content.display_value",
+        type: "aliased_data.statement_type.display_value",
+        language: "aliased_data.statement_language.display_value",
     },
 }));
 </script>
@@ -120,7 +120,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_content"
                     :graph-slug="props.graphSlug"
-                    :value="rowData.aliased_data.statement_content ?? null"
+                    :aliased-node-data="
+                        rowData.aliased_data.statement_content ?? null
+                    "
                     :mode="VIEW"
                     :should-show-label="false"
                 />
@@ -129,7 +131,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_type"
                     :graph-slug="props.graphSlug"
-                    :value="rowData.aliased_data.statement_type ?? null"
+                    :aliased-node-data="
+                        rowData.aliased_data.statement_type ?? null
+                    "
                     :mode="VIEW"
                     :should-show-label="false"
                 />
@@ -138,7 +142,9 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_language"
                     :graph-slug="props.graphSlug"
-                    :value="rowData.aliased_data.statement_language ?? null"
+                    :aliased-node-data="
+                        rowData.aliased_data.statement_language ?? null
+                    "
                     :mode="VIEW"
                     :should-show-label="false"
                 />
@@ -147,7 +153,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_data_assignment_object_used"
                     :graph-slug="props.graphSlug"
-                    :value="
+                    :aliased-node-data="
                         rowData.aliased_data
                             .statement_data_assignment_object_used ?? null
                     "
@@ -156,7 +162,7 @@ const metaStringLabel = computed<MetaStringText>(() => ({
                 <GenericWidget
                     node-alias="statement_data_assignment_actor"
                     :graph-slug="props.graphSlug"
-                    :value="
+                    :aliased-node-data="
                         rowData.aliased_data.statement_data_assignment_actor ??
                         null
                     "

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeNote/components/SchemeNoteViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeNote/components/SchemeNoteViewer.vue
@@ -6,7 +6,7 @@ import Button from "primevue/button";
 import Tag from "primevue/tag";
 
 import MetaStringViewer from "@/arches_lingo/components/generic/MetaStringViewer.vue";
-import GenericWidget from "@/arches_component_lab/generics/GenericWidget/GenericWidget.vue";
+import GenericWidget from "@/arches_vue_components/generics/GenericWidget/GenericWidget.vue";
 
 import { VIEW } from "@/arches_lingo/constants.ts";
 import { useUserStore } from "@/arches_lingo/stores/useUserStore.ts";

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeStandard/SchemeStandard.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeStandard/SchemeStandard.vue
@@ -9,7 +9,7 @@ import SchemeStandardEditor from "@/arches_lingo/components/scheme/SchemeStandar
 
 import { EDIT, VIEW } from "@/arches_lingo/constants.ts";
 
-import { fetchTileData } from "@/arches_component_lab/generics/GenericCard/api.ts";
+import { fetchTileData } from "@/arches_vue_components/generics/GenericCard/api.ts";
 import { useResourceStore } from "@/arches_lingo/composables/useResourceStore.ts";
 
 import type {

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeStandard/components/SchemeStandardEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeStandard/components/SchemeStandardEditor.vue
@@ -150,9 +150,9 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         graph-slug="scheme"
                         node-alias="creation_sources"
-                        :node-value="
-                            props.tileData?.aliased_data.creation_sources
-                                ?.node_value
+                        :value="
+                            props.tileData?.aliased_data.creation_sources ??
+                            null
                         "
                         :mode="EDIT"
                     />

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeStandard/components/SchemeStandardEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeStandard/components/SchemeStandardEditor.vue
@@ -108,9 +108,8 @@ async function save(e: FormSubmitEvent) {
             updatedTileId = updatedTile.tileid;
         }
 
+        await refreshReportSection!(props.componentName);
         openEditor!(props.componentName, updatedTileId);
-
-        refreshReportSection!(props.componentName);
     } catch (error) {
         toast.add({
             severity: ERROR,
@@ -151,8 +150,9 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         graph-slug="scheme"
                         node-alias="creation_sources"
-                        :aliased-node-data="
+                        :node-value="
                             props.tileData?.aliased_data.creation_sources
+                                ?.node_value
                         "
                         :mode="EDIT"
                     />

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeStandard/components/SchemeStandardEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeStandard/components/SchemeStandardEditor.vue
@@ -150,7 +150,7 @@ async function save(e: FormSubmitEvent) {
                     <GenericWidget
                         graph-slug="scheme"
                         node-alias="creation_sources"
-                        :value="
+                        :aliased-node-data="
                             props.tileData?.aliased_data.creation_sources ??
                             null
                         "

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeStandard/components/SchemeStandardEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeStandard/components/SchemeStandardEditor.vue
@@ -9,7 +9,7 @@ import { Form } from "@primevue/forms";
 
 import Skeleton from "primevue/skeleton";
 
-import GenericWidget from "@/arches_component_lab/generics/GenericWidget/GenericWidget.vue";
+import GenericWidget from "@/arches_vue_components/generics/GenericWidget/GenericWidget.vue";
 
 import { createLingoResource, upsertLingoTile } from "@/arches_lingo/api.ts";
 

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeStandard/components/SchemeStandardViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeStandard/components/SchemeStandardViewer.vue
@@ -112,7 +112,9 @@ const buttonIcon = computed(() => {
             <GenericWidget
                 node-alias="creation_sources"
                 :graph-slug="props.graphSlug"
-                :value="props.tileData.aliased_data.creation_sources ?? null"
+                :aliased-node-data="
+                    props.tileData.aliased_data.creation_sources ?? null
+                "
                 :mode="VIEW"
             />
         </div>

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeStandard/components/SchemeStandardViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeStandard/components/SchemeStandardViewer.vue
@@ -112,9 +112,7 @@ const buttonIcon = computed(() => {
             <GenericWidget
                 node-alias="creation_sources"
                 :graph-slug="props.graphSlug"
-                :node-value="
-                    props.tileData.aliased_data.creation_sources?.node_value
-                "
+                :value="props.tileData.aliased_data.creation_sources ?? null"
                 :mode="VIEW"
             />
         </div>

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeStandard/components/SchemeStandardViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeStandard/components/SchemeStandardViewer.vue
@@ -112,8 +112,8 @@ const buttonIcon = computed(() => {
             <GenericWidget
                 node-alias="creation_sources"
                 :graph-slug="props.graphSlug"
-                :aliased-node-data="
-                    props.tileData.aliased_data.creation_sources
+                :node-value="
+                    props.tileData.aliased_data.creation_sources?.node_value
                 "
                 :mode="VIEW"
             />

--- a/arches_lingo/src/arches_lingo/components/scheme/SchemeStandard/components/SchemeStandardViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/scheme/SchemeStandard/components/SchemeStandardViewer.vue
@@ -4,7 +4,7 @@ import { useGettext } from "vue3-gettext";
 
 import Button from "primevue/button";
 
-import GenericWidget from "@/arches_component_lab/generics/GenericWidget/GenericWidget.vue";
+import GenericWidget from "@/arches_vue_components/generics/GenericWidget/GenericWidget.vue";
 
 import { VIEW } from "@/arches_lingo/constants.ts";
 import { useUserStore } from "@/arches_lingo/stores/useUserStore.ts";

--- a/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/ConceptResourceSelectWidget.vue
+++ b/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/ConceptResourceSelectWidget.vue
@@ -58,13 +58,6 @@ const cardXNodeXWidgetData = ref<CardXNodeXWidgetData>();
 const configurationError = ref();
 const searchResult = ref();
 
-const resolvedNodeValue = computed<ResourceInstanceReference[] | null>(() => {
-    if (aliasedNodeData !== undefined) {
-        return aliasedNodeData?.node_value ?? null;
-    }
-    return value ?? null;
-});
-
 const detailsFromAliasedData = computed(() => {
     if (aliasedNodeData?.details?.length) {
         return aliasedNodeData.details;
@@ -85,8 +78,8 @@ watchEffect(async () => {
     isLoading.value = true;
     try {
         if (!detailsFromAliasedData.value) {
-            const conceptIds = resolvedNodeValue.value
-                ?.map((resourceRef) => resourceRef.resourceId)
+            const conceptIds = value
+                ?.map((ref) => ref.resourceId)
                 .filter(Boolean);
             if (conceptIds?.length) {
                 searchResult.value = await getConceptHierarchy(conceptIds);

--- a/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/ConceptResourceSelectWidget.vue
+++ b/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/ConceptResourceSelectWidget.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { watchEffect, ref } from "vue";
+import { computed, watchEffect, ref } from "vue";
 
 import Message from "primevue/message";
 import Skeleton from "primevue/skeleton";
@@ -16,13 +16,17 @@ import { EDIT, VIEW } from "@/arches_component_lab/widgets/constants.ts";
 
 import type { CardXNodeXWidgetData } from "@/arches_component_lab/types.ts";
 import type { WidgetMode } from "@/arches_component_lab/widgets/types.ts";
-import type { ResourceInstanceReference } from "@/arches_component_lab/datatypes/resource-instance-list/types";
+import type {
+    ResourceInstanceListAliasedNodeData,
+    ResourceInstanceReference,
+} from "@/arches_component_lab/datatypes/resource-instance-list/types.ts";
 
 const {
     graphSlug,
     mode,
     nodeAlias,
     resourceInstanceId,
+    aliasedNodeData,
     value,
     shouldShowLabel = true,
     isDirty = false,
@@ -34,7 +38,8 @@ const {
     mode: WidgetMode;
     nodeAlias: string;
     resourceInstanceId?: string;
-    value: ResourceInstanceReference[] | null | undefined;
+    aliasedNodeData?: ResourceInstanceListAliasedNodeData | null;
+    value?: ResourceInstanceReference[] | null;
     shouldShowLabel?: boolean;
     scheme?: string;
     schemeSelectable?: boolean | false;
@@ -45,19 +50,32 @@ const emit = defineEmits([
     "update:isFocused",
     "update:value",
     "update:isLoading",
+    "update:aliasedNodeData",
 ]);
 
 const isLoading = ref(true);
 const cardXNodeXWidgetData = ref<CardXNodeXWidgetData>();
 const configurationError = ref();
+const searchResult = ref();
+
+const resolvedNodeValue = computed<ResourceInstanceReference[] | null>(() => {
+    if (aliasedNodeData !== undefined) {
+        return aliasedNodeData?.node_value ?? null;
+    }
+    return value ?? null;
+});
+
+const detailsFromAliasedData = computed(() => {
+    if (aliasedNodeData?.details?.length) {
+        return aliasedNodeData.details;
+    }
+    return null;
+});
 
 const widgetReadyTracker = useWidgetReadyTracker();
 if (widgetReadyTracker) {
     widgetReadyTracker.register();
 }
-
-const conceptIds = value?.map((ref) => ref.resourceId);
-const searchResult = ref();
 
 watchEffect(async () => {
     if (cardXNodeXWidgetData.value) {
@@ -66,8 +84,13 @@ watchEffect(async () => {
 
     isLoading.value = true;
     try {
-        if (conceptIds) {
-            searchResult.value = await getConceptHierarchy(conceptIds);
+        if (!detailsFromAliasedData.value) {
+            const conceptIds = resolvedNodeValue.value
+                ?.map((resourceRef) => resourceRef.resourceId)
+                .filter(Boolean);
+            if (conceptIds?.length) {
+                searchResult.value = await getConceptHierarchy(conceptIds);
+            }
         }
         cardXNodeXWidgetData.value =
             await useWidgetConfigStore().fetchWidgetConfig(
@@ -83,9 +106,6 @@ watchEffect(async () => {
 });
 
 async function getConceptHierarchy(conceptIds: string[]) {
-    if (conceptIds.length === 0) {
-        return;
-    }
     const parsedResponse = await fetchConceptResources(
         "",
         conceptIds.length,
@@ -138,7 +158,7 @@ async function getConceptHierarchy(conceptIds: string[]) {
         </GenericFormField>
         <ConceptResourceSelectWidgetViewer
             v-else-if="mode === VIEW"
-            :value="searchResult"
+            :value="detailsFromAliasedData ?? searchResult"
         />
     </template>
 </template>

--- a/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/ConceptResourceSelectWidget.vue
+++ b/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/ConceptResourceSelectWidget.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, watchEffect, ref } from "vue";
+import { watchEffect, ref } from "vue";
 
 import Message from "primevue/message";
 import Skeleton from "primevue/skeleton";
@@ -14,19 +14,16 @@ import { fetchConceptResources } from "@/arches_lingo/api.ts";
 import { useWidgetReadyTracker } from "@/arches_lingo/composables/useWidgetReadyTracker.ts";
 import { EDIT, VIEW } from "@/arches_component_lab/widgets/constants.ts";
 
-import type {
-    AliasedNodeData,
-    CardXNodeXWidgetData,
-} from "@/arches_component_lab/types.ts";
+import type { CardXNodeXWidgetData } from "@/arches_component_lab/types.ts";
 import type { WidgetMode } from "@/arches_component_lab/widgets/types.ts";
-import type { ResourceInstanceListValue } from "@/arches_component_lab/datatypes/resource-instance-list/types";
+import type { ResourceInstanceReference } from "@/arches_component_lab/datatypes/resource-instance-list/types";
 
 const {
     graphSlug,
     mode,
     nodeAlias,
     resourceInstanceId,
-    aliasedNodeData,
+    nodeValue,
     shouldShowLabel = true,
     isDirty = false,
     scheme = "",
@@ -37,7 +34,7 @@ const {
     mode: WidgetMode;
     nodeAlias: string;
     resourceInstanceId?: string;
-    aliasedNodeData: ResourceInstanceListValue | null | undefined;
+    nodeValue: ResourceInstanceReference[] | null | undefined;
     shouldShowLabel?: boolean;
     scheme?: string;
     schemeSelectable?: boolean | false;
@@ -59,22 +56,8 @@ if (widgetReadyTracker) {
     widgetReadyTracker.register();
 }
 
-const conceptIds = aliasedNodeData?.details.map(
-    (resource: { display_value: string; resource_id: string }) =>
-        resource.resource_id,
-) as string[] | undefined;
+const conceptIds = nodeValue?.map((ref) => ref.resourceId);
 const searchResult = ref();
-
-const widgetValue = computed(() => {
-    if (aliasedNodeData !== undefined) {
-        return aliasedNodeData as AliasedNodeData;
-    } else if (cardXNodeXWidgetData.value?.config?.defaultValue) {
-        return cardXNodeXWidgetData.value.config
-            .defaultValue as AliasedNodeData;
-    } else {
-        return null;
-    }
-});
 
 watchEffect(async () => {
     if (cardXNodeXWidgetData.value) {
@@ -135,7 +118,7 @@ async function getConceptHierarchy(conceptIds: string[]) {
         <GenericFormField
             v-if="mode === EDIT"
             v-slot="{ onUpdateValue }"
-            :aliased-node-data="widgetValue!"
+            :node-value="nodeValue"
             :is-dirty="isDirty"
             :node-alias="nodeAlias"
             @update:is-dirty="emit('update:isDirty', $event)"

--- a/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/ConceptResourceSelectWidget.vue
+++ b/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/ConceptResourceSelectWidget.vue
@@ -9,7 +9,7 @@ import GenericFormField from "@/arches_component_lab/generics/GenericWidget/comp
 import ConceptResourceSelectWidgetEditor from "@/arches_lingo/components/widgets/ConceptResourceSelectWidget/components/ConceptResourceSelectWidgetEditor.vue";
 import ConceptResourceSelectWidgetViewer from "@/arches_lingo/components/widgets/ConceptResourceSelectWidget/components/ConceptResourceSelectWidgetViewer.vue";
 
-import { fetchCardXNodeXWidgetData } from "@/arches_component_lab/generics/GenericWidget/api.ts";
+import { useWidgetConfigStore } from "@/arches_component_lab/stores/useWidgetConfigStore.ts";
 import { fetchConceptResources } from "@/arches_lingo/api.ts";
 import { useWidgetReadyTracker } from "@/arches_lingo/composables/useWidgetReadyTracker.ts";
 import { EDIT, VIEW } from "@/arches_component_lab/widgets/constants.ts";
@@ -69,10 +69,11 @@ watchEffect(async () => {
         if (conceptIds) {
             searchResult.value = await getConceptHierarchy(conceptIds);
         }
-        cardXNodeXWidgetData.value = await fetchCardXNodeXWidgetData(
-            graphSlug,
-            nodeAlias,
-        );
+        cardXNodeXWidgetData.value =
+            await useWidgetConfigStore().fetchWidgetConfig(
+                graphSlug,
+                nodeAlias,
+            );
     } catch (error) {
         configurationError.value = error;
     } finally {

--- a/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/ConceptResourceSelectWidget.vue
+++ b/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/ConceptResourceSelectWidget.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, watchEffect, ref } from "vue";
+import { watchEffect, ref } from "vue";
 
 import Message from "primevue/message";
 import Skeleton from "primevue/skeleton";
@@ -16,10 +16,7 @@ import { EDIT, VIEW } from "@/arches_component_lab/widgets/constants.ts";
 
 import type { CardXNodeXWidgetData } from "@/arches_component_lab/types.ts";
 import type { WidgetMode } from "@/arches_component_lab/widgets/types.ts";
-import type {
-    ResourceInstanceListAliasedNodeData,
-    ResourceInstanceReference,
-} from "@/arches_component_lab/datatypes/resource-instance-list/types.ts";
+import type { ResourceInstanceListAliasedNodeData } from "@/arches_component_lab/datatypes/resource-instance-list/types.ts";
 
 const {
     graphSlug,
@@ -27,7 +24,6 @@ const {
     nodeAlias,
     resourceInstanceId,
     aliasedNodeData,
-    value,
     shouldShowLabel = true,
     isDirty = false,
     scheme = "",
@@ -39,7 +35,6 @@ const {
     nodeAlias: string;
     resourceInstanceId?: string;
     aliasedNodeData?: ResourceInstanceListAliasedNodeData | null;
-    value?: ResourceInstanceReference[] | null;
     shouldShowLabel?: boolean;
     scheme?: string;
     schemeSelectable?: boolean | false;
@@ -50,25 +45,19 @@ const emit = defineEmits([
     "update:isFocused",
     "update:value",
     "update:isLoading",
-    "update:aliasedNodeData",
 ]);
 
 const isLoading = ref(true);
 const cardXNodeXWidgetData = ref<CardXNodeXWidgetData>();
 const configurationError = ref();
-const searchResult = ref();
-
-const detailsFromAliasedData = computed(() => {
-    if (aliasedNodeData?.details?.length) {
-        return aliasedNodeData.details;
-    }
-    return null;
-});
 
 const widgetReadyTracker = useWidgetReadyTracker();
 if (widgetReadyTracker) {
     widgetReadyTracker.register();
 }
+
+const conceptIds = aliasedNodeData?.details.map((detail) => detail.resource_id);
+const searchResult = ref();
 
 watchEffect(async () => {
     if (cardXNodeXWidgetData.value) {
@@ -77,13 +66,8 @@ watchEffect(async () => {
 
     isLoading.value = true;
     try {
-        if (!detailsFromAliasedData.value) {
-            const conceptIds = value
-                ?.map((ref) => ref.resourceId)
-                .filter(Boolean);
-            if (conceptIds?.length) {
-                searchResult.value = await getConceptHierarchy(conceptIds);
-            }
+        if (conceptIds) {
+            searchResult.value = await getConceptHierarchy(conceptIds);
         }
         cardXNodeXWidgetData.value =
             await useWidgetConfigStore().fetchWidgetConfig(
@@ -99,6 +83,9 @@ watchEffect(async () => {
 });
 
 async function getConceptHierarchy(conceptIds: string[]) {
+    if (conceptIds.length === 0) {
+        return;
+    }
     const parsedResponse = await fetchConceptResources(
         "",
         conceptIds.length,
@@ -132,7 +119,7 @@ async function getConceptHierarchy(conceptIds: string[]) {
         <GenericFormField
             v-if="mode === EDIT"
             v-slot="{ onUpdateValue }"
-            :value="value"
+            :value="aliasedNodeData?.node_value ?? null"
             :is-dirty="isDirty"
             :node-alias="nodeAlias"
             @update:is-dirty="emit('update:isDirty', $event)"
@@ -151,7 +138,7 @@ async function getConceptHierarchy(conceptIds: string[]) {
         </GenericFormField>
         <ConceptResourceSelectWidgetViewer
             v-else-if="mode === VIEW"
-            :value="detailsFromAliasedData ?? searchResult"
+            :value="searchResult"
         />
     </template>
 </template>

--- a/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/ConceptResourceSelectWidget.vue
+++ b/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/ConceptResourceSelectWidget.vue
@@ -23,7 +23,7 @@ const {
     mode,
     nodeAlias,
     resourceInstanceId,
-    nodeValue,
+    value,
     shouldShowLabel = true,
     isDirty = false,
     scheme = "",
@@ -34,7 +34,7 @@ const {
     mode: WidgetMode;
     nodeAlias: string;
     resourceInstanceId?: string;
-    nodeValue: ResourceInstanceReference[] | null | undefined;
+    value: ResourceInstanceReference[] | null | undefined;
     shouldShowLabel?: boolean;
     scheme?: string;
     schemeSelectable?: boolean | false;
@@ -56,7 +56,7 @@ if (widgetReadyTracker) {
     widgetReadyTracker.register();
 }
 
-const conceptIds = nodeValue?.map((ref) => ref.resourceId);
+const conceptIds = value?.map((ref) => ref.resourceId);
 const searchResult = ref();
 
 watchEffect(async () => {
@@ -118,7 +118,7 @@ async function getConceptHierarchy(conceptIds: string[]) {
         <GenericFormField
             v-if="mode === EDIT"
             v-slot="{ onUpdateValue }"
-            :node-value="nodeValue"
+            :value="value"
             :is-dirty="isDirty"
             :node-alias="nodeAlias"
             @update:is-dirty="emit('update:isDirty', $event)"

--- a/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/ConceptResourceSelectWidget.vue
+++ b/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/ConceptResourceSelectWidget.vue
@@ -4,19 +4,19 @@ import { watchEffect, ref } from "vue";
 import Message from "primevue/message";
 import Skeleton from "primevue/skeleton";
 
-import GenericWidgetLabel from "@/arches_component_lab/generics/GenericWidget/components/GenericWidgetLabel.vue";
-import GenericFormField from "@/arches_component_lab/generics/GenericWidget/components/GenericFormField.vue";
+import GenericWidgetLabel from "@/arches_vue_components/generics/GenericWidget/components/GenericWidgetLabel.vue";
+import GenericFormField from "@/arches_vue_components/generics/GenericWidget/components/GenericFormField.vue";
 import ConceptResourceSelectWidgetEditor from "@/arches_lingo/components/widgets/ConceptResourceSelectWidget/components/ConceptResourceSelectWidgetEditor.vue";
 import ConceptResourceSelectWidgetViewer from "@/arches_lingo/components/widgets/ConceptResourceSelectWidget/components/ConceptResourceSelectWidgetViewer.vue";
 
-import { useWidgetConfigStore } from "@/arches_component_lab/stores/useWidgetConfigStore.ts";
+import { useWidgetConfigStore } from "@/arches_vue_components/stores/useWidgetConfigStore.ts";
 import { fetchConceptResources } from "@/arches_lingo/api.ts";
 import { useWidgetReadyTracker } from "@/arches_lingo/composables/useWidgetReadyTracker.ts";
-import { EDIT, VIEW } from "@/arches_component_lab/widgets/constants.ts";
+import { EDIT, VIEW } from "@/arches_vue_components/widgets/constants.ts";
 
-import type { CardXNodeXWidgetData } from "@/arches_component_lab/types.ts";
-import type { WidgetMode } from "@/arches_component_lab/widgets/types.ts";
-import type { ResourceInstanceListAliasedNodeData } from "@/arches_component_lab/datatypes/resource-instance-list/types.ts";
+import type { CardXNodeXWidgetData } from "@/arches_vue_components/types.ts";
+import type { WidgetMode } from "@/arches_vue_components/widgets/types.ts";
+import type { ResourceInstanceListAliasedNodeData } from "@/arches_vue_components/datatypes/resource-instance-list/types.ts";
 
 const {
     graphSlug,

--- a/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/ConceptResourceSelectWidget.vue
+++ b/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/ConceptResourceSelectWidget.vue
@@ -118,12 +118,11 @@ async function getConceptHierarchy(conceptIds: string[]) {
         />
         <GenericFormField
             v-if="mode === EDIT"
-            v-slot="{ onUpdateValue }"
-            :value="aliasedNodeData?.node_value ?? null"
+            v-slot="{ onWidgetInitialized, onUpdateAliasedNodeData }"
             :is-dirty="isDirty"
             :node-alias="nodeAlias"
             @update:is-dirty="emit('update:isDirty', $event)"
-            @update:value="emit('update:value', $event)"
+            @update:aliased-node-data="emit('update:value', $event)"
         >
             <ConceptResourceSelectWidgetEditor
                 :value="searchResult"
@@ -132,8 +131,22 @@ async function getConceptHierarchy(conceptIds: string[]) {
                 :graph-slug="graphSlug"
                 :scheme="scheme"
                 :scheme-selectable="schemeSelectable"
-                @update:value="onUpdateValue($event)"
-                @update:is-editor-mounted="emit('update:isLoading', $event)"
+                @initialized="
+                    onWidgetInitialized(
+                        aliasedNodeData ?? {
+                            node_value: null,
+                            display_value: '',
+                            details: [],
+                        },
+                    )
+                "
+                @update:value="
+                    onUpdateAliasedNodeData({
+                        node_value: $event,
+                        display_value: '',
+                        details: [],
+                    })
+                "
             />
         </GenericFormField>
         <ConceptResourceSelectWidgetViewer

--- a/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/ConceptResourceSelectWidget.vue
+++ b/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/ConceptResourceSelectWidget.vue
@@ -58,6 +58,10 @@ if (widgetReadyTracker) {
 
 const conceptIds = aliasedNodeData?.details.map((detail) => detail.resource_id);
 const searchResult = ref();
+const isWidgetInitialized = ref(false);
+const resolvedInitialValue = ref<ResourceInstanceListAliasedNodeData | null>(
+    null,
+);
 
 watchEffect(async () => {
     if (cardXNodeXWidgetData.value) {
@@ -96,6 +100,13 @@ async function getConceptHierarchy(conceptIds: string[]) {
     );
     return parsedResponse.data;
 }
+
+function onWidgetInitialized(
+    aliasedNodeData: ResourceInstanceListAliasedNodeData,
+) {
+    isWidgetInitialized.value = true;
+    resolvedInitialValue.value = aliasedNodeData;
+}
 </script>
 
 <template>
@@ -118,36 +129,42 @@ async function getConceptHierarchy(conceptIds: string[]) {
         />
         <GenericFormField
             v-if="mode === EDIT"
-            v-slot="{ onWidgetInitialized, onUpdateAliasedNodeData }"
+            v-slot="{ onUpdateAliasedNodeData }"
             :is-dirty="isDirty"
+            :initial-value="resolvedInitialValue"
             :node-alias="nodeAlias"
             @update:is-dirty="emit('update:isDirty', $event)"
             @update:aliased-node-data="emit('update:value', $event)"
         >
-            <ConceptResourceSelectWidgetEditor
-                :value="searchResult"
-                :node-alias="nodeAlias"
-                :resource-instance-id="resourceInstanceId"
-                :graph-slug="graphSlug"
-                :scheme="scheme"
-                :scheme-selectable="schemeSelectable"
-                @initialized="
-                    onWidgetInitialized(
-                        aliasedNodeData ?? {
-                            node_value: null,
+            <div
+                v-show="isWidgetInitialized"
+                style="display: contents"
+            >
+                <ConceptResourceSelectWidgetEditor
+                    :value="searchResult"
+                    :node-alias="nodeAlias"
+                    :resource-instance-id="resourceInstanceId"
+                    :graph-slug="graphSlug"
+                    :scheme="scheme"
+                    :scheme-selectable="schemeSelectable"
+                    @initialized="
+                        onWidgetInitialized(
+                            aliasedNodeData ?? {
+                                node_value: null,
+                                display_value: '',
+                                details: [],
+                            },
+                        )
+                    "
+                    @update:value="
+                        onUpdateAliasedNodeData({
+                            node_value: $event,
                             display_value: '',
                             details: [],
-                        },
-                    )
-                "
-                @update:value="
-                    onUpdateAliasedNodeData({
-                        node_value: $event,
-                        display_value: '',
-                        details: [],
-                    })
-                "
-            />
+                        })
+                    "
+                />
+            </div>
         </GenericFormField>
         <ConceptResourceSelectWidgetViewer
             v-else-if="mode === VIEW"

--- a/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/components/ConceptResourceSelectWidgetEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/components/ConceptResourceSelectWidgetEditor.vue
@@ -14,10 +14,7 @@ import { useLanguageStore } from "@/arches_lingo/stores/useLanguageStore.ts";
 
 import type { MultiSelectFilterEvent } from "primevue/multiselect";
 import type { VirtualScrollerLazyEvent } from "primevue/virtualscroller";
-import type {
-    ResourceInstanceListValue,
-    ResourceInstanceReference,
-} from "@/arches_component_lab/datatypes/resource-instance-list/types";
+import type { ResourceInstanceReference } from "@/arches_component_lab/datatypes/resource-instance-list/types";
 import type { SearchResultItem } from "@/arches_lingo/types.ts";
 
 const props = defineProps<{
@@ -30,7 +27,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-    (event: "update:value", updatedValue: ResourceInstanceListValue): void;
+    (event: "update:value", updatedValue: ResourceInstanceReference[]): void;
     (event: "update:isEditorMounted", isMounted: boolean): void;
 }>();
 
@@ -166,10 +163,6 @@ function getChipLabel(resourceId: string): string | undefined {
 }
 
 function onUpdateModelValue(updatedValue: string[]) {
-    const options = updatedValue.map((resourceId: string) => {
-        return getOption(resourceId);
-    });
-
     const formattedNodeValues: ResourceInstanceReference[] = updatedValue.map(
         (value) => {
             return {
@@ -181,13 +174,7 @@ function onUpdateModelValue(updatedValue: string[]) {
         },
     );
 
-    const formattedValue = {
-        display_value: options.map((option) => option?.label).join(", "),
-        node_value: formattedNodeValues,
-        details: [],
-    } as ResourceInstanceListValue;
-
-    emit("update:value", formattedValue);
+    emit("update:value", formattedNodeValues);
 }
 </script>
 

--- a/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/components/ConceptResourceSelectWidgetEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/components/ConceptResourceSelectWidgetEditor.vue
@@ -28,7 +28,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
     (event: "update:value", updatedValue: ResourceInstanceReference[]): void;
-    (event: "update:isEditorMounted", isMounted: boolean): void;
+    (event: "initialized"): void;
 }>();
 
 const { $gettext } = useGettext();
@@ -67,7 +67,7 @@ const initialValueFromTileData = computed(() => {
 });
 
 onMounted(() => {
-    emit("update:isEditorMounted", true);
+    emit("initialized");
 });
 
 function clearOptions() {

--- a/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/components/ConceptResourceSelectWidgetEditor.vue
+++ b/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/components/ConceptResourceSelectWidgetEditor.vue
@@ -14,7 +14,7 @@ import { useLanguageStore } from "@/arches_lingo/stores/useLanguageStore.ts";
 
 import type { MultiSelectFilterEvent } from "primevue/multiselect";
 import type { VirtualScrollerLazyEvent } from "primevue/virtualscroller";
-import type { ResourceInstanceReference } from "@/arches_component_lab/datatypes/resource-instance-list/types";
+import type { ResourceInstanceReference } from "@/arches_vue_components/datatypes/resource-instance-list/types";
 import type { SearchResultItem } from "@/arches_lingo/types.ts";
 
 const props = defineProps<{

--- a/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/components/ConceptResourceSelectWidgetViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/components/ConceptResourceSelectWidgetViewer.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import { storeToRefs } from "pinia";
 import { getItemLabel } from "@/arches_controlled_lists/utils.ts";
 import { getParentLabels } from "@/arches_lingo/utils.ts";
@@ -12,6 +13,19 @@ const props = defineProps<{
 }>();
 
 const { selectedLanguage, systemLanguage } = storeToRefs(useLanguageStore());
+
+const parentLabels = computed(() =>
+    Object.fromEntries(
+        (props.value ?? []).map((searchResult) => [
+            searchResult.id,
+            getParentLabels(
+                searchResult,
+                selectedLanguage.value.code,
+                systemLanguage.value.code,
+            ),
+        ]),
+    ),
+);
 </script>
 <template>
     <div
@@ -38,22 +52,10 @@ const { selectedLanguage, systemLanguage } = storeToRefs(useLanguageStore());
             </RouterLink>
         </span>
         <span
-            v-if="
-                getParentLabels(
-                    searchResult,
-                    selectedLanguage.code,
-                    systemLanguage.code,
-                )
-            "
+            v-if="parentLabels[searchResult.id]"
             class="concept-hierarchy"
         >
-            [{{
-                getParentLabels(
-                    searchResult,
-                    selectedLanguage.code,
-                    systemLanguage.code,
-                )
-            }}]
+            [{{ parentLabels[searchResult.id] }}]
         </span>
     </div>
 </template>

--- a/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/components/ConceptResourceSelectWidgetViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/components/ConceptResourceSelectWidgetViewer.vue
@@ -1,53 +1,83 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import { storeToRefs } from "pinia";
 import { getItemLabel } from "@/arches_controlled_lists/utils.ts";
 import { getParentLabels } from "@/arches_lingo/utils.ts";
 import { useLanguageStore } from "@/arches_lingo/stores/useLanguageStore.ts";
 import { routeNames } from "@/arches_lingo/routes.ts";
 
+import type { ResourceInstanceListOption } from "@/arches_component_lab/datatypes/resource-instance-list/types.ts";
 import type { SearchResultItem } from "@/arches_lingo/types.ts";
 
+interface DisplayItem {
+    id: string;
+    label: string;
+    parentsLabel: string | null;
+}
+
 const props = defineProps<{
-    value?: SearchResultItem[];
+    value?: SearchResultItem[] | ResourceInstanceListOption[] | null;
 }>();
 
 const { selectedLanguage, systemLanguage } = storeToRefs(useLanguageStore());
+
+const displayItems = computed<DisplayItem[]>(() => {
+    if (!props.value?.length) {
+        return [];
+    }
+
+    const firstItem = props.value[0];
+    if ("resource_id" in firstItem) {
+        return (props.value as ResourceInstanceListOption[]).map((item) => ({
+            id: item.resource_id,
+            label: item.display_value,
+            parentsLabel: null,
+        }));
+    }
+
+    return (props.value as SearchResultItem[]).map((item) => ({
+        id: item.id,
+        label: getItemLabel(
+            item,
+            selectedLanguage.value.code,
+            systemLanguage.value.code,
+        ).value,
+        parentsLabel: getParentLabels(
+            item,
+            selectedLanguage.value.code,
+            systemLanguage.value.code,
+        ),
+    }));
+});
 </script>
+
 <template>
     <div
-        v-for="searchResult in props.value"
-        :key="searchResult.id"
+        v-for="displayItem in displayItems"
+        :key="displayItem.id"
     >
         <span>
             <RouterLink
                 :to="{
                     name: routeNames.concept,
                     params: {
-                        id: searchResult.id,
+                        id: displayItem.id,
                     },
                 }"
                 class="text-link"
             >
-                {{
-                    getItemLabel(
-                        searchResult,
-                        selectedLanguage.code,
-                        systemLanguage.code,
-                    ).value
-                }}
+                {{ displayItem.label }}
             </RouterLink>
         </span>
-        <span class="concept-hierarchy">
-            [{{
-                getParentLabels(
-                    searchResult,
-                    selectedLanguage.code,
-                    systemLanguage.code,
-                )
-            }}]
+        <span
+            v-if="displayItem.parentsLabel"
+            class="concept-hierarchy"
+        >
+            [{{ displayItem.parentsLabel }}]
         </span>
     </div>
 </template>
+
 <style scoped>
 .concept-hierarchy {
     font-size: small;

--- a/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/components/ConceptResourceSelectWidgetViewer.vue
+++ b/arches_lingo/src/arches_lingo/components/widgets/ConceptResourceSelectWidget/components/ConceptResourceSelectWidgetViewer.vue
@@ -1,79 +1,59 @@
 <script setup lang="ts">
-import { computed } from "vue";
 import { storeToRefs } from "pinia";
 import { getItemLabel } from "@/arches_controlled_lists/utils.ts";
 import { getParentLabels } from "@/arches_lingo/utils.ts";
 import { useLanguageStore } from "@/arches_lingo/stores/useLanguageStore.ts";
 import { routeNames } from "@/arches_lingo/routes.ts";
 
-import type { ResourceInstanceListOption } from "@/arches_component_lab/datatypes/resource-instance-list/types.ts";
 import type { SearchResultItem } from "@/arches_lingo/types.ts";
 
-interface DisplayItem {
-    id: string;
-    label: string;
-    parentsLabel: string | null;
-}
-
 const props = defineProps<{
-    value?: SearchResultItem[] | ResourceInstanceListOption[] | null;
+    value?: SearchResultItem[];
 }>();
 
 const { selectedLanguage, systemLanguage } = storeToRefs(useLanguageStore());
-
-const displayItems = computed<DisplayItem[]>(() => {
-    if (!props.value?.length) {
-        return [];
-    }
-
-    const firstItem = props.value[0];
-    if ("resource_id" in firstItem) {
-        return (props.value as ResourceInstanceListOption[]).map((item) => ({
-            id: item.resource_id,
-            label: item.display_value,
-            parentsLabel: null,
-        }));
-    }
-
-    return (props.value as SearchResultItem[]).map((item) => ({
-        id: item.id,
-        label: getItemLabel(
-            item,
-            selectedLanguage.value.code,
-            systemLanguage.value.code,
-        ).value,
-        parentsLabel: getParentLabels(
-            item,
-            selectedLanguage.value.code,
-            systemLanguage.value.code,
-        ),
-    }));
-});
 </script>
-
 <template>
     <div
-        v-for="displayItem in displayItems"
-        :key="displayItem.id"
+        v-for="searchResult in props.value"
+        :key="searchResult.id"
     >
         <span>
             <RouterLink
                 :to="{
                     name: routeNames.concept,
                     params: {
-                        id: displayItem.id,
+                        id: searchResult.id,
                     },
                 }"
                 class="text-link"
             >
-                {{ displayItem.label }}
+                {{
+                    getItemLabel(
+                        searchResult,
+                        selectedLanguage.code,
+                        systemLanguage.code,
+                    ).value
+                }}
             </RouterLink>
         </span>
         <span
-            v-if="displayItem.parentsLabel"
+            v-if="
+                getParentLabels(
+                    searchResult,
+                    selectedLanguage.code,
+                    systemLanguage.code,
+                )
+            "
             class="concept-hierarchy"
         >
-            [{{ displayItem.parentsLabel }}]
+            [{{
+                getParentLabels(
+                    searchResult,
+                    selectedLanguage.code,
+                    systemLanguage.code,
+                )
+            }}]
         </span>
     </div>
 </template>

--- a/arches_lingo/src/arches_lingo/composables/useWidgetReadyTracker.ts
+++ b/arches_lingo/src/arches_lingo/composables/useWidgetReadyTracker.ts
@@ -1,7 +1,7 @@
 import { computed, inject, provide, ref } from "vue";
 
 /**
- * String injection key shared with GenericWidget (arches-component-lab).
+ * String injection key shared with GenericWidget (arches-vue-components).
  * GenericWidget injects this key to self-register and report readiness,
  * so a typed Symbol import is not possible across packages.
  */

--- a/arches_lingo/src/arches_lingo/constants.ts
+++ b/arches_lingo/src/arches_lingo/constants.ts
@@ -1,5 +1,5 @@
 import type { Component, InjectionKey, Ref } from "vue";
-import type { Language } from "@/arches_component_lab/types.ts";
+import type { Language } from "@/arches_vue_components/types.ts";
 import type { Concept } from "@/arches_lingo/types.ts";
 
 export const ERROR = "error";

--- a/arches_lingo/src/arches_lingo/pages/HomePage.vue
+++ b/arches_lingo/src/arches_lingo/pages/HomePage.vue
@@ -7,7 +7,7 @@ import MultiSelect from "primevue/multiselect";
 import Message from "primevue/message";
 import Skeleton from "primevue/skeleton";
 
-import { fetchLanguages } from "@/arches_component_lab/widgets/api.ts";
+import { fetchLanguages } from "@/arches_vue_components/widgets/api.ts";
 import {
     fetchDashboardStats,
     fetchLingoResources,
@@ -20,7 +20,7 @@ import DashboardStatCards from "@/arches_lingo/components/dashboard/DashboardSta
 import MissingTranslationsPanel from "@/arches_lingo/components/dashboard/MissingTranslationsPanel.vue";
 import RecentActivityTable from "@/arches_lingo/components/dashboard/RecentActivityTable.vue";
 
-import type { Language } from "@/arches_component_lab/types.ts";
+import type { Language } from "@/arches_vue_components/types.ts";
 import type {
     DashboardStats,
     MissingTranslationsResponse,

--- a/arches_lingo/src/arches_lingo/stores/useLanguageStore.ts
+++ b/arches_lingo/src/arches_lingo/stores/useLanguageStore.ts
@@ -7,7 +7,7 @@ import { fetchI18nData, fetchLanguages } from "@/arches_lingo/api.ts";
 import { FALLBACK_LANGUAGE } from "@/arches_lingo/constants.ts";
 import { getAutonym } from "@/arches_lingo/utils.ts";
 
-import type { Language } from "@/arches_component_lab/types";
+import type { Language } from "@/arches_vue_components/types";
 
 export const useLanguageStore = defineStore("language", () => {
     const gettext = useGettext();

--- a/arches_lingo/src/arches_lingo/types.ts
+++ b/arches_lingo/src/arches_lingo/types.ts
@@ -6,9 +6,8 @@ import type { EDIT, VIEW } from "@/arches_lingo/constants.ts";
 import type { ReferenceSelectTreeNode } from "@/arches_controlled_lists/datatypes/reference-select/types.ts";
 import type { Label } from "@/arches_controlled_lists/types.ts";
 
-import type { StringValue } from "@/arches_component_lab/datatypes/string/types.ts";
-import type { ResourceInstanceListValue } from "@/arches_component_lab/datatypes/resource-instance-list/types.ts";
-import type { FileListValue } from "@/arches_component_lab/datatypes/file-list/types.ts";
+import type { AliasedNodeData } from "@/arches_component_lab/types.ts";
+import type { FileReference } from "@/arches_component_lab/datatypes/file-list/types.ts";
 
 export interface User {
     first_name: string;
@@ -155,38 +154,38 @@ interface QuerysetsReferenceSelectFetchedOption {
 }
 
 export interface AppellativeStatusAliases extends AliasedData {
-    appellative_status_ascribed_name_content: StringValue;
+    appellative_status_ascribed_name_content: AliasedNodeData;
     appellative_status_ascribed_name_language?: QuerysetsReferenceSelectFetchedOption;
     appellative_status_ascribed_relation?: QuerysetsReferenceSelectFetchedOption;
     appellative_status_status_metatype?: QuerysetsReferenceSelectFetchedOption;
     appellative_status_status?: QuerysetsReferenceSelectFetchedOption;
-    appellative_status_data_assignment_object_used: ResourceInstanceListValue;
-    appellative_status_data_assignment_actor: ResourceInstanceListValue;
+    appellative_status_data_assignment_object_used: AliasedNodeData;
+    appellative_status_data_assignment_actor: AliasedNodeData;
     appellative_status_data_assignment_type: QuerysetsReferenceSelectFetchedOption;
-    appellative_status_timespan_begin_of_the_begin: StringValue;
-    appellative_status_timespan_end_of_the_end: StringValue;
+    appellative_status_timespan_begin_of_the_begin: AliasedNodeData;
+    appellative_status_timespan_end_of_the_end: AliasedNodeData;
 }
 
 export interface ConceptNameAlises extends AliasedData {
-    name: StringValue;
+    name: AliasedNodeData;
 }
 
 export type ConceptName = TileData<ConceptNameAlises>;
 
 export interface DigitalObjectContentAliases extends AliasedData {
-    content: FileListValue[];
+    content: AliasedNodeData;
 }
 
 export type DigitalObjectContent = TileData<DigitalObjectContentAliases>;
 
 export interface ConceptImagesAliases extends AliasedData {
-    depicting_digital_asset_internal: ResourceInstanceListValue;
+    depicting_digital_asset_internal: AliasedNodeData;
 }
 
 export type ConceptImages = TileData<ConceptImagesAliases>;
 
 export interface DigitalObjectNameAliases extends AliasedData {
-    name_content: StringValue;
+    name_content: AliasedNodeData;
 }
 
 export type DigitalObjectName = TileData<DigitalObjectNameAliases>;
@@ -202,52 +201,52 @@ export type DigitalObjectInstance = ResourceData<DigitalObjectInstanceAliases>;
 export type AppellativeStatus = TileData<AppellativeStatusAliases>;
 
 export interface ConceptStatementAliases extends AliasedData {
-    statement_content: StringValue;
+    statement_content: AliasedNodeData;
     statement_language?: QuerysetsReferenceSelectFetchedOption;
     statement_type?: QuerysetsReferenceSelectFetchedOption;
     statement_type_metatype?: QuerysetsReferenceSelectFetchedOption;
-    statement_data_assignment_object_used?: ResourceInstanceListValue;
-    statement_data_assignment_actor?: ResourceInstanceListValue;
+    statement_data_assignment_object_used?: AliasedNodeData;
+    statement_data_assignment_actor?: AliasedNodeData;
     statement_data_assignment_type?: QuerysetsReferenceSelectFetchedOption;
-    statement_data_assignment_timespan_begin_of_the_begin?: StringValue | null;
-    statement_data_assignment_timespan_end_of_the_end?: StringValue | null;
+    statement_data_assignment_timespan_begin_of_the_begin?: AliasedNodeData | null;
+    statement_data_assignment_timespan_end_of_the_end?: AliasedNodeData | null;
 }
 
 export type ConceptStatement = TileData<ConceptStatementAliases>;
 
 export interface ConceptRelationAliases extends AliasedData {
-    relation_status_ascribed_comparate: ResourceInstanceListValue;
+    relation_status_ascribed_comparate: AliasedNodeData;
     relation_status_ascribed_relation: ReferenceSelectTreeNode[];
     relation_status_status: ReferenceSelectTreeNode[];
     relation_status_status_metatype: ReferenceSelectTreeNode[];
     relation_status_timespan_begin_of_the_begin: string;
     relation_status_timespan_end_of_the_end: string;
-    relation_status_data_assignment_actor: ResourceInstanceListValue;
-    relation_status_data_assignment_object_used: ResourceInstanceListValue;
+    relation_status_data_assignment_actor: AliasedNodeData;
+    relation_status_data_assignment_object_used: AliasedNodeData;
     relation_status_data_assignment_type: ReferenceSelectTreeNode[];
 }
 
 export type ConceptRelationStatus = TileData<ConceptRelationAliases>;
 
 export interface ConceptMatchAliases extends AliasedData {
-    match_status_ascribed_comparate: StringValue;
+    match_status_ascribed_comparate: AliasedNodeData;
     match_status_ascribed_relation: ReferenceSelectTreeNode[];
     match_status_status: ReferenceSelectTreeNode[];
     match_status_status_metatype: ReferenceSelectTreeNode[];
     match_status_timespan_begin_of_the_begin: string;
     match_status_timespan_end_of_the_end: string;
-    match_status_data_assignment_actor: ResourceInstanceListValue;
-    match_status_data_assignment_object_used: ResourceInstanceListValue;
+    match_status_data_assignment_actor: AliasedNodeData;
+    match_status_data_assignment_object_used: AliasedNodeData;
     match_status_data_assignment_type: ReferenceSelectTreeNode[];
 }
 
 export type ConceptMatchStatus = TileData<ConceptMatchAliases>;
 
 export interface ConceptClassificationStatusAliases extends AliasedData {
-    classification_status_ascribed_classification: ResourceInstanceListValue;
+    classification_status_ascribed_classification: AliasedNodeData;
     classification_status_ascribed_relation: ReferenceSelectTreeNode[];
-    classification_status_data_assignment_actor: ResourceInstanceListValue;
-    classification_status_data_assignment_object_used: ResourceInstanceListValue;
+    classification_status_data_assignment_actor: AliasedNodeData;
+    classification_status_data_assignment_object_used: AliasedNodeData;
     classification_status_data_assignment_type: ReferenceSelectTreeNode[];
     classification_status_timespan_begin_of_the_begin: string;
     classification_status_timespan_end_of_the_end: string;
@@ -266,8 +265,8 @@ export interface ConceptTypeAliases extends AliasedData {
 export type ConceptType = TileData<ConceptTypeAliases>;
 
 export interface IdentifierAliases extends AliasedData {
-    identifier_content: StringValue;
-    identifier_label?: StringValue;
+    identifier_content: AliasedNodeData;
+    identifier_label?: AliasedNodeData;
     identifier_type?: QuerysetsReferenceSelectFetchedOption;
     identifier_type_metatype?: QuerysetsReferenceSelectFetchedOption;
 }
@@ -275,21 +274,21 @@ export interface IdentifierAliases extends AliasedData {
 export type Identifier = TileData<IdentifierAliases>;
 
 export interface SchemeStatementAliases extends AliasedData {
-    statement_content: StringValue;
+    statement_content: AliasedNodeData;
     statement_language?: QuerysetsReferenceSelectFetchedOption;
     statement_type?: QuerysetsReferenceSelectFetchedOption;
     statement_type_metatype?: QuerysetsReferenceSelectFetchedOption;
-    statement_data_assignment_object_used?: ResourceInstanceListValue;
-    statement_data_assignment_actor?: ResourceInstanceListValue;
+    statement_data_assignment_object_used?: AliasedNodeData;
+    statement_data_assignment_actor?: AliasedNodeData;
     statement_data_assignment_type?: QuerysetsReferenceSelectFetchedOption;
-    statement_data_assignment_timespan_begin_of_the_begin?: StringValue | null;
-    statement_data_assignment_timespan_end_of_the_end?: StringValue | null;
+    statement_data_assignment_timespan_begin_of_the_begin?: AliasedNodeData | null;
+    statement_data_assignment_timespan_end_of_the_end?: AliasedNodeData | null;
 }
 
 export type SchemeStatement = TileData<SchemeStatementAliases>;
 
 export interface SchemeRightsAliases extends TileData {
-    right_holder?: ResourceInstanceListValue;
+    right_holder?: AliasedNodeData;
     right_type?: QuerysetsReferenceSelectFetchedOption;
     right_statement?: SchemeRightStatement;
 }
@@ -297,8 +296,8 @@ export interface SchemeRightsAliases extends TileData {
 export type SchemeRights = TileData<SchemeRightsAliases>;
 
 export interface SchemeRightStatementAliases extends AliasedData {
-    right_statement_content?: StringValue;
-    right_statement_label?: StringValue;
+    right_statement_content?: AliasedNodeData;
+    right_statement_label?: AliasedNodeData;
     right_statement_language?: QuerysetsReferenceSelectFetchedOption;
     right_statement_type?: QuerysetsReferenceSelectFetchedOption;
     right_statement_type_metatype?: QuerysetsReferenceSelectFetchedOption;
@@ -307,14 +306,14 @@ export interface SchemeRightStatementAliases extends AliasedData {
 export type SchemeRightStatement = TileData<SchemeRightStatementAliases>;
 
 export interface SchemeNamespaceAliases extends AliasedData {
-    namespace_name: StringValue;
+    namespace_name: AliasedNodeData;
     namespace_type: QuerysetsReferenceSelectFetchedOption;
 }
 
 export type SchemeNamespace = TileData<SchemeNamespaceAliases>;
 
 export interface SchemeCreationAliases extends AliasedData {
-    creation_sources: ResourceInstanceListValue;
+    creation_sources: AliasedNodeData;
 }
 
 export type SchemeCreation = TileData<SchemeCreationAliases>;
@@ -330,13 +329,13 @@ export interface ConceptInstance {
 
 export interface ConceptClassificationStatusAliases extends AliasedData {
     aliased_data: {
-        classification_status_ascribed_classification?: ResourceInstanceListValue;
+        classification_status_ascribed_classification?: AliasedNodeData;
         classification_status_ascribed_relation?: QuerysetsReferenceSelectFetchedOption;
-        classification_status_data_assignment_actor?: ResourceInstanceListValue;
-        classification_status_data_assignment_object_used?: ResourceInstanceListValue;
+        classification_status_data_assignment_actor?: AliasedNodeData;
+        classification_status_data_assignment_object_used?: AliasedNodeData;
         classification_status_data_assignment_type?: QuerysetsReferenceSelectFetchedOption;
-        classification_status_timespan_end_of_the_end?: StringValue | null;
-        classification_status_timespan_begin_of_the_begin?: StringValue | null;
+        classification_status_timespan_end_of_the_end?: AliasedNodeData | null;
+        classification_status_timespan_begin_of_the_begin?: AliasedNodeData | null;
         classification_status_type?: QuerysetsReferenceSelectFetchedOption;
         classification_status_type_metatype?: QuerysetsReferenceSelectFetchedOption;
     };
@@ -348,9 +347,9 @@ export interface ConceptHeaderData {
     descriptor?: ResourceDescriptor;
     principalUser?: number | string;
     lifeCycleState: string;
-    partOfScheme?: ResourceInstanceListValue;
+    partOfScheme?: AliasedNodeData;
     schemeLabel?: string;
-    parentConcepts?: ResourceInstanceListValue[];
+    parentConcepts?: AliasedNodeData[];
     type?: ReferenceSelectTreeNode[];
     status?: ReferenceSelectTreeNode[];
     identifier?: string;

--- a/arches_lingo/src/arches_lingo/types.ts
+++ b/arches_lingo/src/arches_lingo/types.ts
@@ -9,8 +9,6 @@ import type {
 } from "@/arches_controlled_lists/datatypes/reference-select/types.ts";
 import type { Label } from "@/arches_controlled_lists/types.ts";
 
-import type { AliasedNodeData } from "@/arches_component_lab/types.ts";
-
 export interface User {
     first_name: string;
     last_name: string;
@@ -153,38 +151,38 @@ export interface ResourceData<T extends AliasedData = AliasedData> {
 type QuerysetsReferenceSelectFetchedOption = ReferenceSelectNodeValue[] | null;
 
 export interface AppellativeStatusAliases extends AliasedData {
-    appellative_status_ascribed_name_content: AliasedNodeData;
+    appellative_status_ascribed_name_content: unknown;
     appellative_status_ascribed_name_language?: QuerysetsReferenceSelectFetchedOption;
     appellative_status_ascribed_relation?: QuerysetsReferenceSelectFetchedOption;
     appellative_status_status_metatype?: QuerysetsReferenceSelectFetchedOption;
     appellative_status_status?: QuerysetsReferenceSelectFetchedOption;
-    appellative_status_data_assignment_object_used: AliasedNodeData;
-    appellative_status_data_assignment_actor: AliasedNodeData;
+    appellative_status_data_assignment_object_used: unknown;
+    appellative_status_data_assignment_actor: unknown;
     appellative_status_data_assignment_type: QuerysetsReferenceSelectFetchedOption;
-    appellative_status_timespan_begin_of_the_begin: AliasedNodeData;
-    appellative_status_timespan_end_of_the_end: AliasedNodeData;
+    appellative_status_timespan_begin_of_the_begin: unknown;
+    appellative_status_timespan_end_of_the_end: unknown;
 }
 
 export interface ConceptNameAlises extends AliasedData {
-    name: AliasedNodeData;
+    name: unknown;
 }
 
 export type ConceptName = TileData<ConceptNameAlises>;
 
 export interface DigitalObjectContentAliases extends AliasedData {
-    content: AliasedNodeData;
+    content: unknown;
 }
 
 export type DigitalObjectContent = TileData<DigitalObjectContentAliases>;
 
 export interface ConceptImagesAliases extends AliasedData {
-    depicting_digital_asset_internal: AliasedNodeData;
+    depicting_digital_asset_internal: unknown;
 }
 
 export type ConceptImages = TileData<ConceptImagesAliases>;
 
 export interface DigitalObjectNameAliases extends AliasedData {
-    name_content: AliasedNodeData;
+    name_content: unknown;
 }
 
 export type DigitalObjectName = TileData<DigitalObjectNameAliases>;
@@ -200,52 +198,52 @@ export type DigitalObjectInstance = ResourceData<DigitalObjectInstanceAliases>;
 export type AppellativeStatus = TileData<AppellativeStatusAliases>;
 
 export interface ConceptStatementAliases extends AliasedData {
-    statement_content: AliasedNodeData;
+    statement_content: unknown;
     statement_language?: QuerysetsReferenceSelectFetchedOption;
     statement_type?: QuerysetsReferenceSelectFetchedOption;
     statement_type_metatype?: QuerysetsReferenceSelectFetchedOption;
-    statement_data_assignment_object_used?: AliasedNodeData;
-    statement_data_assignment_actor?: AliasedNodeData;
+    statement_data_assignment_object_used?: unknown;
+    statement_data_assignment_actor?: unknown;
     statement_data_assignment_type?: QuerysetsReferenceSelectFetchedOption;
-    statement_data_assignment_timespan_begin_of_the_begin?: AliasedNodeData | null;
-    statement_data_assignment_timespan_end_of_the_end?: AliasedNodeData | null;
+    statement_data_assignment_timespan_begin_of_the_begin?: unknown | null;
+    statement_data_assignment_timespan_end_of_the_end?: unknown | null;
 }
 
 export type ConceptStatement = TileData<ConceptStatementAliases>;
 
 export interface ConceptRelationAliases extends AliasedData {
-    relation_status_ascribed_comparate: AliasedNodeData;
+    relation_status_ascribed_comparate: unknown;
     relation_status_ascribed_relation: ReferenceSelectTreeNode[];
     relation_status_status: ReferenceSelectTreeNode[];
     relation_status_status_metatype: ReferenceSelectTreeNode[];
     relation_status_timespan_begin_of_the_begin: string;
     relation_status_timespan_end_of_the_end: string;
-    relation_status_data_assignment_actor: AliasedNodeData;
-    relation_status_data_assignment_object_used: AliasedNodeData;
+    relation_status_data_assignment_actor: unknown;
+    relation_status_data_assignment_object_used: unknown;
     relation_status_data_assignment_type: ReferenceSelectTreeNode[];
 }
 
 export type ConceptRelationStatus = TileData<ConceptRelationAliases>;
 
 export interface ConceptMatchAliases extends AliasedData {
-    match_status_ascribed_comparate: AliasedNodeData;
+    match_status_ascribed_comparate: unknown;
     match_status_ascribed_relation: ReferenceSelectTreeNode[];
     match_status_status: ReferenceSelectTreeNode[];
     match_status_status_metatype: ReferenceSelectTreeNode[];
     match_status_timespan_begin_of_the_begin: string;
     match_status_timespan_end_of_the_end: string;
-    match_status_data_assignment_actor: AliasedNodeData;
-    match_status_data_assignment_object_used: AliasedNodeData;
+    match_status_data_assignment_actor: unknown;
+    match_status_data_assignment_object_used: unknown;
     match_status_data_assignment_type: ReferenceSelectTreeNode[];
 }
 
 export type ConceptMatchStatus = TileData<ConceptMatchAliases>;
 
 export interface ConceptClassificationStatusAliases extends AliasedData {
-    classification_status_ascribed_classification: AliasedNodeData;
+    classification_status_ascribed_classification: unknown;
     classification_status_ascribed_relation: ReferenceSelectTreeNode[];
-    classification_status_data_assignment_actor: AliasedNodeData;
-    classification_status_data_assignment_object_used: AliasedNodeData;
+    classification_status_data_assignment_actor: unknown;
+    classification_status_data_assignment_object_used: unknown;
     classification_status_data_assignment_type: ReferenceSelectTreeNode[];
     classification_status_timespan_begin_of_the_begin: string;
     classification_status_timespan_end_of_the_end: string;
@@ -264,8 +262,8 @@ export interface ConceptTypeAliases extends AliasedData {
 export type ConceptType = TileData<ConceptTypeAliases>;
 
 export interface IdentifierAliases extends AliasedData {
-    identifier_content: AliasedNodeData;
-    identifier_label?: AliasedNodeData;
+    identifier_content: unknown;
+    identifier_label?: unknown;
     identifier_type?: QuerysetsReferenceSelectFetchedOption;
     identifier_type_metatype?: QuerysetsReferenceSelectFetchedOption;
 }
@@ -273,21 +271,21 @@ export interface IdentifierAliases extends AliasedData {
 export type Identifier = TileData<IdentifierAliases>;
 
 export interface SchemeStatementAliases extends AliasedData {
-    statement_content: AliasedNodeData;
+    statement_content: unknown;
     statement_language?: QuerysetsReferenceSelectFetchedOption;
     statement_type?: QuerysetsReferenceSelectFetchedOption;
     statement_type_metatype?: QuerysetsReferenceSelectFetchedOption;
-    statement_data_assignment_object_used?: AliasedNodeData;
-    statement_data_assignment_actor?: AliasedNodeData;
+    statement_data_assignment_object_used?: unknown;
+    statement_data_assignment_actor?: unknown;
     statement_data_assignment_type?: QuerysetsReferenceSelectFetchedOption;
-    statement_data_assignment_timespan_begin_of_the_begin?: AliasedNodeData | null;
-    statement_data_assignment_timespan_end_of_the_end?: AliasedNodeData | null;
+    statement_data_assignment_timespan_begin_of_the_begin?: unknown | null;
+    statement_data_assignment_timespan_end_of_the_end?: unknown | null;
 }
 
 export type SchemeStatement = TileData<SchemeStatementAliases>;
 
 export interface SchemeRightsAliases extends TileData {
-    right_holder?: AliasedNodeData;
+    right_holder?: unknown;
     right_type?: QuerysetsReferenceSelectFetchedOption;
     right_statement?: SchemeRightStatement;
 }
@@ -295,8 +293,8 @@ export interface SchemeRightsAliases extends TileData {
 export type SchemeRights = TileData<SchemeRightsAliases>;
 
 export interface SchemeRightStatementAliases extends AliasedData {
-    right_statement_content?: AliasedNodeData;
-    right_statement_label?: AliasedNodeData;
+    right_statement_content?: unknown;
+    right_statement_label?: unknown;
     right_statement_language?: QuerysetsReferenceSelectFetchedOption;
     right_statement_type?: QuerysetsReferenceSelectFetchedOption;
     right_statement_type_metatype?: QuerysetsReferenceSelectFetchedOption;
@@ -305,14 +303,14 @@ export interface SchemeRightStatementAliases extends AliasedData {
 export type SchemeRightStatement = TileData<SchemeRightStatementAliases>;
 
 export interface SchemeNamespaceAliases extends AliasedData {
-    namespace_name: AliasedNodeData;
+    namespace_name: unknown;
     namespace_type: QuerysetsReferenceSelectFetchedOption;
 }
 
 export type SchemeNamespace = TileData<SchemeNamespaceAliases>;
 
 export interface SchemeCreationAliases extends AliasedData {
-    creation_sources: AliasedNodeData;
+    creation_sources: unknown;
 }
 
 export type SchemeCreation = TileData<SchemeCreationAliases>;
@@ -328,13 +326,13 @@ export interface ConceptInstance {
 
 export interface ConceptClassificationStatusAliases extends AliasedData {
     aliased_data: {
-        classification_status_ascribed_classification?: AliasedNodeData;
+        classification_status_ascribed_classification?: unknown;
         classification_status_ascribed_relation?: QuerysetsReferenceSelectFetchedOption;
-        classification_status_data_assignment_actor?: AliasedNodeData;
-        classification_status_data_assignment_object_used?: AliasedNodeData;
+        classification_status_data_assignment_actor?: unknown;
+        classification_status_data_assignment_object_used?: unknown;
         classification_status_data_assignment_type?: QuerysetsReferenceSelectFetchedOption;
-        classification_status_timespan_end_of_the_end?: AliasedNodeData | null;
-        classification_status_timespan_begin_of_the_begin?: AliasedNodeData | null;
+        classification_status_timespan_end_of_the_end?: unknown | null;
+        classification_status_timespan_begin_of_the_begin?: unknown | null;
         classification_status_type?: QuerysetsReferenceSelectFetchedOption;
         classification_status_type_metatype?: QuerysetsReferenceSelectFetchedOption;
     };
@@ -346,9 +344,9 @@ export interface ConceptHeaderData {
     descriptor?: ResourceDescriptor;
     principalUser?: number | string;
     lifeCycleState: string;
-    partOfScheme?: AliasedNodeData;
+    partOfScheme?: unknown;
     schemeLabel?: string;
-    parentConcepts?: AliasedNodeData[];
+    parentConcepts?: unknown[];
     type?: ReferenceSelectTreeNode[];
     status?: ReferenceSelectTreeNode[];
     identifier?: string;

--- a/arches_lingo/src/arches_lingo/types.ts
+++ b/arches_lingo/src/arches_lingo/types.ts
@@ -3,11 +3,12 @@ import type { MenuItem } from "primevue/menuitem";
 import type { TreeNode } from "primevue/treenode";
 import type { EDIT, VIEW } from "@/arches_lingo/constants.ts";
 
-import type {
-    ReferenceSelectTreeNode,
-    ReferenceSelectNodeValue,
-} from "@/arches_controlled_lists/datatypes/reference-select/types.ts";
+import type { ReferenceSelectTreeNode } from "@/arches_controlled_lists/datatypes/reference-select/types.ts";
 import type { Label } from "@/arches_controlled_lists/types.ts";
+
+import type { StringAliasedNodeData } from "@/arches_component_lab/datatypes/string/types.ts";
+import type { ResourceInstanceListAliasedNodeData } from "@/arches_component_lab/datatypes/resource-instance-list/types.ts";
+import type { FileListAliasedNodeData } from "@/arches_component_lab/datatypes/file-list/types.ts";
 
 export interface User {
     first_name: string;
@@ -148,41 +149,45 @@ export interface ResourceData<T extends AliasedData = AliasedData> {
     aliased_data: T;
 }
 
-type QuerysetsReferenceSelectFetchedOption = ReferenceSelectNodeValue[] | null;
+interface QuerysetsReferenceSelectFetchedOption {
+    display_value: string;
+    node_value: ReferenceSelectTreeNode[];
+    details: unknown[];
+}
 
 export interface AppellativeStatusAliases extends AliasedData {
-    appellative_status_ascribed_name_content: unknown;
+    appellative_status_ascribed_name_content: StringAliasedNodeData;
     appellative_status_ascribed_name_language?: QuerysetsReferenceSelectFetchedOption;
     appellative_status_ascribed_relation?: QuerysetsReferenceSelectFetchedOption;
     appellative_status_status_metatype?: QuerysetsReferenceSelectFetchedOption;
     appellative_status_status?: QuerysetsReferenceSelectFetchedOption;
-    appellative_status_data_assignment_object_used: unknown;
-    appellative_status_data_assignment_actor: unknown;
+    appellative_status_data_assignment_object_used: ResourceInstanceListAliasedNodeData;
+    appellative_status_data_assignment_actor: ResourceInstanceListAliasedNodeData;
     appellative_status_data_assignment_type: QuerysetsReferenceSelectFetchedOption;
-    appellative_status_timespan_begin_of_the_begin: unknown;
-    appellative_status_timespan_end_of_the_end: unknown;
+    appellative_status_timespan_begin_of_the_begin: StringAliasedNodeData;
+    appellative_status_timespan_end_of_the_end: StringAliasedNodeData;
 }
 
 export interface ConceptNameAlises extends AliasedData {
-    name: unknown;
+    name: StringAliasedNodeData;
 }
 
 export type ConceptName = TileData<ConceptNameAlises>;
 
 export interface DigitalObjectContentAliases extends AliasedData {
-    content: unknown;
+    content: FileListAliasedNodeData;
 }
 
 export type DigitalObjectContent = TileData<DigitalObjectContentAliases>;
 
 export interface ConceptImagesAliases extends AliasedData {
-    depicting_digital_asset_internal: unknown;
+    depicting_digital_asset_internal: ResourceInstanceListAliasedNodeData;
 }
 
 export type ConceptImages = TileData<ConceptImagesAliases>;
 
 export interface DigitalObjectNameAliases extends AliasedData {
-    name_content: unknown;
+    name_content: StringAliasedNodeData;
 }
 
 export type DigitalObjectName = TileData<DigitalObjectNameAliases>;
@@ -198,52 +203,52 @@ export type DigitalObjectInstance = ResourceData<DigitalObjectInstanceAliases>;
 export type AppellativeStatus = TileData<AppellativeStatusAliases>;
 
 export interface ConceptStatementAliases extends AliasedData {
-    statement_content: unknown;
+    statement_content: StringAliasedNodeData;
     statement_language?: QuerysetsReferenceSelectFetchedOption;
     statement_type?: QuerysetsReferenceSelectFetchedOption;
     statement_type_metatype?: QuerysetsReferenceSelectFetchedOption;
-    statement_data_assignment_object_used?: unknown;
-    statement_data_assignment_actor?: unknown;
+    statement_data_assignment_object_used?: ResourceInstanceListAliasedNodeData;
+    statement_data_assignment_actor?: ResourceInstanceListAliasedNodeData;
     statement_data_assignment_type?: QuerysetsReferenceSelectFetchedOption;
-    statement_data_assignment_timespan_begin_of_the_begin?: unknown | null;
-    statement_data_assignment_timespan_end_of_the_end?: unknown | null;
+    statement_data_assignment_timespan_begin_of_the_begin?: StringAliasedNodeData | null;
+    statement_data_assignment_timespan_end_of_the_end?: StringAliasedNodeData | null;
 }
 
 export type ConceptStatement = TileData<ConceptStatementAliases>;
 
 export interface ConceptRelationAliases extends AliasedData {
-    relation_status_ascribed_comparate: unknown;
-    relation_status_ascribed_relation: ReferenceSelectTreeNode[];
-    relation_status_status: ReferenceSelectTreeNode[];
-    relation_status_status_metatype: ReferenceSelectTreeNode[];
-    relation_status_timespan_begin_of_the_begin: string;
-    relation_status_timespan_end_of_the_end: string;
-    relation_status_data_assignment_actor: unknown;
-    relation_status_data_assignment_object_used: unknown;
-    relation_status_data_assignment_type: ReferenceSelectTreeNode[];
+    relation_status_ascribed_comparate: ResourceInstanceListAliasedNodeData;
+    relation_status_ascribed_relation: QuerysetsReferenceSelectFetchedOption;
+    relation_status_status: QuerysetsReferenceSelectFetchedOption;
+    relation_status_status_metatype: QuerysetsReferenceSelectFetchedOption;
+    relation_status_timespan_begin_of_the_begin: StringAliasedNodeData;
+    relation_status_timespan_end_of_the_end: StringAliasedNodeData;
+    relation_status_data_assignment_actor: ResourceInstanceListAliasedNodeData;
+    relation_status_data_assignment_object_used: ResourceInstanceListAliasedNodeData;
+    relation_status_data_assignment_type: QuerysetsReferenceSelectFetchedOption;
 }
 
 export type ConceptRelationStatus = TileData<ConceptRelationAliases>;
 
 export interface ConceptMatchAliases extends AliasedData {
-    match_status_ascribed_comparate: unknown;
-    match_status_ascribed_relation: ReferenceSelectTreeNode[];
-    match_status_status: ReferenceSelectTreeNode[];
-    match_status_status_metatype: ReferenceSelectTreeNode[];
-    match_status_timespan_begin_of_the_begin: string;
-    match_status_timespan_end_of_the_end: string;
-    match_status_data_assignment_actor: unknown;
-    match_status_data_assignment_object_used: unknown;
-    match_status_data_assignment_type: ReferenceSelectTreeNode[];
+    match_status_ascribed_comparate: StringAliasedNodeData;
+    match_status_ascribed_relation: QuerysetsReferenceSelectFetchedOption;
+    match_status_status: QuerysetsReferenceSelectFetchedOption;
+    match_status_status_metatype: QuerysetsReferenceSelectFetchedOption;
+    match_status_timespan_begin_of_the_begin: StringAliasedNodeData;
+    match_status_timespan_end_of_the_end: StringAliasedNodeData;
+    match_status_data_assignment_actor: ResourceInstanceListAliasedNodeData;
+    match_status_data_assignment_object_used: ResourceInstanceListAliasedNodeData;
+    match_status_data_assignment_type: QuerysetsReferenceSelectFetchedOption;
 }
 
 export type ConceptMatchStatus = TileData<ConceptMatchAliases>;
 
 export interface ConceptClassificationStatusAliases extends AliasedData {
-    classification_status_ascribed_classification: unknown;
+    classification_status_ascribed_classification: ResourceInstanceListAliasedNodeData;
     classification_status_ascribed_relation: ReferenceSelectTreeNode[];
-    classification_status_data_assignment_actor: unknown;
-    classification_status_data_assignment_object_used: unknown;
+    classification_status_data_assignment_actor: ResourceInstanceListAliasedNodeData;
+    classification_status_data_assignment_object_used: ResourceInstanceListAliasedNodeData;
     classification_status_data_assignment_type: ReferenceSelectTreeNode[];
     classification_status_timespan_begin_of_the_begin: string;
     classification_status_timespan_end_of_the_end: string;
@@ -255,15 +260,15 @@ export type ConceptClassificationStatus =
     TileData<ConceptClassificationStatusAliases>;
 
 export interface ConceptTypeAliases extends AliasedData {
-    type: ReferenceSelectTreeNode[];
-    metatype?: ReferenceSelectTreeNode[];
+    type: QuerysetsReferenceSelectFetchedOption;
+    metatype?: QuerysetsReferenceSelectFetchedOption;
 }
 
 export type ConceptType = TileData<ConceptTypeAliases>;
 
 export interface IdentifierAliases extends AliasedData {
-    identifier_content: unknown;
-    identifier_label?: unknown;
+    identifier_content: StringAliasedNodeData;
+    identifier_label?: StringAliasedNodeData;
     identifier_type?: QuerysetsReferenceSelectFetchedOption;
     identifier_type_metatype?: QuerysetsReferenceSelectFetchedOption;
 }
@@ -271,21 +276,21 @@ export interface IdentifierAliases extends AliasedData {
 export type Identifier = TileData<IdentifierAliases>;
 
 export interface SchemeStatementAliases extends AliasedData {
-    statement_content: unknown;
+    statement_content: StringAliasedNodeData;
     statement_language?: QuerysetsReferenceSelectFetchedOption;
     statement_type?: QuerysetsReferenceSelectFetchedOption;
     statement_type_metatype?: QuerysetsReferenceSelectFetchedOption;
-    statement_data_assignment_object_used?: unknown;
-    statement_data_assignment_actor?: unknown;
+    statement_data_assignment_object_used?: ResourceInstanceListAliasedNodeData;
+    statement_data_assignment_actor?: ResourceInstanceListAliasedNodeData;
     statement_data_assignment_type?: QuerysetsReferenceSelectFetchedOption;
-    statement_data_assignment_timespan_begin_of_the_begin?: unknown | null;
-    statement_data_assignment_timespan_end_of_the_end?: unknown | null;
+    statement_data_assignment_timespan_begin_of_the_begin?: StringAliasedNodeData | null;
+    statement_data_assignment_timespan_end_of_the_end?: StringAliasedNodeData | null;
 }
 
 export type SchemeStatement = TileData<SchemeStatementAliases>;
 
 export interface SchemeRightsAliases extends TileData {
-    right_holder?: unknown;
+    right_holder?: ResourceInstanceListAliasedNodeData;
     right_type?: QuerysetsReferenceSelectFetchedOption;
     right_statement?: SchemeRightStatement;
 }
@@ -293,8 +298,8 @@ export interface SchemeRightsAliases extends TileData {
 export type SchemeRights = TileData<SchemeRightsAliases>;
 
 export interface SchemeRightStatementAliases extends AliasedData {
-    right_statement_content?: unknown;
-    right_statement_label?: unknown;
+    right_statement_content?: StringAliasedNodeData;
+    right_statement_label?: StringAliasedNodeData;
     right_statement_language?: QuerysetsReferenceSelectFetchedOption;
     right_statement_type?: QuerysetsReferenceSelectFetchedOption;
     right_statement_type_metatype?: QuerysetsReferenceSelectFetchedOption;
@@ -303,14 +308,14 @@ export interface SchemeRightStatementAliases extends AliasedData {
 export type SchemeRightStatement = TileData<SchemeRightStatementAliases>;
 
 export interface SchemeNamespaceAliases extends AliasedData {
-    namespace_name: unknown;
+    namespace_name: StringAliasedNodeData;
     namespace_type: QuerysetsReferenceSelectFetchedOption;
 }
 
 export type SchemeNamespace = TileData<SchemeNamespaceAliases>;
 
 export interface SchemeCreationAliases extends AliasedData {
-    creation_sources: unknown;
+    creation_sources: ResourceInstanceListAliasedNodeData;
 }
 
 export type SchemeCreation = TileData<SchemeCreationAliases>;
@@ -326,13 +331,13 @@ export interface ConceptInstance {
 
 export interface ConceptClassificationStatusAliases extends AliasedData {
     aliased_data: {
-        classification_status_ascribed_classification?: unknown;
+        classification_status_ascribed_classification?: ResourceInstanceListAliasedNodeData;
         classification_status_ascribed_relation?: QuerysetsReferenceSelectFetchedOption;
-        classification_status_data_assignment_actor?: unknown;
-        classification_status_data_assignment_object_used?: unknown;
+        classification_status_data_assignment_actor?: ResourceInstanceListAliasedNodeData;
+        classification_status_data_assignment_object_used?: ResourceInstanceListAliasedNodeData;
         classification_status_data_assignment_type?: QuerysetsReferenceSelectFetchedOption;
-        classification_status_timespan_end_of_the_end?: unknown | null;
-        classification_status_timespan_begin_of_the_begin?: unknown | null;
+        classification_status_timespan_end_of_the_end?: StringAliasedNodeData | null;
+        classification_status_timespan_begin_of_the_begin?: StringAliasedNodeData | null;
         classification_status_type?: QuerysetsReferenceSelectFetchedOption;
         classification_status_type_metatype?: QuerysetsReferenceSelectFetchedOption;
     };
@@ -344,9 +349,9 @@ export interface ConceptHeaderData {
     descriptor?: ResourceDescriptor;
     principalUser?: number | string;
     lifeCycleState: string;
-    partOfScheme?: unknown;
+    partOfScheme?: ResourceInstanceListAliasedNodeData;
     schemeLabel?: string;
-    parentConcepts?: unknown[];
+    parentConcepts?: ResourceInstanceListAliasedNodeData[];
     type?: ReferenceSelectTreeNode[];
     status?: ReferenceSelectTreeNode[];
     identifier?: string;

--- a/arches_lingo/src/arches_lingo/types.ts
+++ b/arches_lingo/src/arches_lingo/types.ts
@@ -3,11 +3,13 @@ import type { MenuItem } from "primevue/menuitem";
 import type { TreeNode } from "primevue/treenode";
 import type { EDIT, VIEW } from "@/arches_lingo/constants.ts";
 
-import type { ReferenceSelectTreeNode } from "@/arches_controlled_lists/datatypes/reference-select/types.ts";
+import type {
+    ReferenceSelectTreeNode,
+    ReferenceSelectNodeValue,
+} from "@/arches_controlled_lists/datatypes/reference-select/types.ts";
 import type { Label } from "@/arches_controlled_lists/types.ts";
 
 import type { AliasedNodeData } from "@/arches_component_lab/types.ts";
-import type { FileReference } from "@/arches_component_lab/datatypes/file-list/types.ts";
 
 export interface User {
     first_name: string;
@@ -148,10 +150,7 @@ export interface ResourceData<T extends AliasedData = AliasedData> {
     aliased_data: T;
 }
 
-interface QuerysetsReferenceSelectFetchedOption {
-    display_value: string;
-    node_value: ReferenceSelectTreeNode[];
-}
+type QuerysetsReferenceSelectFetchedOption = ReferenceSelectNodeValue[] | null;
 
 export interface AppellativeStatusAliases extends AliasedData {
     appellative_status_ascribed_name_content: AliasedNodeData;

--- a/arches_lingo/src/arches_lingo/types.ts
+++ b/arches_lingo/src/arches_lingo/types.ts
@@ -7,7 +7,10 @@ import type { ReferenceSelectTreeNode } from "@/arches_controlled_lists/datatype
 import type { Label } from "@/arches_controlled_lists/types.ts";
 
 import type { StringAliasedNodeData } from "@/arches_component_lab/datatypes/string/types.ts";
-import type { ResourceInstanceListAliasedNodeData } from "@/arches_component_lab/datatypes/resource-instance-list/types.ts";
+import type {
+    ResourceInstanceListAliasedNodeData,
+    ResourceInstanceReference,
+} from "@/arches_component_lab/datatypes/resource-instance-list/types.ts";
 import type { FileListAliasedNodeData } from "@/arches_component_lab/datatypes/file-list/types.ts";
 
 export interface User {
@@ -351,7 +354,7 @@ export interface ConceptHeaderData {
     lifeCycleState: string;
     partOfScheme?: ResourceInstanceListAliasedNodeData;
     schemeLabel?: string;
-    parentConcepts?: ResourceInstanceListAliasedNodeData[];
+    parentConcepts?: ResourceInstanceReference[];
     type?: ReferenceSelectTreeNode[];
     status?: ReferenceSelectTreeNode[];
     identifier?: string;

--- a/arches_lingo/src/arches_lingo/types.ts
+++ b/arches_lingo/src/arches_lingo/types.ts
@@ -520,7 +520,14 @@ export type FacetType =
     | "lifecycle_state"
     | "concept_set"
     | "attribution_source"
-    | "attribution_contributor";
+    | "attribution_contributor"
+    | "related_image";
+
+export type ImageAttribute =
+    | "has_image"
+    | "file_name"
+    | "title"
+    | "description";
 
 export interface SearchCondition {
     id: string;
@@ -532,6 +539,7 @@ export interface SearchCondition {
     direction?: "broader" | "narrower";
     cascade?: boolean;
     match_mode?: MatchMode;
+    image_attribute?: ImageAttribute;
     negated?: boolean;
 }
 

--- a/arches_lingo/src/arches_lingo/types.ts
+++ b/arches_lingo/src/arches_lingo/types.ts
@@ -155,7 +155,7 @@ export interface ResourceData<T extends AliasedData = AliasedData> {
 
 interface QuerysetsReferenceSelectFetchedOption {
     display_value: string;
-    node_value: ReferenceSelectTreeNode[];
+    node_value: ReferenceSelectTreeNode[] | null;
     details: unknown[];
 }
 

--- a/arches_lingo/src/arches_lingo/types.ts
+++ b/arches_lingo/src/arches_lingo/types.ts
@@ -6,12 +6,12 @@ import type { EDIT, VIEW } from "@/arches_lingo/constants.ts";
 import type { ReferenceSelectTreeNode } from "@/arches_controlled_lists/datatypes/reference-select/types.ts";
 import type { Label } from "@/arches_controlled_lists/types.ts";
 
-import type { StringAliasedNodeData } from "@/arches_component_lab/datatypes/string/types.ts";
+import type { StringAliasedNodeData } from "@/arches_vue_components/datatypes/string/types.ts";
 import type {
     ResourceInstanceListAliasedNodeData,
     ResourceInstanceReference,
-} from "@/arches_component_lab/datatypes/resource-instance-list/types.ts";
-import type { FileListAliasedNodeData } from "@/arches_component_lab/datatypes/file-list/types.ts";
+} from "@/arches_vue_components/datatypes/resource-instance-list/types.ts";
+import type { FileListAliasedNodeData } from "@/arches_vue_components/datatypes/file-list/types.ts";
 
 export interface User {
     first_name: string;

--- a/arches_lingo/src/arches_lingo/utils.spec.ts
+++ b/arches_lingo/src/arches_lingo/utils.spec.ts
@@ -10,7 +10,7 @@ import {
 } from "@/arches_lingo/utils.ts";
 import schemesFixture from "./fixtures/test_scheme.json";
 
-import type { Language } from "@/arches_component_lab/types.ts";
+import type { Language } from "@/arches_vue_components/types.ts";
 import type { IconLabels, Scheme } from "@/arches_lingo/types";
 
 const ENGLISH: Language = {

--- a/arches_lingo/src/arches_lingo/utils.ts
+++ b/arches_lingo/src/arches_lingo/utils.ts
@@ -370,29 +370,16 @@ export function getStatementText(
 
     const best = statements.reduce((bestMatch, current) => {
         const currentLang =
-            current.aliased_data.statement_language?.node_value[0]?.data?.uri
-                ?.split("/")
-                .pop()
-                ?.toLowerCase();
+            current.aliased_data?.statement_language?.display_value?.toLowerCase();
         const bestLang =
-            bestMatch.aliased_data.statement_language?.node_value[0]?.data?.uri
-                ?.split("/")
-                .pop()
-                ?.toLowerCase();
-        return rankLanguage(currentLang) > rankLanguage(bestLang)
-            ? current
-            : bestMatch;
+            bestMatch.aliased_data?.statement_language?.display_value?.toLowerCase();
+        if (rankLanguage(currentLang) > rankLanguage(bestLang)) {
+            return current;
+        }
+        return bestMatch;
     });
 
-    const bestLangCode =
-        best.aliased_data.statement_language?.node_value[0]?.data?.uri
-            ?.split("/")
-            .pop();
-    const contentNodeValue = best.aliased_data.statement_content.node_value;
-    if (bestLangCode) {
-        return contentNodeValue?.[bestLangCode]?.value ?? "";
-    }
-    return Object.values(contentNodeValue ?? {})[0]?.value ?? "";
+    return best.aliased_data?.statement_content?.display_value ?? "";
 }
 
 export async function createOrUpdateConcept(

--- a/arches_lingo/src/arches_lingo/utils.ts
+++ b/arches_lingo/src/arches_lingo/utils.ts
@@ -369,16 +369,40 @@ export function getStatementText(
     }
 
     const best = statements.reduce((bestMatch, current) => {
-        const currentLang =
-            current.aliased_data?.statement_language?.display_value?.toLowerCase();
-        const bestLang =
-            bestMatch.aliased_data?.statement_language?.display_value?.toLowerCase();
+        const currentRefs = current.aliased_data
+            ?.statement_language as unknown as
+            | Array<{ uri: string }>
+            | null
+            | undefined;
+        const currentLang = currentRefs?.[0]?.uri
+            ?.split("/")
+            .pop()
+            ?.toLowerCase();
+        const bestRefs = bestMatch.aliased_data
+            ?.statement_language as unknown as
+            | Array<{ uri: string }>
+            | null
+            | undefined;
+        const bestLang = bestRefs?.[0]?.uri?.split("/").pop()?.toLowerCase();
         return rankLanguage(currentLang) > rankLanguage(bestLang)
             ? current
             : bestMatch;
     });
 
-    return best.aliased_data?.statement_content?.display_value ?? "";
+    const bestLangRefs = best.aliased_data?.statement_language as unknown as
+        | Array<{ uri: string }>
+        | null
+        | undefined;
+    const bestLangCode = bestLangRefs?.[0]?.uri?.split("/").pop();
+    const contentMap = best.aliased_data?.statement_content as unknown as
+        | Record<string, { value: string }>
+        | null
+        | undefined;
+    return (
+        (bestLangCode
+            ? contentMap?.[bestLangCode]?.value
+            : Object.values(contentMap ?? {})[0]?.value) ?? ""
+    );
 }
 
 export async function createOrUpdateConcept(

--- a/arches_lingo/src/arches_lingo/utils.ts
+++ b/arches_lingo/src/arches_lingo/utils.ts
@@ -369,40 +369,30 @@ export function getStatementText(
     }
 
     const best = statements.reduce((bestMatch, current) => {
-        const currentRefs = current.aliased_data
-            ?.statement_language as unknown as
-            | Array<{ uri: string }>
-            | null
-            | undefined;
-        const currentLang = currentRefs?.[0]?.uri
-            ?.split("/")
-            .pop()
-            ?.toLowerCase();
-        const bestRefs = bestMatch.aliased_data
-            ?.statement_language as unknown as
-            | Array<{ uri: string }>
-            | null
-            | undefined;
-        const bestLang = bestRefs?.[0]?.uri?.split("/").pop()?.toLowerCase();
+        const currentLang =
+            current.aliased_data.statement_language?.node_value[0]?.data?.uri
+                ?.split("/")
+                .pop()
+                ?.toLowerCase();
+        const bestLang =
+            bestMatch.aliased_data.statement_language?.node_value[0]?.data?.uri
+                ?.split("/")
+                .pop()
+                ?.toLowerCase();
         return rankLanguage(currentLang) > rankLanguage(bestLang)
             ? current
             : bestMatch;
     });
 
-    const bestLangRefs = best.aliased_data?.statement_language as unknown as
-        | Array<{ uri: string }>
-        | null
-        | undefined;
-    const bestLangCode = bestLangRefs?.[0]?.uri?.split("/").pop();
-    const contentMap = best.aliased_data?.statement_content as unknown as
-        | Record<string, { value: string }>
-        | null
-        | undefined;
-    return (
-        (bestLangCode
-            ? contentMap?.[bestLangCode]?.value
-            : Object.values(contentMap ?? {})[0]?.value) ?? ""
-    );
+    const bestLangCode =
+        best.aliased_data.statement_language?.node_value[0]?.data?.uri
+            ?.split("/")
+            .pop();
+    const contentNodeValue = best.aliased_data.statement_content.node_value;
+    if (bestLangCode) {
+        return contentNodeValue?.[bestLangCode]?.value ?? "";
+    }
+    return Object.values(contentNodeValue ?? {})[0]?.value ?? "";
 }
 
 export async function createOrUpdateConcept(

--- a/arches_lingo/src/arches_lingo/utils.ts
+++ b/arches_lingo/src/arches_lingo/utils.ts
@@ -11,11 +11,11 @@ import {
     TOP_CONCEPT_ICON,
     CONCEPT_TYPE_NODE_ALIAS,
 } from "@/arches_lingo/constants.ts";
-import { fetchTileData } from "@/arches_component_lab/generics/GenericCard/api.ts";
+import { fetchTileData } from "@/arches_vue_components/generics/GenericCard/api.ts";
 import { getItemLabel } from "@/arches_controlled_lists/utils.ts";
 
 import type { TreeNode } from "primevue/treenode";
-import type { Language } from "@/arches_component_lab/types.ts";
+import type { Language } from "@/arches_vue_components/types.ts";
 import type {
     Concept,
     ConceptType,

--- a/arches_lingo/urls.py
+++ b/arches_lingo/urls.py
@@ -311,7 +311,7 @@ urlpatterns = [
         name="api-lingo-concept-resolve",
     ),
     path("", include("arches_controlled_lists.urls")),
-    path("", include("arches_component_lab.urls")),
+    path("", include("arches_vue_components.urls")),
 ]
 
 # Ensure Arches core urls are superseded by project-level urls

--- a/arches_lingo/urls.py
+++ b/arches_lingo/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls.static import static
 from django.urls import include, path
 
 from arches_lingo.views.root import LingoRootView
+from arches_lingo.views.api.dereference import DereferenceableResourceView
 from arches_lingo.views.api.concepts import (
     ConceptAncestorsView,
     ConceptChildrenView,
@@ -74,18 +75,20 @@ urlpatterns = [
     path("login", LingoRootView.as_view(), name="login"),
     path("advanced-search", LingoRootView.as_view(), name="advanced-search"),
     path("schemes", LingoRootView.as_view(), name="schemes"),
-    path("scheme/<uuid:id>", LingoRootView.as_view(), name="scheme"),
+    # Identity URIs: content-negotiated. Browsers get the SPA; machines requesting
+    # an RDF representation (Accept header or ?format=) get SKOS for the resource.
+    path("scheme/<uuid:id>", DereferenceableResourceView.as_view(), name="scheme"),
     path("scheme/new", LingoRootView.as_view(), name="new-scheme"),
-    path("concept/<uuid:id>", LingoRootView.as_view(), name="concept"),
+    path("concept/<uuid:id>", DereferenceableResourceView.as_view(), name="concept"),
     path("concept/new", LingoRootView.as_view(), name="new-concept"),
     path(
         "schemes/<slug:scheme_identifier>",
-        LingoRootView.as_view(),
+        DereferenceableResourceView.as_view(),
         name="scheme-by-identifier",
     ),
     path(
         "schemes/<slug:scheme_identifier>/concepts/<slug:concept_identifier>",
-        LingoRootView.as_view(),
+        DereferenceableResourceView.as_view(),
         name="concept-by-identifier",
     ),
     path("sources", LingoRootView.as_view(), name="sources"),

--- a/arches_lingo/utils/advanced_search.py
+++ b/arches_lingo/utils/advanced_search.py
@@ -178,6 +178,16 @@ class AdvancedSearchEvaluator:
         lookup = self.MATCH_MODE_LOOKUPS.get(match_mode, "icontains")
         return Q(**{f"{field}__{lookup}": value})
 
+    @staticmethod
+    def _escape_like_wildcards(value):
+        """Escape LIKE/ILIKE special characters so user input matches literally.
+
+        The backslash escape character must be doubled first, then the % and _
+        wildcards escaped, so that values such as ``50%`` or ``a_b`` are matched
+        as-is rather than being interpreted as wildcard patterns.
+        """
+        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
     def _facet_label(self, condition):
         """Search by label text, optionally filtered by type and language."""
         filters = Q(nodegroup_id=CONCEPT_NAME_NODEGROUP)
@@ -667,33 +677,38 @@ class AdvancedSearchEvaluator:
     def _concepts_depicting(self, digital_object_ids):
         """Return concept PKs whose internal depiction references any digital object.
 
-        Matches the ``depicting_digital_asset_internal`` resource-instance-list node
-        against the given digital-object resource IDs via JSONB containment.
+        The ``depicting_digital_asset_internal`` node is a resource-instance-list
+        (a JSONB array of ``{"resourceId": ...}`` objects).  Rather than OR-ing one
+        JSONB containment clause per matched digital object — which produces an
+        ever-growing predicate as the number of matches grows — the array is
+        unnested inside a single RawSQL EXISTS and each element's ``resourceId`` is
+        compared against the matched IDs with ``= ANY``, mirroring the approach in
+        ``_digital_objects_by_file_name``.
         """
-        containment = Q()
-        matched_any = False
-        for digital_object_id in digital_object_ids:
-            matched_any = True
-            containment |= Q(
-                **{
-                    f"data__{DEPICTING_DIGITAL_ASSET_INTERNAL_NODE}__contains": [
-                        {"resourceId": str(digital_object_id)}
-                    ]
-                }
-            )
-
-        if not matched_any:
-            # No digital objects matched — an empty Q() would otherwise match
-            # every internal-depiction tile, so short-circuit to no concepts.
+        digital_object_id_strings = [
+            str(digital_object_id) for digital_object_id in digital_object_ids
+        ]
+        if not digital_object_id_strings:
+            # No digital objects matched, so no concept can depict one.
             return TileModel.objects.none().values_list(
                 "resourceinstance_id", flat=True
             )
+
+        depiction_matches = RawSQL(
+            """EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements(tiledata->%s) AS depiction
+                WHERE depiction ->> 'resourceId' = ANY(%s))""",
+            [DEPICTING_DIGITAL_ASSET_INTERNAL_NODE, digital_object_id_strings],
+            output_field=BooleanField(),
+        )
 
         return (
             TileModel.objects.filter(
                 nodegroup_id=DEPICTING_DIGITAL_ASSET_INTERNAL_NODEGROUP,
             )
-            .filter(containment)
+            .annotate(depiction_matches=depiction_matches)
+            .filter(depiction_matches=True)
             .values_list("resourceinstance_id", flat=True)
             .distinct()
         )
@@ -717,14 +732,18 @@ class AdvancedSearchEvaluator:
                 output_field=BooleanField(),
             )
         else:
+            # The ORM match-mode lookups (icontains, istartswith, ...) escape LIKE
+            # wildcards automatically, but this hand-built ILIKE pattern must escape
+            # them itself so that a % or _ in the user's value matches literally.
+            escaped_value = self._escape_like_wildcards(value)
             if match_mode == "exact":
-                pattern = value
+                pattern = escaped_value
             elif match_mode == "starts_with":
-                pattern = f"{value}%"
+                pattern = f"{escaped_value}%"
             elif match_mode == "ends_with":
-                pattern = f"%{value}"
+                pattern = f"%{escaped_value}"
             else:  # contains
-                pattern = f"%{value}%"
+                pattern = f"%{escaped_value}%"
 
             file_name_matches = RawSQL(
                 """EXISTS (

--- a/arches_lingo/utils/advanced_search.py
+++ b/arches_lingo/utils/advanced_search.py
@@ -19,7 +19,7 @@ QuerySets.
 """
 
 from django.db import connection
-from django.db.models import Q
+from django.db.models import BooleanField, Q
 from django.db.models.expressions import RawSQL
 
 from arches.app.models.models import ResourceInstance, TileModel
@@ -52,6 +52,15 @@ from arches_lingo.const import (
     MATCH_STATUS_COMPARATE_NODE,
     CONCEPT_TYPE_NODEGROUP,
     CONCEPT_TYPE_NODEID,
+    DEPICTING_DIGITAL_ASSET_INTERNAL_NODEGROUP,
+    DEPICTING_DIGITAL_ASSET_INTERNAL_NODE,
+    DEPICTING_DIGITAL_ASSET_EXTERNAL_NODEGROUP,
+    DIGITAL_OBJECT_CONTENT_NODEGROUP,
+    DIGITAL_OBJECT_CONTENT_NODE,
+    DIGITAL_OBJECT_NAME_NODEGROUP,
+    DIGITAL_OBJECT_NAME_CONTENT_NODE,
+    DIGITAL_OBJECT_STATEMENT_NODEGROUP,
+    DIGITAL_OBJECT_STATEMENT_CONTENT_NODE,
 )
 from arches_lingo.models import ConceptSet
 
@@ -72,6 +81,7 @@ VALID_FACETS = {
     "concept_set",
     "attribution_source",
     "attribution_contributor",
+    "related_image",
 }
 
 
@@ -653,6 +663,151 @@ class AdvancedSearchEvaluator:
             .values_list("resourceinstance_id", flat=True)
             .distinct()
         )
+
+    def _concepts_depicting(self, digital_object_ids):
+        """Return concept PKs whose internal depiction references any digital object.
+
+        Matches the ``depicting_digital_asset_internal`` resource-instance-list node
+        against the given digital-object resource IDs via JSONB containment.
+        """
+        containment = Q()
+        matched_any = False
+        for digital_object_id in digital_object_ids:
+            matched_any = True
+            containment |= Q(
+                **{
+                    f"data__{DEPICTING_DIGITAL_ASSET_INTERNAL_NODE}__contains": [
+                        {"resourceId": str(digital_object_id)}
+                    ]
+                }
+            )
+
+        if not matched_any:
+            # No digital objects matched — an empty Q() would otherwise match
+            # every internal-depiction tile, so short-circuit to no concepts.
+            return TileModel.objects.none().values_list(
+                "resourceinstance_id", flat=True
+            )
+
+        return (
+            TileModel.objects.filter(
+                nodegroup_id=DEPICTING_DIGITAL_ASSET_INTERNAL_NODEGROUP,
+            )
+            .filter(containment)
+            .values_list("resourceinstance_id", flat=True)
+            .distinct()
+        )
+
+    def _digital_objects_by_file_name(self, value, match_mode):
+        """Return digital-object resource PKs whose content file name matches value.
+
+        The ``content`` node is a file-list whose tiledata is a JSON array of file
+        objects.  Matching a file name therefore requires unnesting the array and
+        comparing each element's ``name`` — expressed as a RawSQL EXISTS predicate
+        so the database performs the scan rather than Python.
+        """
+        if match_mode == "exists":
+            file_name_matches = RawSQL(
+                """EXISTS (
+                    SELECT 1
+                    FROM jsonb_array_elements(tiledata->%s) AS file_element
+                    WHERE file_element ->> 'name' IS NOT NULL
+                      AND file_element ->> 'name' <> '')""",
+                [DIGITAL_OBJECT_CONTENT_NODE],
+                output_field=BooleanField(),
+            )
+        else:
+            if match_mode == "exact":
+                pattern = value
+            elif match_mode == "starts_with":
+                pattern = f"{value}%"
+            elif match_mode == "ends_with":
+                pattern = f"%{value}"
+            else:  # contains
+                pattern = f"%{value}%"
+
+            file_name_matches = RawSQL(
+                """EXISTS (
+                    SELECT 1
+                    FROM jsonb_array_elements(tiledata->%s) AS file_element
+                    WHERE file_element ->> 'name' ILIKE %s)""",
+                [DIGITAL_OBJECT_CONTENT_NODE, pattern],
+                output_field=BooleanField(),
+            )
+
+        # RawSQL is a boolean *expression*, which .filter() cannot consume
+        # directly; annotate it and filter on the annotation instead.
+        return (
+            TileModel.objects.filter(nodegroup_id=DIGITAL_OBJECT_CONTENT_NODEGROUP)
+            .annotate(file_name_matches=file_name_matches)
+            .filter(file_name_matches=True)
+            .values_list("resourceinstance_id", flat=True)
+            .distinct()
+        )
+
+    def _digital_objects_by_text_node(self, nodegroup_id, node_id, value, match_mode):
+        """Return digital-object resource PKs whose text node matches value."""
+        filters = Q(nodegroup_id=nodegroup_id)
+        filters &= self._text_filter(f"data__{node_id}", value, match_mode)
+        return (
+            TileModel.objects.filter(filters)
+            .values_list("resourceinstance_id", flat=True)
+            .distinct()
+        )
+
+    def _facet_related_image(self, condition):
+        """Find concepts by their related (depicting) images.
+
+        The ``image_attribute`` sub-field selects what is matched:
+
+        * ``has_image`` — concepts with an internal digital-object depiction OR an
+          external image URL.  ``exists`` is implied regardless of match_mode.
+        * ``file_name`` — the file name on the linked digital object's content.
+        * ``title`` — the linked digital object's name.
+        * ``description`` — the linked digital object's statement.
+
+        The last three are two-hop: matching digital-object resources are resolved
+        first, then concepts referencing any of them via
+        ``depicting_digital_asset_internal`` are returned.  These attributes apply
+        only to internal digital objects — external URLs carry no such metadata.
+        """
+        image_attribute = condition.get("image_attribute", "has_image")
+
+        if image_attribute == "has_image":
+            return (
+                TileModel.objects.filter(
+                    Q(nodegroup_id=DEPICTING_DIGITAL_ASSET_INTERNAL_NODEGROUP)
+                    | Q(nodegroup_id=DEPICTING_DIGITAL_ASSET_EXTERNAL_NODEGROUP)
+                )
+                .values_list("resourceinstance_id", flat=True)
+                .distinct()
+            )
+
+        value = condition.get("value", "").strip()
+        match_mode = condition.get("match_mode", "contains")
+        if not value and match_mode != "exists":
+            return self._all_concept_ids()
+
+        if image_attribute == "file_name":
+            digital_object_ids = self._digital_objects_by_file_name(value, match_mode)
+        elif image_attribute == "title":
+            digital_object_ids = self._digital_objects_by_text_node(
+                DIGITAL_OBJECT_NAME_NODEGROUP,
+                DIGITAL_OBJECT_NAME_CONTENT_NODE,
+                value,
+                match_mode,
+            )
+        elif image_attribute == "description":
+            digital_object_ids = self._digital_objects_by_text_node(
+                DIGITAL_OBJECT_STATEMENT_NODEGROUP,
+                DIGITAL_OBJECT_STATEMENT_CONTENT_NODE,
+                value,
+                match_mode,
+            )
+        else:
+            return self._all_concept_ids().none()
+
+        return self._concepts_depicting(digital_object_ids)
 
     def _facet_attribution_contributor(self, condition):
         """Find concepts whose labels or notes are attributed to a specific contributor.

--- a/arches_lingo/utils/concept_lifecycle.py
+++ b/arches_lingo/utils/concept_lifecycle.py
@@ -16,11 +16,11 @@ PUBLISHED_STATE_ID = uuid.UUID("6b0f1a7b-5b3d-4b2a-8a5b-7c3a1b0f2d9e")
 RETIRED_STATE_ID = uuid.UUID("9d2e1c0b-7a6b-4b3d-8c1a-0f2d9e6b0a7c")
 LOCKED_STATE_ID = uuid.UUID("c9f7e3d1-2a5b-4c8d-9e6f-3b0a1d2e4f7c")
 
-# Lifecycle states in which a resource has been published and its URI is a stable,
-# publicly resolvable identifier. Draft and Editing resources are pre-publication and
-# are not dereferenceable to anonymous consumers. Retired concepts remain resolvable so
-# that previously published URIs do not break; they are marked as deprecated in the
-# serialized output.
+# Lifecycle states whose URIs we treat as publicly resolvable to anonymous consumers.
+# Retired resources stay resolvable (marked owl:deprecated in the serialized output) so
+# that previously published URIs do not break. These states do not strictly guarantee
+# prior publication: a resource can be retired or locked directly from draft, in which
+# case it is anonymously resolvable here as well.
 PUBLICLY_DEREFERENCEABLE_STATE_IDS = frozenset(
     {PUBLISHED_STATE_ID, LOCKED_STATE_ID, RETIRED_STATE_ID}
 )

--- a/arches_lingo/utils/concept_lifecycle.py
+++ b/arches_lingo/utils/concept_lifecycle.py
@@ -12,8 +12,18 @@ from arches_lingo.const import (
 
 DRAFT_STATE_ID = uuid.UUID("0e7f8c6d-1f7b-4c2a-9a0c-2b9e0d6c8f11")
 EDITING_STATE_ID = uuid.UUID("b3a6a0d2-2b5c-4c2f-9d6c-0c2a5b7d1e8f")
+PUBLISHED_STATE_ID = uuid.UUID("6b0f1a7b-5b3d-4b2a-8a5b-7c3a1b0f2d9e")
 RETIRED_STATE_ID = uuid.UUID("9d2e1c0b-7a6b-4b3d-8c1a-0f2d9e6b0a7c")
 LOCKED_STATE_ID = uuid.UUID("c9f7e3d1-2a5b-4c8d-9e6f-3b0a1d2e4f7c")
+
+# Lifecycle states in which a resource has been published and its URI is a stable,
+# publicly resolvable identifier. Draft and Editing resources are pre-publication and
+# are not dereferenceable to anonymous consumers. Retired concepts remain resolvable so
+# that previously published URIs do not break; they are marked as deprecated in the
+# serialized output.
+PUBLICLY_DEREFERENCEABLE_STATE_IDS = frozenset(
+    {PUBLISHED_STATE_ID, LOCKED_STATE_ID, RETIRED_STATE_ID}
+)
 
 STRATEGY_REPARENT = "reparent"
 STRATEGY_DELETE_CHILDREN = "delete_children"

--- a/arches_lingo/utils/skos.py
+++ b/arches_lingo/utils/skos.py
@@ -2,7 +2,7 @@ import uuid
 from collections import defaultdict
 from django.db.models import Q
 from rdflib import Literal, Namespace, RDF, URIRef
-from rdflib.namespace import SKOS, DCTERMS
+from rdflib.namespace import SKOS, DCTERMS, OWL
 from rdflib.graph import Graph
 from arches.app.models import models
 from arches.app.models.system_settings import settings
@@ -14,6 +14,19 @@ from arches_lingo.etl_modules.migrate_to_lingo import LingoResourceImporter
 
 # define the ARCHES namespace
 ARCHES = Namespace(settings.ARCHES_NAMESPACE_FOR_DATA_EXPORT)
+
+
+def subject_uri_for(resource_id, resource_uri_map=None):
+    """Return the canonical RDF subject URI for a resource.
+
+    Prefers the resource's minted public URI (a stable, resolvable identifier);
+    falls back to the UUID-based ARCHES data-export URI when no public URI exists.
+    """
+    if resource_uri_map:
+        public_uri = resource_uri_map.get(str(resource_id))
+        if public_uri:
+            return URIRef(public_uri)
+    return ARCHES[str(resource_id)]
 
 
 class SKOSReader(SKOSReader):
@@ -346,27 +359,33 @@ class SKOSReader(SKOSReader):
 
 
 class SKOSWriter:
-    def write_skos_from_triples(self, schemes_triples, concepts_triples):
+    def write_skos_from_triples(
+        self, schemes_triples, concepts_triples, resource_uri_map=None
+    ):
+        self.resource_uri_map = resource_uri_map or {}
         rdf_graph = Graph()
         rdf_graph.bind("skos", SKOS)
         rdf_graph.bind("dcterms", DCTERMS)
         rdf_graph.bind("arches", ARCHES)
+        rdf_graph.bind("owl", OWL)
 
         self.language_lookup = {
             lang.name: lang.code for lang in models.Language.objects.all()
         }
 
         for scheme_id, triples in schemes_triples.items():
-            rdf_scheme_id = ARCHES[str(scheme_id)]
+            rdf_scheme_id = subject_uri_for(scheme_id, self.resource_uri_map)
             rdf_graph.add((rdf_scheme_id, RDF.type, SKOS.ConceptScheme))
+            self._add_uuid_sameas(rdf_graph, rdf_scheme_id, scheme_id)
             for triple in triples:
                 predicates, object = self.extract_predicate_object(triple)
                 for predicate in predicates:
                     rdf_graph.add((rdf_scheme_id, predicate, object))
 
         for concept_id, triples in concepts_triples.items():
-            rdf_concept_id = ARCHES[str(concept_id)]
+            rdf_concept_id = subject_uri_for(concept_id, self.resource_uri_map)
             rdf_graph.add((rdf_concept_id, RDF.type, SKOS.Concept))
+            self._add_uuid_sameas(rdf_graph, rdf_concept_id, concept_id)
             for triple in triples:
                 predicates, object = self.extract_predicate_object(triple)
                 for predicate in predicates:
@@ -377,6 +396,16 @@ class SKOSWriter:
 
         return rdf_graph
 
+    def _add_uuid_sameas(self, rdf_graph, subject, resource_id):
+        """Link a public-URI subject back to its UUID-based ARCHES URI via owl:sameAs.
+
+        This keeps the UUID form discoverable for consumers that only know the
+        internal identifier. No-op when the subject already is the ARCHES URI.
+        """
+        arches_uri = ARCHES[str(resource_id)]
+        if subject != arches_uri:
+            rdf_graph.add((subject, OWL.sameAs, arches_uri))
+
     def extract_predicate_object(self, triple):
         # Some predicates are multivalue reference datatype fields, so process all predicates
         # as lists for ease of handling
@@ -386,8 +415,13 @@ class SKOSWriter:
         object_language = triple.get("object_language")
         if object_language:
             object = Literal(object, lang=object_language)
+        elif triple.get("object_is_uri") and object:
+            # A matched concept's comparate is a URI reference, not a literal.
+            object = URIRef(str(object))
         if isinstance(object, models.ResourceInstance):
-            object = ARCHES[str(object.resourceinstanceid)]
+            object = subject_uri_for(
+                object.resourceinstanceid, getattr(self, "resource_uri_map", None)
+            )
         if not isinstance(object, Literal) and not isinstance(object, URIRef):
             object = Literal(object)
 

--- a/arches_lingo/utils/skos.py
+++ b/arches_lingo/utils/skos.py
@@ -1,5 +1,7 @@
+import logging
 import uuid
 from collections import defaultdict
+from urllib.parse import urlsplit
 from django.db.models import Q
 from rdflib import Literal, Namespace, RDF, URIRef
 from rdflib.namespace import SKOS, DCTERMS, OWL
@@ -11,6 +13,8 @@ from arches_controlled_lists.utils.skos import SKOSReader
 from arches_controlled_lists.models import List, ListItem, ListItemValue
 
 from arches_lingo.etl_modules.migrate_to_lingo import LingoResourceImporter
+
+logger = logging.getLogger(__name__)
 
 # define the ARCHES namespace
 ARCHES = Namespace(settings.ARCHES_NAMESPACE_FOR_DATA_EXPORT)
@@ -379,6 +383,8 @@ class SKOSWriter:
             self._add_uuid_sameas(rdf_graph, rdf_scheme_id, scheme_id)
             for triple in triples:
                 predicates, object = self.extract_predicate_object(triple)
+                if object is None:
+                    continue
                 for predicate in predicates:
                     rdf_graph.add((rdf_scheme_id, predicate, object))
 
@@ -388,6 +394,8 @@ class SKOSWriter:
             self._add_uuid_sameas(rdf_graph, rdf_concept_id, concept_id)
             for triple in triples:
                 predicates, object = self.extract_predicate_object(triple)
+                if object is None:
+                    continue
                 for predicate in predicates:
                     if predicate == SKOS.hasTopConcept:
                         rdf_graph.add((object, SKOS.hasTopConcept, rdf_concept_id))
@@ -415,17 +423,32 @@ class SKOSWriter:
         object_language = triple.get("object_language")
         if object_language:
             object = Literal(object, lang=object_language)
-        elif triple.get("object_is_uri") and object:
-            # A matched concept's comparate is a URI reference, not a literal.
-            object = URIRef(str(object))
+        elif triple.get("object_is_uri"):
+            object = self.uri_reference_or_none(object)
         if isinstance(object, models.ResourceInstance):
             object = subject_uri_for(
                 object.resourceinstanceid, getattr(self, "resource_uri_map", None)
             )
-        if not isinstance(object, Literal) and not isinstance(object, URIRef):
+        if object is not None and not isinstance(object, (Literal, URIRef)):
             object = Literal(object)
 
         return predicates, object
+
+    def uri_reference_or_none(self, object):
+        """Return a URIRef for a match comparate, or None to skip an unusable value.
+
+        Match/mapping comparates hold an external (or locally-resolvable) URI rather
+        than a resource instance. An empty comparate or a value that is not an
+        absolute URI is skipped instead of being emitted as a bogus URI reference.
+        """
+        if not object:
+            return None
+        object_string = str(object).strip()
+        parsed = urlsplit(object_string)
+        if not parsed.scheme or not (parsed.netloc or parsed.path):
+            logger.warning("Skipping non-URI match comparate: %s", object_string)
+            return None
+        return URIRef(object_string)
 
     def transform_predicate_values(self, predicate_references):
         if isinstance(predicate_references, str):

--- a/arches_lingo/utils/skos_serializer.py
+++ b/arches_lingo/utils/skos_serializer.py
@@ -98,6 +98,53 @@ TILE_TREE_TO_TRIPLE_MAPPING = {
 }
 
 
+# Registry of the RDF serializations Lingo exposes for dereferenced resources,
+# keyed by the short format token also accepted as a ?format= query value.
+RDF_FORMATS = {
+    "jsonld": {
+        "rdflib": "json-ld",
+        "content_type": "application/ld+json",
+        "accept_types": ["application/ld+json"],
+    },
+    "xml": {
+        "rdflib": "pretty-xml",
+        "content_type": "application/rdf+xml",
+        "accept_types": ["application/rdf+xml"],
+    },
+    "turtle": {
+        "rdflib": "turtle",
+        "content_type": "text/turtle; charset=utf-8",
+        "accept_types": ["text/turtle"],
+    },
+    "nt": {
+        "rdflib": "nt",
+        "content_type": "application/n-triples",
+        "accept_types": ["application/n-triples"],
+    },
+}
+
+# Aliases tolerated in the ?format= query string.
+_FORMAT_ALIASES = {
+    "json-ld": "jsonld",
+    "ttl": "turtle",
+    "rdf": "xml",
+    "rdfxml": "xml",
+    "n-triples": "nt",
+    "ntriples": "nt",
+}
+
+_HTML_TYPES = {"text/html", "application/xhtml+xml"}
+
+# Sentinel returned when a client explicitly demands a format we do not offer.
+NOT_ACCEPTABLE = object()
+
+_ACCEPT_TYPE_TO_FORMAT = {
+    accept_type: rdf_format
+    for rdf_format, spec in RDF_FORMATS.items()
+    for accept_type in spec["accept_types"]
+}
+
+
 def extract_triples_from_aliased_tiles(nodegroup_alias, tile_trees):
     """Build triple dicts for a single nodegroup's tile(s) using the mapping table."""
     triples = []
@@ -121,7 +168,6 @@ def extract_triples_from_aliased_tiles(nodegroup_alias, tile_trees):
             elif (
                 triple_component == "default_predicate" and triple["predicate"] is None
             ):
-                # Fall back on default predicates for relationships if none was found
                 triple["predicate"] = node_alias
             elif triple_component != "default_predicate":
                 try:
@@ -296,55 +342,6 @@ def _serialize_graph_as_jsonld(rdf_graph):
     }
     compacted = jsonld.compact(expanded, context)
     return json.dumps(compacted, indent=2, sort_keys=True).encode("utf-8")
-
-
-# --- Content negotiation -------------------------------------------------------
-
-# Registry of the RDF serializations Lingo exposes for dereferenced resources.
-# Keyed by the short format token also accepted as a ?format= query value.
-RDF_FORMATS = {
-    "jsonld": {
-        "rdflib": "json-ld",
-        "content_type": "application/ld+json",
-        "accept_types": ["application/ld+json"],
-    },
-    "xml": {
-        "rdflib": "pretty-xml",
-        "content_type": "application/rdf+xml",
-        "accept_types": ["application/rdf+xml"],
-    },
-    "turtle": {
-        "rdflib": "turtle",
-        "content_type": "text/turtle; charset=utf-8",
-        "accept_types": ["text/turtle"],
-    },
-    "nt": {
-        "rdflib": "nt",
-        "content_type": "application/n-triples",
-        "accept_types": ["application/n-triples"],
-    },
-}
-
-# Aliases tolerated in the ?format= query string.
-_FORMAT_ALIASES = {
-    "json-ld": "jsonld",
-    "ttl": "turtle",
-    "rdf": "xml",
-    "rdfxml": "xml",
-    "n-triples": "nt",
-    "ntriples": "nt",
-}
-
-_HTML_TYPES = {"text/html", "application/xhtml+xml"}
-
-# Sentinel returned when a client explicitly demands a format we do not offer.
-NOT_ACCEPTABLE = object()
-
-_ACCEPT_TYPE_TO_FORMAT = {
-    accept_type: rdf_format
-    for rdf_format, spec in RDF_FORMATS.items()
-    for accept_type in spec["accept_types"]
-}
 
 
 def _parse_accept_header(accept_header):

--- a/arches_lingo/utils/skos_serializer.py
+++ b/arches_lingo/utils/skos_serializer.py
@@ -1,0 +1,397 @@
+"""Shared SKOS serialization for Lingo schemes and concepts.
+
+This module is the single source of truth for turning Lingo tile data into SKOS
+triples. It is used both by the batch thesaurus exporter (whole-hierarchy file
+dumps) and by the content-negotiated dereferencing views (a single resource
+serialized live in response to an ``Accept`` header).
+
+The triple mapping and per-nodegroup extraction previously lived inline in the
+exporter; they were moved here so that a dereferenced concept and the same
+concept in a bulk export can never diverge.
+"""
+
+import json
+import logging
+from collections import defaultdict
+
+from django.utils.translation import gettext as _
+
+from pyld import jsonld
+from rdflib import Literal
+from rdflib.namespace import DCTERMS, OWL, SKOS
+
+from arches.app.models.models import ResourceInstance, TileModel
+from arches_querysets.models import ResourceTileTree
+
+from arches_lingo.const import (
+    CONCEPTS_GRAPH_ID,
+    SCHEMES_GRAPH_ID,
+    TOP_CONCEPT_OF_NODE_AND_NODEGROUP,
+    URI_CONTENT_NODE,
+    URI_NODEGROUP,
+)
+from arches_lingo.utils.skos import SKOSWriter, subject_uri_for
+
+logger = logging.getLogger(__name__)
+
+
+"""
+Mapping dict consists of nodegroup aliases as top level keys. Their values are dicts
+where the key indicates the component of a triple and the value are node aliases which
+are used to extract data from Arches Queryset TileTrees. There is also an option to
+define a default predicate if a predicate is not found in the tile tree. Some predicates
+are hardcoded SKOS predicates for specific relationships.
+
+nodegroup_alias: {
+    "predicate": "<predicate_node_alias>" | "<skos_predicate_value>",
+    "object": "<object_node_alias>",
+    "object_language": "<object_language_node_alias>" (optional)
+    "default_predicate": "<default_predicate_value>" (optional)
+}
+"""
+TILE_TREE_TO_TRIPLE_MAPPING = {
+    # Scheme and Concept Mappings:
+    "appellative_status": {
+        "predicate": "appellative_status_ascribed_relation",
+        "object": "appellative_status_ascribed_name_content",
+        "object_language": "appellative_status_ascribed_name_language",
+    },
+    "identifier": {
+        "predicate": "identifier_type",
+        "object": "identifier_content",
+    },
+    "statement": {
+        "predicate": "statement_type",
+        "object": "statement_content",
+        "object_language": "statement_language",
+    },
+    # Concept Mappings:
+    "top_concept_of": {
+        "predicate": "hasTopConcept",  # hardcoded SKOS predicate
+        "object": "top_concept_of",
+    },
+    "part_of_scheme": {
+        "predicate": "inScheme",  # hardcoded SKOS predicate
+        "object": "part_of_scheme",
+    },
+    # Hierarchy
+    "classification_status": {
+        "predicate": "classification_status_ascribed_relation",
+        "object": "classification_status_ascribed_classification",
+        "default_predicate": "broader",
+    },
+    # Associated Concepts
+    "relation_status": {
+        "predicate": "relation_status_ascribed_relation",
+        "object": "relation_status_ascribed_comparate",
+        "default_predicate": "related",
+    },
+    # Mapping/match relationships to concepts in other vocabularies. The comparate
+    # holds an external (or locally-resolvable) URI rather than a resource instance,
+    # so its object is emitted as a URI reference, not a string literal.
+    "match_status": {
+        "predicate": "match_status_ascribed_relation",
+        "object": "match_status_ascribed_comparate",
+        "object_is_uri": True,
+        "default_predicate": "mappingRelation",
+    },
+}
+
+
+def extract_triples_from_aliased_tiles(nodegroup_alias, tile_trees):
+    """Build triple dicts for a single nodegroup's tile(s) using the mapping table."""
+    triples = []
+    mapping = TILE_TREE_TO_TRIPLE_MAPPING.get(nodegroup_alias)
+    if mapping is None:
+        logger.error("No mapping found for nodegroup alias: %s", nodegroup_alias)
+        return []
+    if type(tile_trees) is not list:
+        tile_trees = [tile_trees]
+    for tile_tree in tile_trees:
+        triple = defaultdict(str)
+        for triple_component, node_alias in mapping.items():
+            if triple_component == "object_is_uri":
+                # A flag (not a node lookup) carried through to the writer.
+                triple[triple_component] = node_alias
+                continue
+            if node_alias in ["inScheme", "hasTopConcept"]:
+                # Predicate for concept -> scheme relationship is not stored as a node
+                # value but instead derived from the relationship itself
+                triple[triple_component] = node_alias
+            elif (
+                triple_component == "default_predicate" and triple["predicate"] is None
+            ):
+                # Fall back on default predicates for relationships if none was found
+                triple["predicate"] = node_alias
+            elif triple_component != "default_predicate":
+                try:
+                    predicate = getattr(tile_tree.aliased_data, node_alias)
+                except AttributeError:
+                    # Expected when we've directly mapped a relationship that won't be
+                    # wrapped as AliasedData as returned from a queryset (e.g.
+                    # top_concept_of and part_of_scheme during partial hierarchy export)
+                    predicate = tile_tree
+                triple[triple_component] = predicate
+        triples.append(triple)
+    return triples
+
+
+def build_triples_for_resource(resource):
+    """Build the full list of SKOS triple dicts for one scheme or concept resource.
+
+    Only nodegroups that appear in ``TILE_TREE_TO_TRIPLE_MAPPING`` are considered;
+    unmapped nodegroups (images, namespace, status, etc.) contribute no triples.
+    """
+    triples = []
+    for nodegroup_alias in TILE_TREE_TO_TRIPLE_MAPPING:
+        tile_trees = getattr(resource.aliased_data, nodegroup_alias, None)
+        if tile_trees:
+            triples.extend(
+                extract_triples_from_aliased_tiles(nodegroup_alias, tile_trees)
+            )
+    return triples
+
+
+def collect_referenced_resource_ids(triples):
+    """Return the set of resourceinstanceids referenced as triple objects.
+
+    These are the other concepts/schemes that a resource points at (broader,
+    related, inScheme, hasTopConcept), whose public URIs we also want to resolve
+    so that links between resources use canonical URIs rather than UUID URIs.
+    """
+    referenced_ids = set()
+    for triple in triples:
+        triple_object = triple.get("object")
+        if isinstance(triple_object, ResourceInstance):
+            referenced_ids.add(str(triple_object.resourceinstanceid))
+    return referenced_ids
+
+
+def build_scheme_top_concept_triples(scheme_id):
+    """Build ``skos:hasTopConcept`` triples for a scheme from its concepts' tiles.
+
+    The top-concept relationship is stored on each concept's ``top_concept_of``
+    tile, so it is invisible when a scheme is serialized on its own. We recover it
+    by finding every concept that names this scheme as a top concept.
+    """
+    top_concept_ids = TileModel.objects.filter(
+        nodegroup_id=TOP_CONCEPT_OF_NODE_AND_NODEGROUP,
+        **{
+            f"data__{TOP_CONCEPT_OF_NODE_AND_NODEGROUP}__contains": [
+                {"resourceId": str(scheme_id)}
+            ]
+        },
+    ).values_list("resourceinstance_id", flat=True)
+
+    triples = []
+    for top_concept_id in top_concept_ids:
+        triple = defaultdict(str)
+        triple["predicate"] = "hasTopConcept"
+        triple["object"] = ResourceInstance(resourceinstanceid=top_concept_id)
+        triples.append(triple)
+    return triples
+
+
+def build_resource_uri_map(resource_ids):
+    """Map resourceinstanceid (str) -> stored public URI string.
+
+    Resources without a minted URI tile (e.g. unpublished drafts) are simply
+    absent from the map; callers fall back to the UUID-based ARCHES URI.
+    """
+    string_ids = [str(resource_id) for resource_id in resource_ids if resource_id]
+    if not string_ids:
+        return {}
+    uri_tiles = TileModel.objects.filter(
+        nodegroup_id=URI_NODEGROUP,
+        resourceinstance_id__in=string_ids,
+    ).values("resourceinstance_id", "data")
+    uri_map = {}
+    for uri_tile in uri_tiles:
+        uri_value = (uri_tile["data"] or {}).get(URI_CONTENT_NODE)
+        if uri_value:
+            uri_map[str(uri_tile["resourceinstance_id"])] = uri_value
+    return uri_map
+
+
+def graph_kind_for_graph_id(graph_id):
+    """Return "scheme" or "concept" for a Lingo graph id, or None if neither."""
+    if str(graph_id) == SCHEMES_GRAPH_ID:
+        return "scheme"
+    if str(graph_id) == CONCEPTS_GRAPH_ID:
+        return "concept"
+    return None
+
+
+def serialize_resource(resource_id, graph_kind, rdf_format, *, mark_deprecated=False):
+    """Serialize a single scheme or concept as SKOS in the requested RDF format.
+
+    Returns a ``(body_bytes, content_type)`` tuple, or ``(None, None)`` if the
+    resource could not be found or produced no triples.
+    """
+    format_spec = RDF_FORMATS[rdf_format]
+    graph_slug = "scheme" if graph_kind == "scheme" else "concept"
+
+    resource = ResourceTileTree.get_tiles(
+        graph_slug=graph_slug, resource_ids=[resource_id]
+    ).first()
+    if resource is None:
+        return None, None
+
+    triples = build_triples_for_resource(resource)
+    if graph_kind == "scheme":
+        # A scheme's top concepts are recorded on the concept tiles, so when
+        # serializing the scheme in isolation we enumerate them here.
+        triples.extend(build_scheme_top_concept_triples(resource_id))
+    if not triples:
+        logger.warning(_("No SKOS triples could be built for resource %s"), resource_id)
+        return None, None
+
+    referenced_ids = collect_referenced_resource_ids(triples)
+    resource_uri_map = build_resource_uri_map({str(resource_id), *referenced_ids})
+
+    triples_by_resource = {resource.resourceinstanceid: triples}
+    writer = SKOSWriter()
+    if graph_kind == "scheme":
+        rdf_graph = writer.write_skos_from_triples(
+            triples_by_resource, {}, resource_uri_map=resource_uri_map
+        )
+    else:
+        rdf_graph = writer.write_skos_from_triples(
+            {}, triples_by_resource, resource_uri_map=resource_uri_map
+        )
+
+    if mark_deprecated:
+        rdf_graph.add(
+            (
+                subject_uri_for(resource_id, resource_uri_map),
+                OWL.deprecated,
+                Literal(True),
+            )
+        )
+
+    if rdf_format == "jsonld":
+        body = _serialize_graph_as_jsonld(rdf_graph)
+    else:
+        body = rdf_graph.serialize(format=format_spec["rdflib"])
+        if isinstance(body, str):
+            body = body.encode("utf-8")
+    return body, format_spec["content_type"]
+
+
+def _serialize_graph_as_jsonld(rdf_graph):
+    """Serialize an rdflib graph to compacted JSON-LD.
+
+    The installed rdflib (4.2.2) has no JSON-LD serializer, so we bridge through
+    N-Triples and pyld (already an Arches dependency), then compact against the
+    SKOS/DCTERMS/OWL namespaces for a readable document.
+    """
+    ntriples = rdf_graph.serialize(format="nt")
+    if isinstance(ntriples, bytes):
+        ntriples = ntriples.decode("utf-8")
+    expanded = jsonld.from_rdf(ntriples, {"format": "application/nquads"})
+    context = {
+        "skos": str(SKOS),
+        "dcterms": str(DCTERMS),
+        "owl": str(OWL),
+    }
+    compacted = jsonld.compact(expanded, context)
+    return json.dumps(compacted, indent=2, sort_keys=True).encode("utf-8")
+
+
+# --- Content negotiation -------------------------------------------------------
+
+# Registry of the RDF serializations Lingo exposes for dereferenced resources.
+# Keyed by the short format token also accepted as a ?format= query value.
+RDF_FORMATS = {
+    "jsonld": {
+        "rdflib": "json-ld",
+        "content_type": "application/ld+json",
+        "accept_types": ["application/ld+json"],
+    },
+    "xml": {
+        "rdflib": "pretty-xml",
+        "content_type": "application/rdf+xml",
+        "accept_types": ["application/rdf+xml"],
+    },
+    "turtle": {
+        "rdflib": "turtle",
+        "content_type": "text/turtle; charset=utf-8",
+        "accept_types": ["text/turtle"],
+    },
+    "nt": {
+        "rdflib": "nt",
+        "content_type": "application/n-triples",
+        "accept_types": ["application/n-triples"],
+    },
+}
+
+# Aliases tolerated in the ?format= query string.
+_FORMAT_ALIASES = {
+    "json-ld": "jsonld",
+    "ttl": "turtle",
+    "rdf": "xml",
+    "rdfxml": "xml",
+    "n-triples": "nt",
+    "ntriples": "nt",
+}
+
+_HTML_TYPES = {"text/html", "application/xhtml+xml"}
+
+# Sentinel returned when a client explicitly demands a format we do not offer.
+NOT_ACCEPTABLE = object()
+
+_ACCEPT_TYPE_TO_FORMAT = {
+    accept_type: rdf_format
+    for rdf_format, spec in RDF_FORMATS.items()
+    for accept_type in spec["accept_types"]
+}
+
+
+def _parse_accept_header(accept_header):
+    """Return media types from an Accept header, most-preferred first (by q-value)."""
+    media_types = []
+    for index, part in enumerate(accept_header.split(",")):
+        segments = part.strip().split(";")
+        media_type = segments[0].strip().lower()
+        if not media_type:
+            continue
+        quality = 1.0
+        for parameter in segments[1:]:
+            parameter = parameter.strip()
+            if parameter.startswith("q="):
+                try:
+                    quality = float(parameter[2:])
+                except ValueError:
+                    quality = 0.0
+        # Preserve original order for equal q-values with a stable secondary key.
+        media_types.append((media_type, quality, index))
+    media_types.sort(key=lambda entry: (-entry[1], entry[2]))
+    return [media_type for media_type, _quality, _index in media_types]
+
+
+def negotiate_rdf_format(accept_header, explicit_format=None):
+    """Resolve the desired representation for a dereferenced resource.
+
+    Returns one of:
+    - a key in ``RDF_FORMATS`` (serve that RDF representation),
+    - ``None`` (serve the HTML single-page app — the default for browsers),
+    - ``NOT_ACCEPTABLE`` (client explicitly asked for an unsupported ?format=).
+    """
+    if explicit_format:
+        explicit_format = explicit_format.strip().lower()
+        explicit_format = _FORMAT_ALIASES.get(explicit_format, explicit_format)
+        if explicit_format == "html":
+            return None
+        if explicit_format in RDF_FORMATS:
+            return explicit_format
+        return NOT_ACCEPTABLE
+
+    if not accept_header:
+        return None
+
+    for media_type in _parse_accept_header(accept_header):
+        if media_type in _HTML_TYPES or media_type == "*/*":
+            return None
+        if media_type in _ACCEPT_TYPE_TO_FORMAT:
+            return _ACCEPT_TYPE_TO_FORMAT[media_type]
+    return None

--- a/arches_lingo/views/api/concepts.py
+++ b/arches_lingo/views/api/concepts.py
@@ -233,13 +233,7 @@ class ConceptRelationshipView(ConceptTreeView):
         relationships = concept.aliased_data.relation_status
 
         return_data = {
-            "scheme_id": concept.aliased_data.part_of_scheme.aliased_data.part_of_scheme[
-                "node_value"
-            ][
-                0
-            ][
-                "resourceId"
-            ],
+            "scheme_id": concept.aliased_data.part_of_scheme.aliased_data.part_of_scheme.pk,
             "data": relationships,
         }
 

--- a/arches_lingo/views/api/concepts.py
+++ b/arches_lingo/views/api/concepts.py
@@ -233,7 +233,13 @@ class ConceptRelationshipView(ConceptTreeView):
         relationships = concept.aliased_data.relation_status
 
         return_data = {
-            "scheme_id": concept.aliased_data.part_of_scheme.aliased_data.part_of_scheme.pk,
+            "scheme_id": concept.aliased_data.part_of_scheme.aliased_data.part_of_scheme[
+                "node_value"
+            ][
+                0
+            ][
+                "resourceId"
+            ],
             "data": relationships,
         }
 

--- a/arches_lingo/views/api/dereference.py
+++ b/arches_lingo/views/api/dereference.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 
 from django.http import Http404, HttpResponse
@@ -19,6 +20,8 @@ from arches_lingo.utils.skos_serializer import (
 )
 from arches_lingo.views.root import LingoRootView
 
+logger = logging.getLogger(__name__)
+
 
 class DereferenceableResourceView(View):
     """Serve a scheme or concept URI as either the HTML app or a SKOS representation.
@@ -36,7 +39,6 @@ class DereferenceableResourceView(View):
         )
 
         if rdf_format is None:
-            # Default (browsers, */*, no Accept): serve the single-page application.
             return LingoRootView.as_view()(request, *args, **kwargs)
 
         if rdf_format is NOT_ACCEPTABLE:
@@ -54,12 +56,20 @@ class DereferenceableResourceView(View):
         if not self._may_dereference(request, lifecycle_state_id):
             raise Http404()
 
-        body, content_type = serialize_resource(
-            resource_id,
-            graph_kind,
-            rdf_format,
-            mark_deprecated=lifecycle_state_id == RETIRED_STATE_ID,
-        )
+        try:
+            body, content_type = serialize_resource(
+                resource_id,
+                graph_kind,
+                rdf_format,
+                mark_deprecated=lifecycle_state_id == RETIRED_STATE_ID,
+            )
+        except Exception:
+            logger.exception("Failed to serialize resource %s as SKOS", resource_id)
+            return HttpResponse(
+                "The requested representation could not be generated for this resource.",
+                status=500,
+                content_type="text/plain",
+            )
         if body is None:
             raise Http404()
 

--- a/arches_lingo/views/api/dereference.py
+++ b/arches_lingo/views/api/dereference.py
@@ -1,0 +1,121 @@
+import uuid
+
+from django.http import Http404, HttpResponse
+from django.utils.cache import patch_vary_headers
+from django.views import View
+
+from arches.app.models.models import ResourceIdentifier, ResourceInstance
+
+from arches_lingo.permissions import anonymous_access_allowed, is_authenticated_user
+from arches_lingo.utils.concept_lifecycle import (
+    PUBLICLY_DEREFERENCEABLE_STATE_IDS,
+    RETIRED_STATE_ID,
+)
+from arches_lingo.utils.skos_serializer import (
+    NOT_ACCEPTABLE,
+    graph_kind_for_graph_id,
+    negotiate_rdf_format,
+    serialize_resource,
+)
+from arches_lingo.views.root import LingoRootView
+
+
+class DereferenceableResourceView(View):
+    """Serve a scheme or concept URI as either the HTML app or a SKOS representation.
+
+    The same identity URI is dereferenceable by both browsers and machines:
+    an ``Accept`` header (or ``?format=`` override) requesting an RDF serialization
+    returns SKOS for that single resource; anything else falls through to the Vue
+    single-page application, exactly as before this view existed.
+    """
+
+    def get(self, request, *args, **kwargs):
+        rdf_format = negotiate_rdf_format(
+            request.META.get("HTTP_ACCEPT", ""),
+            explicit_format=request.GET.get("format"),
+        )
+
+        if rdf_format is None:
+            # Default (browsers, */*, no Accept): serve the single-page application.
+            return LingoRootView.as_view()(request, *args, **kwargs)
+
+        if rdf_format is NOT_ACCEPTABLE:
+            return HttpResponse(
+                "The requested representation is not available for this resource.",
+                status=406,
+                content_type="text/plain",
+            )
+
+        resource_id, graph_kind = self._resolve_target(kwargs)
+        if resource_id is None or graph_kind is None:
+            raise Http404()
+
+        lifecycle_state_id = self._lifecycle_state_id(resource_id)
+        if not self._may_dereference(request, lifecycle_state_id):
+            raise Http404()
+
+        body, content_type = serialize_resource(
+            resource_id,
+            graph_kind,
+            rdf_format,
+            mark_deprecated=lifecycle_state_id == RETIRED_STATE_ID,
+        )
+        if body is None:
+            raise Http404()
+
+        response = HttpResponse(body, content_type=content_type)
+        patch_vary_headers(response, ("Accept",))
+        response["Content-Location"] = f"{request.path}?format={rdf_format}"
+        return response
+
+    def _resolve_target(self, kwargs):
+        """Return (resource_id, graph_kind) for the requested URI, or (None, None).
+
+        Slug-based routes carry a scheme/concept identifier; UUID routes carry an
+        ``id``. In every case the graph kind is confirmed from the loaded resource
+        so that only Lingo schemes/concepts are ever serialized as SKOS.
+        """
+        identifier = kwargs.get("concept_identifier") or kwargs.get("scheme_identifier")
+        if identifier:
+            resource_id = (
+                ResourceIdentifier.objects.filter(
+                    identifier=identifier,
+                    source="arches-lingo",
+                )
+                .values_list("resourceid", flat=True)
+                .first()
+            )
+        else:
+            resource_id = kwargs.get("id")
+
+        if resource_id is None:
+            return None, None
+
+        graph_id = (
+            ResourceInstance.objects.filter(pk=resource_id)
+            .values_list("graph_id", flat=True)
+            .first()
+        )
+        if graph_id is None:
+            return None, None
+        return resource_id, graph_kind_for_graph_id(graph_id)
+
+    def _lifecycle_state_id(self, resource_id):
+        raw_state_id = (
+            ResourceInstance.objects.filter(pk=resource_id)
+            .values_list("resource_instance_lifecycle_state_id", flat=True)
+            .first()
+        )
+        if raw_state_id is None:
+            return None
+        return uuid.UUID(str(raw_state_id))
+
+    def _may_dereference(self, request, lifecycle_state_id):
+        """Authenticated users may preview any state; anonymous consumers get only
+        published (publicly dereferenceable) resources, and only when anonymous
+        access is enabled."""
+        if is_authenticated_user(request.user):
+            return True
+        if not anonymous_access_allowed():
+            return False
+        return lifecycle_state_id in PUBLICLY_DEREFERENCEABLE_STATE_IDS

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -134,7 +134,7 @@ run_dev_server() {
 	echo ""
 	cd ${APP_FOLDER}
     echo "Running Django"
-	exec /bin/bash -c "source ../ENV/bin/activate && cd ../arches-component-lab/ && pip install -e . && cd ../arches-controlled-lists && pip install -e . && cd ../arches-querysets && pip install -e .&& cd ../arches && pip install -e . && cd ../arches-lingo && service memcached start && pip3 install debugpy -t /tmp && python -Wdefault /tmp/debugpy --listen 0.0.0.0:5678 manage.py runserver 0.0.0.0:${DJANGO_PORT}"
+	exec /bin/bash -c "source ../ENV/bin/activate && cd ../arches-vue-components/ && pip install -e . && cd ../arches-controlled-lists && pip install -e . && cd ../arches-querysets && pip install -e .&& cd ../arches && pip install -e . && cd ../arches-lingo && service memcached start && pip3 install debugpy -t /tmp && python -Wdefault /tmp/debugpy --listen 0.0.0.0:5678 manage.py runserver 0.0.0.0:${DJANGO_PORT}"
 }
 
 # "exec" means that it will finish building???

--- a/docker/static_frontend_configuration/tsconfig-paths.json
+++ b/docker/static_frontend_configuration/tsconfig-paths.json
@@ -8,8 +8,8 @@
             "@/arches_lingo/*": [
                 "../arches_lingo/src/arches_lingo/*"
             ],
-            "@/arches_component_lab/*": [
-                "../../ENV/lib/python3.12/site-packages/arches_component_lab/src/arches_component_lab/*"
+            "@/arches_vue_components/*": [
+                "../../ENV/lib/python3.12/site-packages/arches_vue_components/src/arches_vue_components/*"
             ],
             "@/arches_controlled_lists/*": [
                 "../../ENV/lib/python3.12/site-packages/arches_controlled_lists/src/arches_controlled_lists/*"

--- a/docker/static_frontend_configuration/urls.json
+++ b/docker/static_frontend_configuration/urls.json
@@ -1078,31 +1078,31 @@
             "params": ["workflowid"]
         }
     ],
-    "arches_component_lab:api-card-x-node-x-widget": [
+    "arches_vue_components:api-card-x-node-x-widget": [
         {
             "url": "/api/card-x-node-x-widget-data/{graph_slug}/{node_alias}",
             "params": ["graph_slug", "node_alias"]
         }
     ],
-    "arches_component_lab:api-card-x-node-x-widget-list-from-nodegroup": [
+    "arches_vue_components:api-card-x-node-x-widget-list-from-nodegroup": [
         {
             "url": "/api/card-x-node-x-widget-list-from-nodegroup/{graph_slug}/{nodegroup_alias}",
             "params": ["graph_slug", "nodegroup_alias"]
         }
     ],
-    "arches_component_lab:api-concepts-tree": [
+    "arches_vue_components:api-concepts-tree": [
         {
             "url": "/api/concepts/{graph_slug}/{node_alias}",
             "params": ["graph_slug", "node_alias"]
         }
     ],
-    "arches_component_lab:api-languages-with-request-language": [
+    "arches_vue_components:api-languages-with-request-language": [
         {
             "url": "/api/languages-with-request-language",
             "params": []
         }
     ],
-    "arches_component_lab:api-relatable-resources": [
+    "arches_vue_components:api-relatable-resources": [
         {
             "url": "/api/relatable-resources/{graph}/{node_alias}",
             "params": ["graph", "node_alias"]

--- a/docker/static_frontend_configuration/webpack-metadata.json
+++ b/docker/static_frontend_configuration/webpack-metadata.json
@@ -4,13 +4,13 @@
     "APP_ROOT": "/web_root/arches-lingo/arches_lingo",
     "ARCHES_APPLICATIONS": [
         "arches_lingo",
-        "arches_component_lab",
+        "arches_vue_components",
         "arches_controlled_lists",
         "arches_querysets"
     ],
     "ARCHES_APPLICATIONS_PATHS": {
         "arches_lingo": "/web_root/arches-lingo/arches_lingo",
-        "arches_component_lab": "/web_root/ENV/lib/python3.12/site-packages/arches_component_lab",
+        "arches_vue_components": "/web_root/ENV/lib/python3.12/site-packages/arches_vue_components",
         "arches_controlled_lists": "/web_root/ENV/lib/python3.12/site-packages/arches_controlled_lists",
         "arches_querysets": "/web_root/ENV/lib/python3.12/site-packages/arches_querysets"
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,5 @@
 
+import globals from "globals";
 import js from "@eslint/js";
 import pluginVue from 'eslint-plugin-vue';
 import tseslint from 'typescript-eslint';
@@ -14,17 +15,7 @@ export default [
     {
         "languageOptions": {
             "globals": {
-                "define": false,
-                "require": false,
-                "window": false,
-                "console": false,
-                "history": false,
-                "location": false,
-                "Promise": false,
-                "setTimeout": false,
-                "URL": false,
-                "URLSearchParams": false,
-                "fetch": false
+                ...globals.browser,
             },
             "parser": vueESLintParser,
             "parserOptions": {
@@ -37,6 +28,13 @@ export default [
             },
         },
         "rules": {
+            "@typescript-eslint/no-unused-vars": [
+                "error", { 
+                    "argsIgnorePattern": "^_", 
+                    "varsIgnorePattern": "^_",
+                    "caughtErrorsIgnorePattern": "^_",
+                }
+            ],
             "semi": ["error", "always"],
         },
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,8 +29,8 @@ export default [
         },
         "rules": {
             "@typescript-eslint/no-unused-vars": [
-                "error", { 
-                    "argsIgnorePattern": "^_", 
+                "error", {
+                    "argsIgnorePattern": "^_",
                     "varsIgnorePattern": "^_",
                     "caughtErrorsIgnorePattern": "^_",
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@primevue/forms": "4.3.7",
                 "arches": "archesproject/arches#dev/8.1.x",
+                "arches-controlled-lists": "archesproject/arches-controlled-lists#dev/1.2.x",
                 "arches-vue-components": "archesproject/arches-vue-components#dev/2.0.x",
                 "pinia": "3.0.4",
                 "vue-router": "4.4.3"
@@ -107,25 +108,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/babel"
-            }
-        },
-        "node_modules/@babel/eslint-parser": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.28.6.tgz",
-            "integrity": "sha512-QGmsKi2PBO/MHSQk+AAgA9R6OHQr+VqnniFE0eMWZcVcfBZoA2dKn2hUsl3Csg/Plt9opRUWdY7//VXsrIlEiA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
-                "eslint-visitor-keys": "^2.1.0",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.11.0",
-                "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
             }
         },
         "node_modules/@babel/generator": {
@@ -1640,11 +1622,14 @@
             }
         },
         "node_modules/@bcoe/v8-coverage": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
-            "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+            "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/@cacheable/memory": {
             "version": "2.2.0",
@@ -1803,9 +1788,9 @@
             }
         },
         "node_modules/@csstools/css-syntax-patches-for-csstree": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
-            "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+            "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
             "dev": true,
             "funding": [
                 {
@@ -1871,6 +1856,29 @@
                 "@csstools/css-tokenizer": "^3.0.4"
             }
         },
+        "node_modules/@csstools/selector-specificity": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
+            "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "postcss-selector-parser": "^7.0.0"
+            }
+        },
         "node_modules/@discoveryjs/json-ext": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -1905,7 +1913,6 @@
             "os": [
                 "aix"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1923,7 +1930,6 @@
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1941,7 +1947,6 @@
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1959,7 +1964,6 @@
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1977,7 +1981,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1995,7 +1998,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2013,7 +2015,6 @@
             "os": [
                 "freebsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2031,7 +2032,6 @@
             "os": [
                 "freebsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2049,7 +2049,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2067,7 +2066,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2085,7 +2083,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2103,7 +2100,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2121,7 +2117,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2139,7 +2134,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2157,7 +2151,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2175,7 +2168,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2193,7 +2185,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2211,7 +2202,6 @@
             "os": [
                 "netbsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2229,7 +2219,6 @@
             "os": [
                 "netbsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2247,7 +2236,6 @@
             "os": [
                 "openbsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2265,7 +2253,6 @@
             "os": [
                 "openbsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2283,7 +2270,6 @@
             "os": [
                 "openharmony"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2301,7 +2287,6 @@
             "os": [
                 "sunos"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2319,7 +2304,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2337,7 +2321,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2355,15 +2338,14 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-            "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+            "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2403,167 +2385,89 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.21.2",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-            "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+            "version": "0.23.5",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+            "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/object-schema": "^2.1.7",
+                "@eslint/object-schema": "^3.0.5",
                 "debug": "^4.3.1",
-                "minimatch": "^3.1.5"
+                "minimatch": "^10.2.4"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            }
-        },
-        "node_modules/@eslint/config-array/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/@eslint/config-array/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-            "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+            "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/core": "^0.17.0"
+                "@eslint/core": "^1.2.1"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             }
         },
         "node_modules/@eslint/core": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-            "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+            "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@types/json-schema": "^7.0.15"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            }
-        },
-        "node_modules/@eslint/eslintrc": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
-            "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ajv": "^6.14.0",
-                "debug": "^4.3.2",
-                "espree": "^10.0.1",
-                "globals": "^14.0.0",
-                "ignore": "^5.2.0",
-                "import-fresh": "^3.2.1",
-                "js-yaml": "^4.3.0",
-                "minimatch": "^3.1.5",
-                "strip-json-comments": "^3.1.1"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.39.4",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-            "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+            "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             },
             "funding": {
                 "url": "https://eslint.org/donate"
+            },
+            "peerDependencies": {
+                "eslint": "^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "eslint": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@eslint/object-schema": {
-            "version": "2.1.7",
-            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-            "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+            "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-            "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+            "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/core": "^0.17.0",
+                "@eslint/core": "^1.2.1",
                 "levn": "^0.4.1"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             }
         },
         "node_modules/@gerhobbelt/linewrap": {
@@ -3534,16 +3438,6 @@
             "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
             "license": "BSD-3-Clause"
         },
-        "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
-            "version": "5.1.1-v1",
-            "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
-            "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "eslint-scope": "5.1.1"
-            }
-        },
         "node_modules/@noble/hashes": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
@@ -3876,9 +3770,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
-            "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
+            "integrity": "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==",
             "cpu": [
                 "arm"
             ],
@@ -3890,9 +3784,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
-            "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
+            "integrity": "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==",
             "cpu": [
                 "arm64"
             ],
@@ -3904,9 +3798,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
-            "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
+            "integrity": "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==",
             "cpu": [
                 "arm64"
             ],
@@ -3918,9 +3812,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
-            "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
+            "integrity": "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==",
             "cpu": [
                 "x64"
             ],
@@ -3932,9 +3826,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
-            "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
+            "integrity": "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==",
             "cpu": [
                 "arm64"
             ],
@@ -3946,9 +3840,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
-            "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
+            "integrity": "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==",
             "cpu": [
                 "x64"
             ],
@@ -3960,9 +3854,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
-            "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
+            "integrity": "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==",
             "cpu": [
                 "arm"
             ],
@@ -3974,9 +3868,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
-            "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
+            "integrity": "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==",
             "cpu": [
                 "arm"
             ],
@@ -3988,9 +3882,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
-            "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
+            "integrity": "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==",
             "cpu": [
                 "arm64"
             ],
@@ -4002,9 +3896,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
-            "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
+            "integrity": "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==",
             "cpu": [
                 "arm64"
             ],
@@ -4016,9 +3910,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
-            "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
+            "integrity": "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==",
             "cpu": [
                 "loong64"
             ],
@@ -4030,9 +3924,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
-            "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
+            "integrity": "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==",
             "cpu": [
                 "loong64"
             ],
@@ -4044,9 +3938,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
-            "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
+            "integrity": "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==",
             "cpu": [
                 "ppc64"
             ],
@@ -4058,9 +3952,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
-            "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
+            "integrity": "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==",
             "cpu": [
                 "ppc64"
             ],
@@ -4072,9 +3966,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
-            "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
+            "integrity": "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==",
             "cpu": [
                 "riscv64"
             ],
@@ -4086,9 +3980,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
-            "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
+            "integrity": "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -4100,9 +3994,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
-            "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
+            "integrity": "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==",
             "cpu": [
                 "s390x"
             ],
@@ -4114,9 +4008,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
-            "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
+            "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
             "cpu": [
                 "x64"
             ],
@@ -4128,9 +4022,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
-            "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
+            "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
             "cpu": [
                 "x64"
             ],
@@ -4142,9 +4036,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
-            "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
+            "integrity": "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==",
             "cpu": [
                 "x64"
             ],
@@ -4156,9 +4050,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
-            "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
+            "integrity": "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==",
             "cpu": [
                 "arm64"
             ],
@@ -4170,9 +4064,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
-            "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
+            "integrity": "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==",
             "cpu": [
                 "arm64"
             ],
@@ -4184,9 +4078,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
-            "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
+            "integrity": "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==",
             "cpu": [
                 "ia32"
             ],
@@ -4198,9 +4092,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
-            "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
+            "integrity": "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==",
             "cpu": [
                 "x64"
             ],
@@ -4212,9 +4106,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
-            "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
+            "integrity": "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==",
             "cpu": [
                 "x64"
             ],
@@ -5966,6 +5860,17 @@
                 "@types/responselike": "^1.0.0"
             }
         },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
         "node_modules/@types/connect": {
             "version": "3.4.38",
             "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -5986,6 +5891,13 @@
                 "@types/express-serve-static-core": "*",
                 "@types/node": "*"
             }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/eslint": {
             "version": "9.6.1",
@@ -6008,6 +5920,13 @@
                 "@types/eslint": "*",
                 "@types/estree": "*"
             }
+        },
+        "node_modules/@types/esrecurse": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+            "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/estree": {
             "version": "1.0.9",
@@ -6177,9 +6096,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "26.1.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-            "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+            "version": "26.1.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+            "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~8.3.0"
@@ -6578,19 +6497,6 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
         "node_modules/@vitejs/plugin-vue": {
             "version": "5.2.4",
             "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
@@ -6606,137 +6512,84 @@
             }
         },
         "node_modules/@vitest/coverage-v8": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz",
-            "integrity": "sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==",
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.7.tgz",
+            "integrity": "sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@ampproject/remapping": "^2.2.1",
-                "@bcoe/v8-coverage": "^0.2.3",
-                "debug": "^4.3.4",
+                "@ampproject/remapping": "^2.3.0",
+                "@bcoe/v8-coverage": "^1.0.2",
+                "ast-v8-to-istanbul": "^0.3.3",
+                "debug": "^4.4.1",
                 "istanbul-lib-coverage": "^3.2.2",
                 "istanbul-lib-report": "^3.0.1",
-                "istanbul-lib-source-maps": "^5.0.4",
-                "istanbul-reports": "^3.1.6",
-                "magic-string": "^0.30.5",
-                "magicast": "^0.3.3",
-                "picocolors": "^1.0.0",
-                "std-env": "^3.5.0",
-                "strip-literal": "^2.0.0",
-                "test-exclude": "^6.0.0"
+                "istanbul-lib-source-maps": "^5.0.6",
+                "istanbul-reports": "^3.1.7",
+                "magic-string": "^0.30.17",
+                "magicast": "^0.3.5",
+                "std-env": "^3.9.0",
+                "test-exclude": "^7.0.1",
+                "tinyrainbow": "^2.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
-                "vitest": "1.6.1"
+                "@vitest/browser": "3.2.7",
+                "vitest": "3.2.7"
+            },
+            "peerDependenciesMeta": {
+                "@vitest/browser": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
-            "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+            "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "1.6.1",
-                "@vitest/utils": "1.6.1",
-                "chai": "^4.3.10"
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "3.2.7",
+                "@vitest/utils": "3.2.7",
+                "chai": "^5.2.0",
+                "tinyrainbow": "^2.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
-        "node_modules/@vitest/runner": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
-            "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+        "node_modules/@vitest/mocker": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+            "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "1.6.1",
-                "p-limit": "^5.0.0",
-                "pathe": "^1.1.1"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            }
-        },
-        "node_modules/@vitest/runner/node_modules/p-limit": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
-            "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "yocto-queue": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@vitest/runner/node_modules/yocto-queue": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
-            "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12.20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@vitest/snapshot": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
-            "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "magic-string": "^0.30.5",
-                "pathe": "^1.1.1",
-                "pretty-format": "^29.7.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            }
-        },
-        "node_modules/@vitest/spy": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
-            "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tinyspy": "^2.2.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            }
-        },
-        "node_modules/@vitest/utils": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
-            "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "diff-sequences": "^29.6.3",
+                "@vitest/spy": "3.2.7",
                 "estree-walker": "^3.0.3",
-                "loupe": "^2.3.7",
-                "pretty-format": "^29.7.0"
+                "magic-string": "^0.30.17"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
             }
         },
-        "node_modules/@vitest/utils/node_modules/estree-walker": {
+        "node_modules/@vitest/mocker/node_modules/estree-walker": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
             "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
@@ -6746,31 +6599,102 @@
                 "@types/estree": "^1.0.0"
             }
         },
-        "node_modules/@volar/language-core": {
-            "version": "2.4.15",
-            "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.15.tgz",
-            "integrity": "sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==",
+        "node_modules/@vitest/pretty-format": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+            "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@volar/source-map": "2.4.15"
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+            "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "3.2.7",
+                "pathe": "^2.0.3",
+                "strip-literal": "^3.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+            "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "3.2.7",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+            "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyspy": "^4.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+            "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "3.2.7",
+                "loupe": "^3.1.4",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@volar/language-core": {
+            "version": "2.4.28",
+            "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+            "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@volar/source-map": "2.4.28"
             }
         },
         "node_modules/@volar/source-map": {
-            "version": "2.4.15",
-            "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.15.tgz",
-            "integrity": "sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg==",
+            "version": "2.4.28",
+            "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+            "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@volar/typescript": {
-            "version": "2.4.15",
-            "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.15.tgz",
-            "integrity": "sha512-2aZ8i0cqPGjXb4BhkMsPYDkkuc2ZQ6yOpqwAuNwUoncELqoy5fRgOQtLR9gB0g902iS0NAkvpIzs27geVyVdPg==",
+            "version": "2.4.28",
+            "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+            "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@volar/language-core": "2.4.15",
+                "@volar/language-core": "2.4.28",
                 "path-browserify": "^1.0.1",
                 "vscode-uri": "^3.0.8"
             }
@@ -6827,17 +6751,6 @@
                 "@vue/shared": "3.5.40"
             }
         },
-        "node_modules/@vue/compiler-vue2": {
-            "version": "2.7.16",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
-            "integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "de-indent": "^1.0.2",
-                "he": "^1.2.0"
-            }
-        },
         "node_modules/@vue/devtools-api": {
             "version": "7.7.10",
             "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.10.tgz",
@@ -6872,61 +6785,32 @@
             }
         },
         "node_modules/@vue/language-core": {
-            "version": "2.2.12",
-            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.12.tgz",
-            "integrity": "sha512-IsGljWbKGU1MZpBPN+BvPAdr55YPkj2nB/TBNGNC32Vy2qLG25DYu/NBN2vNtZqdRbTRjaoYrahLrToim2NanA==",
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.8.tgz",
+            "integrity": "sha512-ieGT8jJdhhy0mGzStZhsg/qPw5bQZJg5yF+3+XU6saf4sM7yo9ZXy3h+nCwrm2+b4qS/SypkNdR2jAF3uei9tA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@volar/language-core": "2.4.15",
+                "@volar/language-core": "2.4.28",
                 "@vue/compiler-dom": "^3.5.0",
-                "@vue/compiler-vue2": "^2.7.16",
                 "@vue/shared": "^3.5.0",
-                "alien-signals": "^1.0.3",
-                "minimatch": "^9.0.3",
+                "alien-signals": "^3.2.1",
                 "muggle-string": "^0.4.1",
-                "path-browserify": "^1.0.1"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
+                "path-browserify": "^1.0.1",
+                "picomatch": "^4.0.4"
             }
         },
-        "node_modules/@vue/language-core/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@vue/language-core/node_modules/brace-expansion": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+        "node_modules/@vue/language-core/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/@vue/language-core/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.2"
-            },
             "engines": {
-                "node": ">=16 || 14 >=14.17"
+                "node": ">=12"
             },
             "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/@vue/reactivity": {
@@ -7249,9 +7133,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+            "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -7282,19 +7166,6 @@
             "license": "MIT",
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            }
-        },
-        "node_modules/acorn-walk": {
-            "version": "8.3.5",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
-            "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.11.0"
-            },
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/agent-base": {
@@ -7367,9 +7238,9 @@
             "license": "MIT"
         },
         "node_modules/alien-signals": {
-            "version": "1.0.13",
-            "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-1.0.13.tgz",
-            "integrity": "sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+            "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
             "dev": true,
             "license": "MIT"
         },
@@ -7434,8 +7305,8 @@
             }
         },
         "node_modules/arches": {
-            "version": "8.1.3",
-            "resolved": "git+ssh://git@github.com/archesproject/arches.git#fb23bd6ea6142753b999ca66886e2e1772b8c4be",
+            "version": "8.1.4",
+            "resolved": "git+ssh://git@github.com/archesproject/arches.git#991f271b712bd82589c54f5e03f7b4121b6c535e",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@babel/runtime": "7.28.3",
@@ -7474,7 +7345,7 @@
                 "jquery-migrate": "3.4.1",
                 "jquery-validation": "1.19.5",
                 "jqueryui": "1.11.1",
-                "js-cookie": "3.0.5",
+                "js-cookie": "3.0.8",
                 "knockout": "3.5.0",
                 "knockout-mapping": "~2.6.0",
                 "knockstrap": "1.3.2",
@@ -7502,34 +7373,46 @@
                 "webpack-bundle-tracker": "3.2.0"
             }
         },
+        "node_modules/arches-controlled-lists": {
+            "name": "arches_controlled_lists",
+            "version": "1.2.0",
+            "resolved": "git+ssh://git@github.com/archesproject/arches-controlled-lists.git#e85e28e49642d332a6b8744fe7c277e303748879",
+            "license": "AGPL-3.0-only",
+            "dependencies": {
+                "arches": "archesproject/arches#stable/8.1.3",
+                "arches-vue-components": "archesproject/arches-vue-components#stable/2.0.2",
+                "pinia": "^3.0.4",
+                "vue-router": "4.4.3"
+            }
+        },
         "node_modules/arches-dev-dependencies": {
-            "version": "8.1.3",
-            "resolved": "git+ssh://git@github.com/archesproject/arches-dev-dependencies.git#7420e451511f199b491c3d8dc0e23b132ff3750c",
+            "version": "8.1.4",
+            "resolved": "git+ssh://git@github.com/archesproject/arches-dev-dependencies.git#80c18945071421be0a002f7b7439c2fce9a48058",
             "dev": true,
             "dependencies": {
                 "@babel/core": "7.29.0",
-                "@babel/eslint-parser": "7.28.6",
                 "@babel/plugin-syntax-dynamic-import": "7.8.3",
                 "@babel/plugin-transform-class-properties": "7.28.6",
                 "@babel/plugin-transform-runtime": "7.29.0",
                 "@babel/preset-env": "7.29.0",
+                "@eslint/js": "10.0.1",
                 "@types/js-cookie": "3.0.6",
                 "@typescript-eslint/parser": "8.57.0",
                 "@vitejs/plugin-vue": "5.2.4",
-                "@vitest/coverage-v8": "1.6.1",
+                "@vitest/coverage-v8": "3.2.7",
                 "@vue/test-utils": "2.4.6",
                 "babel-loader": "9.2.1",
                 "clean-webpack-plugin": "4.0.0",
                 "cross-env": "7.0.3",
                 "cross-fetch": "4.1.0",
                 "css-loader": "7.1.4",
-                "eslint": "9.39.4",
+                "eslint": "10.8.0",
                 "eslint-config-prettier": "9.1.0",
-                "eslint-plugin-vue": "9.33.0",
+                "eslint-plugin-vue": "10.10.0",
                 "jsdom": "24.1.3",
                 "mini-css-extract-plugin": "2.10.1",
                 "nodemon": "3.1.14",
-                "postcss": "8.5.8",
+                "postcss": "8.5.23",
                 "postcss-loader": "8.2.1",
                 "prettier": "3.3.0",
                 "sass": "1.78.0",
@@ -7541,12 +7424,12 @@
                 "ts-loader": "9.5.4",
                 "typescript": "5.4.5",
                 "typescript-eslint": "8.57.0",
-                "vitest": "1.6.1",
+                "vitest": "3.2.7",
                 "vue-loader": "17.4.2",
-                "vue-tsc": "2.2.12",
+                "vue-tsc": "3.3.8",
                 "webpack": "5.105.4",
                 "webpack-cli": "5.1.4",
-                "webpack-dev-server": "5.2.3",
+                "webpack-dev-server": "5.2.5",
                 "webpack-merge": "5.10.0"
             }
         },
@@ -7580,9 +7463,9 @@
             }
         },
         "node_modules/arches-dev-dependencies/node_modules/postcss": {
-            "version": "8.5.8",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+            "version": "8.5.23",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+            "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
             "dev": true,
             "funding": [
                 {
@@ -7600,7 +7483,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -7610,7 +7493,8 @@
         },
         "node_modules/arches-vue-components": {
             "name": "arches_vue_components",
-            "resolved": "git+ssh://git@github.com/archesproject/arches-vue-components.git#c62e8a8eee8b6d2cd16462782fe9bc0cc948af59",
+            "version": "2.0.0",
+            "resolved": "git+ssh://git@github.com/archesproject/arches-vue-components.git#354e40218e240a737b1698bbcf0549967cf9ce61",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@mapbox/geojson-extent": "^1.0.1",
@@ -7618,7 +7502,7 @@
                 "@primeuix/themes": "1.0.1",
                 "@primevue/forms": "4.3.9",
                 "@types/geojson": "^7946.0.16",
-                "arches": "archesproject/arches#dev/8.0.x",
+                "arches": "archesproject/arches#dev/8.1.x",
                 "dayjs": "^1.11.13",
                 "dompurify": "^3.2.6",
                 "es-toolkit": "^1.44.0",
@@ -7939,14 +7823,43 @@
             }
         },
         "node_modules/assertion-error": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "*"
+                "node": ">=12"
             }
+        },
+        "node_modules/ast-v8-to-istanbul": {
+            "version": "0.3.12",
+            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+            "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.31",
+                "estree-walker": "^3.0.3",
+                "js-tokens": "^10.0.0"
+            }
+        },
+        "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+            "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/astral-regex": {
             "version": "2.0.0",
@@ -8073,9 +7986,9 @@
             "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.43",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
-            "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.8.tgz",
+            "integrity": "sha512-zAgkquC2WYF0PIc6XbNYkA2uuxxFavzgmX61R+dHDUa558V8Ejf8ozTZFR6QzM24RWu4kBcRkhJ5kpz77j9fnQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -8170,9 +8083,9 @@
             "license": "MIT"
         },
         "node_modules/bonjour-service": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.3.tgz",
-            "integrity": "sha512-2Kd5UYlFUVgAKMTyuBLl6w49wqfOnbxHqmuH0oCl/n7TfAikR0zoowNOP5BU4dfXmm+Vr9JyEN370auSMx+CNg==",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.4.tgz",
+            "integrity": "sha512-jCZcVv7eoc4QesRscwEZtSROBen+6LpKAmBIsQYQrsAeVHLyMXWX/t6eIV5KiRZYNUBl8eVqImEEMQ8L5+c/Kw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8208,16 +8121,16 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -8234,9 +8147,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.6",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
-            "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+            "version": "4.28.7",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+            "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
             "dev": true,
             "funding": [
                 {
@@ -8254,9 +8167,9 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.10.42",
-                "caniuse-lite": "^1.0.30001803",
-                "electron-to-chromium": "^1.5.389",
+                "baseline-browser-mapping": "^2.10.44",
+                "caniuse-lite": "^1.0.30001806",
+                "electron-to-chromium": "^1.5.393",
                 "node-releases": "^2.0.51",
                 "update-browserslist-db": "^1.2.3"
             },
@@ -8489,22 +8402,20 @@
             "license": "CC-BY-4.0"
         },
         "node_modules/chai": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
-            "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+            "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "assertion-error": "^1.1.0",
-                "check-error": "^1.0.3",
-                "deep-eql": "^4.1.3",
-                "get-func-name": "^2.0.2",
-                "loupe": "^2.3.6",
-                "pathval": "^1.1.1",
-                "type-detect": "^4.1.0"
+                "assertion-error": "^2.0.1",
+                "check-error": "^2.1.1",
+                "deep-eql": "^5.0.1",
+                "loupe": "^3.1.0",
+                "pathval": "^2.0.0"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=18"
             }
         },
         "node_modules/chalk": {
@@ -8524,16 +8435,13 @@
             }
         },
         "node_modules/check-error": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-            "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+            "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "get-func-name": "^2.0.2"
-            },
             "engines": {
-                "node": "*"
+                "node": ">= 16"
             }
         },
         "node_modules/chokidar": {
@@ -8865,13 +8773,6 @@
             "dependencies": {
                 "quickselect": "^3.0.0"
             }
-        },
-        "node_modules/confbox": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-            "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/config-chain": {
             "version": "1.1.13",
@@ -9808,13 +9709,6 @@
             "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
             "license": "MIT"
         },
-        "node_modules/de-indent": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-            "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/debug": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -9902,14 +9796,11 @@
             }
         },
         "node_modules/deep-eql": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
-            "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+            "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "type-detect": "^4.0.0"
-            },
             "engines": {
                 "node": ">=6"
             }
@@ -10098,16 +9989,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/diff-sequences": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-            "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
         "node_modules/dir-glob": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -10207,9 +10088,9 @@
             "license": "MIT"
         },
         "node_modules/editorconfig/node_modules/brace-expansion": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10263,9 +10144,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.393",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
-            "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
+            "version": "1.5.398",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.398.tgz",
+            "integrity": "sha512-AsvhAxopJGh6museTDMIjn6JpDYOfgu4RLlygomt87MUwBUqTfd/1EiPtx10/LZE8xpTvkP2E9Gafq7lkLtodQ==",
             "dev": true,
             "license": "ISC"
         },
@@ -10295,9 +10176,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.24.2",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
-            "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
+            "version": "5.24.5",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+            "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10474,9 +10355,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
-            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
             "dev": true,
             "license": "MIT"
         },
@@ -10528,13 +10409,14 @@
             }
         },
         "node_modules/es-toolkit": {
-            "version": "1.49.0",
-            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
-            "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
+            "version": "1.50.0",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+            "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
             "license": "MIT",
             "workspaces": [
                 "docs",
-                "benchmarks"
+                "benchmarks",
+                "tests/types"
             ]
         },
         "node_modules/esbuild": {
@@ -10544,7 +10426,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -10611,33 +10492,33 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.39.4",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-            "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+            "version": "10.8.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+            "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
             "dev": true,
             "license": "MIT",
+            "workspaces": [
+                "packages/*"
+            ],
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
-                "@eslint-community/regexpp": "^4.12.1",
-                "@eslint/config-array": "^0.21.2",
-                "@eslint/config-helpers": "^0.4.2",
-                "@eslint/core": "^0.17.0",
-                "@eslint/eslintrc": "^3.3.5",
-                "@eslint/js": "9.39.4",
-                "@eslint/plugin-kit": "^0.4.1",
+                "@eslint-community/regexpp": "^4.12.2",
+                "@eslint/config-array": "^0.23.5",
+                "@eslint/config-helpers": "^0.7.0",
+                "@eslint/core": "^1.2.1",
+                "@eslint/plugin-kit": "^0.7.2",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",
                 "@types/estree": "^1.0.6",
                 "ajv": "^6.14.0",
-                "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.6",
                 "debug": "^4.3.2",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^8.4.0",
-                "eslint-visitor-keys": "^4.2.1",
-                "espree": "^10.4.0",
-                "esquery": "^1.5.0",
+                "eslint-scope": "^9.1.2",
+                "eslint-visitor-keys": "^5.0.1",
+                "espree": "^11.2.0",
+                "esquery": "^1.7.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
                 "file-entry-cache": "^8.0.0",
@@ -10647,8 +10528,7 @@
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
-                "lodash.merge": "^4.6.2",
-                "minimatch": "^3.1.5",
+                "minimatch": "^10.2.5",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.3"
             },
@@ -10656,7 +10536,7 @@
                 "eslint": "bin/eslint.js"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             },
             "funding": {
                 "url": "https://eslint.org/donate"
@@ -10684,42 +10564,35 @@
             }
         },
         "node_modules/eslint-plugin-vue": {
-            "version": "9.33.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.33.0.tgz",
-            "integrity": "sha512-174lJKuNsuDIlLpjeXc5E2Tss8P44uIimAfGD0b90k0NoirJqpG7stLuU9Vp/9ioTOrQdWVREc4mRd1BD+CvGw==",
+            "version": "10.10.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.10.0.tgz",
+            "integrity": "sha512-dL9x9rBHqqNcByWiLOHK6L0SB97V82/NC0cZRn9cXPjM7pCuWlpQQP9bFH4vjBv80ej1ZpzAkuD8zWH1o9bZbA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-community/eslint-utils": "^4.4.0",
-                "globals": "^13.24.0",
+                "@eslint-community/eslint-utils": "^4.9.1",
                 "natural-compare": "^1.4.0",
                 "nth-check": "^2.1.1",
-                "postcss-selector-parser": "^6.0.15",
-                "semver": "^7.6.3",
-                "vue-eslint-parser": "^9.4.3",
-                "xml-name-validator": "^4.0.0"
+                "postcss-selector-parser": "^7.1.4",
+                "semver": "^7.8.5",
+                "xml-name-validator": "^5.0.0"
             },
             "engines": {
-                "node": "^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "peerDependencies": {
-                "eslint": "^6.2.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
-            }
-        },
-        "node_modules/eslint-plugin-vue/node_modules/globals": {
-            "version": "13.24.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "type-fest": "^0.20.2"
+                "@stylistic/eslint-plugin": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
+                "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "vue-eslint-parser": "^10.3.0"
             },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+            "peerDependenciesMeta": {
+                "@stylistic/eslint-plugin": {
+                    "optional": true
+                },
+                "@typescript-eslint/parser": {
+                    "optional": true
+                }
             }
         },
         "node_modules/eslint-plugin-vue/node_modules/semver": {
@@ -10735,140 +10608,51 @@
                 "node": ">=10"
             }
         },
-        "node_modules/eslint-plugin-vue/node_modules/type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/eslint-scope": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+            "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^4.1.1"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/eslint-visitor-keys": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-            "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/eslint/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/eslint/node_modules/eslint-scope": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-            "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
+                "@types/esrecurse": "^4.3.1",
+                "@types/estree": "^1.0.8",
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/eslint/node_modules/eslint-visitor-keys": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+        "node_modules/eslint-visitor-keys": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/eslint/node_modules/estraverse": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/eslint/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/espree": {
-            "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-            "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+            "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "acorn": "^8.15.0",
+                "acorn": "^8.16.0",
                 "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^4.2.1"
+                "eslint-visitor-keys": "^5.0.1"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/espree/node_modules/eslint-visitor-keys": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
@@ -10887,16 +10671,6 @@
                 "node": ">=0.10"
             }
         },
-        "node_modules/esquery/node_modules/estraverse": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
         "node_modules/esrecurse": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
@@ -10910,20 +10684,10 @@
                 "node": ">=4.0"
             }
         },
-        "node_modules/esrecurse/node_modules/estraverse": {
+        "node_modules/estraverse": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/estraverse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -10972,49 +10736,22 @@
                 "node": ">=0.8.x"
             }
         },
-        "node_modules/execa": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^8.0.1",
-                "human-signals": "^5.0.0",
-                "is-stream": "^3.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^5.1.0",
-                "onetime": "^6.0.0",
-                "signal-exit": "^4.1.0",
-                "strip-final-newline": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=16.17"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/execa/node_modules/get-stream": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/exit": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
             "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+            "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/express": {
@@ -11160,9 +10897,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-            "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
             "dev": true,
             "funding": [
                 {
@@ -11342,9 +11079,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+            "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
             "dev": true,
             "license": "ISC"
         },
@@ -11583,16 +11320,6 @@
             "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==",
             "license": "ISC"
         },
-        "node_modules/get-func-name": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-            "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/get-intrinsic": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -11762,9 +11489,9 @@
             "license": "MIT"
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -11869,19 +11596,6 @@
             },
             "engines": {
                 "node": "^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/globals": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-            "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/globalthis": {
@@ -12116,16 +11830,6 @@
                 "node": "*"
             }
         },
-        "node_modules/he": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "he": "bin/he"
-            }
-        },
         "node_modules/hookable": {
             "version": "5.5.3",
             "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
@@ -12355,16 +12059,6 @@
             },
             "engines": {
                 "node": ">= 14"
-            }
-        },
-        "node_modules/human-signals": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=16.17.0"
             }
         },
         "node_modules/hyperdyperid": {
@@ -13114,19 +12808,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-stream": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/is-string": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -13471,9 +13152,9 @@
             "license": "MIT"
         },
         "node_modules/js-beautify/node_modules/brace-expansion": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13519,13 +13200,10 @@
             }
         },
         "node_modules/js-cookie": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-            "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14"
-            }
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+            "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+            "license": "MIT"
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -13611,16 +13289,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/jsdom/node_modules/xml-name-validator": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
-            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/jsesc": {
@@ -13836,23 +13504,6 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
-        "node_modules/local-pkg": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
-            "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mlly": "^1.7.3",
-                "pkg-types": "^1.2.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            }
-        },
         "node_modules/locate-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -13868,13 +13519,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/lodash": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/lodash-es": {
             "version": "4.18.1",
@@ -13931,13 +13575,6 @@
             "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
             "license": "MIT"
         },
-        "node_modules/lodash.merge": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/lodash.topairs": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.topairs/-/lodash.topairs-4.3.0.tgz",
@@ -13952,14 +13589,11 @@
             "license": "MIT"
         },
         "node_modules/loupe": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-            "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+            "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "get-func-name": "^2.0.1"
-            }
+            "license": "MIT"
         },
         "node_modules/lowercase-keys": {
             "version": "2.0.0",
@@ -14369,19 +14003,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/mimic-fn": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/mimic-response": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
@@ -14429,13 +14050,13 @@
             "license": "ISC"
         },
         "node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "version": "10.2.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+            "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.5"
+                "brace-expansion": "^5.0.8"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -14480,26 +14101,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
             "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-            "license": "MIT"
-        },
-        "node_modules/mlly": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
-            "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.16.0",
-                "pathe": "^2.0.3",
-                "pkg-types": "^1.3.1",
-                "ufo": "^1.6.3"
-            }
-        },
-        "node_modules/mlly/node_modules/pathe": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/moment": {
@@ -14796,35 +14397,6 @@
             "integrity": "sha512-EmL3FHQ1vZ7wofzeLRqGZc7Lt4HpHezwfi2ODz8H2qcvltdIb4yqSo0trFN3Uk08YN7sPSQVETtH4Dg+k8xOBA==",
             "license": "WTFPL"
         },
-        "node_modules/npm-run-path": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-key": "^4.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/npm-run-path/node_modules/path-key": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/nth-check": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -14959,22 +14531,6 @@
                 "wrappy": "1"
             }
         },
-        "node_modules/onetime": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-fn": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/open": {
             "version": "10.2.0",
             "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
@@ -15013,12 +14569,13 @@
             }
         },
         "node_modules/own-keys": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-            "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+            "integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
             "license": "MIT",
             "dependencies": {
-                "get-intrinsic": "^1.2.6",
+                "call-bound": "^1.0.4",
+                "get-intrinsic": "^1.3.0",
                 "object-keys": "^1.1.1",
                 "safe-push-apply": "^1.0.0"
             },
@@ -15293,20 +14850,20 @@
             }
         },
         "node_modules/pathe": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-            "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/pathval": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-            "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+            "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "*"
+                "node": ">= 14.16"
             }
         },
         "node_modules/pbf": {
@@ -15505,25 +15062,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/pkg-types": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-            "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "confbox": "^0.1.8",
-                "mlly": "^1.7.4",
-                "pathe": "^2.0.1"
-            }
-        },
-        "node_modules/pkg-types/node_modules/pathe": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/pkijs": {
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
@@ -15574,9 +15112,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.19",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-            "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+            "version": "8.5.25",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+            "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -15593,7 +15131,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -15677,20 +15215,6 @@
                 "postcss": "^8.1.0"
             }
         },
-        "node_modules/postcss-modules-local-by-default/node_modules/postcss-selector-parser": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cssesc": "^3.0.0",
-                "util-deprecate": "^1.0.2"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/postcss-modules-scope": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
@@ -15705,20 +15229,6 @@
             },
             "peerDependencies": {
                 "postcss": "^8.1.0"
-            }
-        },
-        "node_modules/postcss-modules-scope/node_modules/postcss-selector-parser": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cssesc": "^3.0.0",
-                "util-deprecate": "^1.0.2"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/postcss-modules-values": {
@@ -15772,9 +15282,9 @@
             }
         },
         "node_modules/postcss-selector-parser": {
-            "version": "6.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
-            "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15840,34 +15350,6 @@
             },
             "funding": {
                 "url": "https://github.com/prettier/prettier?sponsor=1"
-            }
-        },
-        "node_modules/pretty-format": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^18.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/pretty-format/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/primeicons": {
@@ -16179,13 +15661,6 @@
             "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
             "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==",
             "license": "ISC"
-        },
-        "node_modules/react-is": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/read-pkg": {
             "version": "5.2.0",
@@ -16634,9 +16109,9 @@
             "license": "MIT"
         },
         "node_modules/rimraf/node_modules/brace-expansion": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -16688,9 +16163,9 @@
             "license": "Unlicense"
         },
         "node_modules/rollup": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
-            "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+            "version": "4.62.3",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
+            "integrity": "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -16704,31 +16179,31 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.62.2",
-                "@rollup/rollup-android-arm64": "4.62.2",
-                "@rollup/rollup-darwin-arm64": "4.62.2",
-                "@rollup/rollup-darwin-x64": "4.62.2",
-                "@rollup/rollup-freebsd-arm64": "4.62.2",
-                "@rollup/rollup-freebsd-x64": "4.62.2",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
-                "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
-                "@rollup/rollup-linux-arm64-gnu": "4.62.2",
-                "@rollup/rollup-linux-arm64-musl": "4.62.2",
-                "@rollup/rollup-linux-loong64-gnu": "4.62.2",
-                "@rollup/rollup-linux-loong64-musl": "4.62.2",
-                "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
-                "@rollup/rollup-linux-ppc64-musl": "4.62.2",
-                "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
-                "@rollup/rollup-linux-riscv64-musl": "4.62.2",
-                "@rollup/rollup-linux-s390x-gnu": "4.62.2",
-                "@rollup/rollup-linux-x64-gnu": "4.62.2",
-                "@rollup/rollup-linux-x64-musl": "4.62.2",
-                "@rollup/rollup-openbsd-x64": "4.62.2",
-                "@rollup/rollup-openharmony-arm64": "4.62.2",
-                "@rollup/rollup-win32-arm64-msvc": "4.62.2",
-                "@rollup/rollup-win32-ia32-msvc": "4.62.2",
-                "@rollup/rollup-win32-x64-gnu": "4.62.2",
-                "@rollup/rollup-win32-x64-msvc": "4.62.2",
+                "@rollup/rollup-android-arm-eabi": "4.62.3",
+                "@rollup/rollup-android-arm64": "4.62.3",
+                "@rollup/rollup-darwin-arm64": "4.62.3",
+                "@rollup/rollup-darwin-x64": "4.62.3",
+                "@rollup/rollup-freebsd-arm64": "4.62.3",
+                "@rollup/rollup-freebsd-x64": "4.62.3",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.62.3",
+                "@rollup/rollup-linux-arm-musleabihf": "4.62.3",
+                "@rollup/rollup-linux-arm64-gnu": "4.62.3",
+                "@rollup/rollup-linux-arm64-musl": "4.62.3",
+                "@rollup/rollup-linux-loong64-gnu": "4.62.3",
+                "@rollup/rollup-linux-loong64-musl": "4.62.3",
+                "@rollup/rollup-linux-ppc64-gnu": "4.62.3",
+                "@rollup/rollup-linux-ppc64-musl": "4.62.3",
+                "@rollup/rollup-linux-riscv64-gnu": "4.62.3",
+                "@rollup/rollup-linux-riscv64-musl": "4.62.3",
+                "@rollup/rollup-linux-s390x-gnu": "4.62.3",
+                "@rollup/rollup-linux-x64-gnu": "4.62.3",
+                "@rollup/rollup-linux-x64-musl": "4.62.3",
+                "@rollup/rollup-openbsd-x64": "4.62.3",
+                "@rollup/rollup-openharmony-arm64": "4.62.3",
+                "@rollup/rollup-win32-arm64-msvc": "4.62.3",
+                "@rollup/rollup-win32-ia32-msvc": "4.62.3",
+                "@rollup/rollup-win32-x64-gnu": "4.62.3",
+                "@rollup/rollup-win32-x64-msvc": "4.62.3",
                 "fsevents": "~2.3.2"
             }
         },
@@ -17730,19 +17205,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/strip-final-newline": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/strip-indent": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -17755,23 +17217,10 @@
                 "node": ">=8"
             }
         },
-        "node_modules/strip-json-comments": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/strip-literal": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
-            "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+            "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -17974,29 +17423,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/stylelint/node_modules/@csstools/selector-specificity": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
-            "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT-0",
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "postcss-selector-parser": "^7.0.0"
-            }
-        },
         "node_modules/stylelint/node_modules/array-union": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -18088,20 +17514,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/stylelint/node_modules/postcss-selector-parser": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cssesc": "^3.0.0",
-                "util-deprecate": "^1.0.2"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/stylelint/node_modules/resolve-from": {
@@ -18385,18 +17797,18 @@
             "license": "MIT"
         },
         "node_modules/test-exclude": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-            "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+            "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@istanbuljs/schema": "^0.1.2",
-                "glob": "^7.1.4",
-                "minimatch": "^3.0.4"
+                "glob": "^10.4.1",
+                "minimatch": "^10.2.2"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=18"
             }
         },
         "node_modules/test-exclude/node_modules/balanced-match": {
@@ -18407,33 +17819,57 @@
             "license": "MIT"
         },
         "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
+                "balanced-match": "^1.0.0"
             }
         },
-        "node_modules/test-exclude/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+        "node_modules/test-exclude/node_modules/glob": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^1.1.7"
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
-                "node": "*"
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/thingies": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.0.tgz",
-            "integrity": "sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.1.tgz",
+            "integrity": "sha512-cV/CMGTK3M4MlnJ/0At6ismOw/A0EEniDNScajjz/Br3c1sqE72YD01rGpPTKwd27wAxI5Pr+6+0w8yofzFRYw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -18458,6 +17894,13 @@
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
             "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+            "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
             "dev": true,
             "license": "MIT"
         },
@@ -18510,13 +17953,13 @@
             }
         },
         "node_modules/tinypool": {
-            "version": "0.8.4",
-            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
-            "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+            "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=14.0.0"
+                "node": "^18.0.0 || >=20.0.0"
             }
         },
         "node_modules/tinyqueue": {
@@ -18525,10 +17968,20 @@
             "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
             "license": "ISC"
         },
+        "node_modules/tinyrainbow": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+            "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/tinyspy": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
-            "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+            "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -18776,16 +18229,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/type-detect": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-            "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/type-fest": {
             "version": "0.18.1",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
@@ -18959,13 +18402,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/ufo": {
-            "version": "1.6.4",
-            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
-            "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/unbox-primitive": {
             "version": "1.1.0",
@@ -19320,7 +18756,6 @@
             "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",
@@ -19391,516 +18826,26 @@
             }
         },
         "node_modules/vite-node": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
-            "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+            "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cac": "^6.7.14",
-                "debug": "^4.3.4",
-                "pathe": "^1.1.1",
-                "picocolors": "^1.0.0",
-                "vite": "^5.0.0"
+                "debug": "^4.4.1",
+                "es-module-lexer": "^1.7.0",
+                "pathe": "^2.0.3",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
             },
             "bin": {
                 "vite-node": "vite-node.mjs"
             },
             "engines": {
-                "node": "^18.0.0 || >=20.0.0"
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-            "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "aix"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/android-arm": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-            "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-            "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/android-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-            "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-            "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-            "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-            "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-            "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-            "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-            "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-            "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-            "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-            "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
-            "cpu": [
-                "mips64el"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-            "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-            "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-            "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-            "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-            "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-            "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-            "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-            "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-            "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-            "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite-node/node_modules/esbuild": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-            "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "bin": {
-                "esbuild": "bin/esbuild"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.21.5",
-                "@esbuild/android-arm": "0.21.5",
-                "@esbuild/android-arm64": "0.21.5",
-                "@esbuild/android-x64": "0.21.5",
-                "@esbuild/darwin-arm64": "0.21.5",
-                "@esbuild/darwin-x64": "0.21.5",
-                "@esbuild/freebsd-arm64": "0.21.5",
-                "@esbuild/freebsd-x64": "0.21.5",
-                "@esbuild/linux-arm": "0.21.5",
-                "@esbuild/linux-arm64": "0.21.5",
-                "@esbuild/linux-ia32": "0.21.5",
-                "@esbuild/linux-loong64": "0.21.5",
-                "@esbuild/linux-mips64el": "0.21.5",
-                "@esbuild/linux-ppc64": "0.21.5",
-                "@esbuild/linux-riscv64": "0.21.5",
-                "@esbuild/linux-s390x": "0.21.5",
-                "@esbuild/linux-x64": "0.21.5",
-                "@esbuild/netbsd-x64": "0.21.5",
-                "@esbuild/openbsd-x64": "0.21.5",
-                "@esbuild/sunos-x64": "0.21.5",
-                "@esbuild/win32-arm64": "0.21.5",
-                "@esbuild/win32-ia32": "0.21.5",
-                "@esbuild/win32-x64": "0.21.5"
-            }
-        },
-        "node_modules/vite-node/node_modules/vite": {
-            "version": "5.4.21",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-            "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "esbuild": "^0.21.3",
-                "postcss": "^8.4.43",
-                "rollup": "^4.20.0"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "less": "*",
-                "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
-                "terser": "^5.4.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "lightningcss": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                }
             }
         },
         "node_modules/vite/node_modules/fdir": {
@@ -19909,7 +18854,6 @@
             "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12.0.0"
             },
@@ -19928,7 +18872,6 @@
             "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -19937,52 +18880,59 @@
             }
         },
         "node_modules/vitest": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
-            "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+            "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "1.6.1",
-                "@vitest/runner": "1.6.1",
-                "@vitest/snapshot": "1.6.1",
-                "@vitest/spy": "1.6.1",
-                "@vitest/utils": "1.6.1",
-                "acorn-walk": "^8.3.2",
-                "chai": "^4.3.10",
-                "debug": "^4.3.4",
-                "execa": "^8.0.1",
-                "local-pkg": "^0.5.0",
-                "magic-string": "^0.30.5",
-                "pathe": "^1.1.1",
-                "picocolors": "^1.0.0",
-                "std-env": "^3.5.0",
-                "strip-literal": "^2.0.0",
-                "tinybench": "^2.5.1",
-                "tinypool": "^0.8.3",
-                "vite": "^5.0.0",
-                "vite-node": "1.6.1",
-                "why-is-node-running": "^2.2.2"
+                "@types/chai": "^5.2.2",
+                "@vitest/expect": "3.2.7",
+                "@vitest/mocker": "3.2.7",
+                "@vitest/pretty-format": "^3.2.7",
+                "@vitest/runner": "3.2.7",
+                "@vitest/snapshot": "3.2.7",
+                "@vitest/spy": "3.2.7",
+                "@vitest/utils": "3.2.7",
+                "chai": "^5.2.0",
+                "debug": "^4.4.1",
+                "expect-type": "^1.2.1",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.2",
+                "std-env": "^3.9.0",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^0.3.2",
+                "tinyglobby": "^0.2.14",
+                "tinypool": "^1.1.1",
+                "tinyrainbow": "^2.0.0",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+                "vite-node": "3.2.4",
+                "why-is-node-running": "^2.3.0"
             },
             "bin": {
                 "vitest": "vitest.mjs"
             },
             "engines": {
-                "node": "^18.0.0 || >=20.0.0"
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
                 "@edge-runtime/vm": "*",
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "@vitest/browser": "1.6.1",
-                "@vitest/ui": "1.6.1",
+                "@types/debug": "^4.1.12",
+                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "@vitest/browser": "3.2.7",
+                "@vitest/ui": "3.2.7",
                 "happy-dom": "*",
                 "jsdom": "*"
             },
             "peerDependenciesMeta": {
                 "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/debug": {
                     "optional": true
                 },
                 "@types/node": {
@@ -20002,494 +18952,17 @@
                 }
             }
         },
-        "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-            "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
-            "cpu": [
-                "ppc64"
-            ],
+        "node_modules/vitest/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
-            "optional": true,
-            "os": [
-                "aix"
-            ],
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/android-arm": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-            "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/android-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-            "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/android-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-            "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-            "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-            "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-            "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-            "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/linux-arm": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-            "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-            "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-            "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-            "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-            "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
-            "cpu": [
-                "mips64el"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-            "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-            "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-            "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/linux-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-            "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-            "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-            "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-            "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-            "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-            "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/win32-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-            "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vitest/node_modules/esbuild": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-            "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "bin": {
-                "esbuild": "bin/esbuild"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.21.5",
-                "@esbuild/android-arm": "0.21.5",
-                "@esbuild/android-arm64": "0.21.5",
-                "@esbuild/android-x64": "0.21.5",
-                "@esbuild/darwin-arm64": "0.21.5",
-                "@esbuild/darwin-x64": "0.21.5",
-                "@esbuild/freebsd-arm64": "0.21.5",
-                "@esbuild/freebsd-x64": "0.21.5",
-                "@esbuild/linux-arm": "0.21.5",
-                "@esbuild/linux-arm64": "0.21.5",
-                "@esbuild/linux-ia32": "0.21.5",
-                "@esbuild/linux-loong64": "0.21.5",
-                "@esbuild/linux-mips64el": "0.21.5",
-                "@esbuild/linux-ppc64": "0.21.5",
-                "@esbuild/linux-riscv64": "0.21.5",
-                "@esbuild/linux-s390x": "0.21.5",
-                "@esbuild/linux-x64": "0.21.5",
-                "@esbuild/netbsd-x64": "0.21.5",
-                "@esbuild/openbsd-x64": "0.21.5",
-                "@esbuild/sunos-x64": "0.21.5",
-                "@esbuild/win32-arm64": "0.21.5",
-                "@esbuild/win32-ia32": "0.21.5",
-                "@esbuild/win32-x64": "0.21.5"
-            }
-        },
-        "node_modules/vitest/node_modules/vite": {
-            "version": "5.4.21",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-            "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "esbuild": "^0.21.3",
-                "postcss": "^8.4.43",
-                "rollup": "^4.20.0"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
             },
             "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "less": "*",
-                "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
-                "terser": "^5.4.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "lightningcss": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                }
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/vscode-uri": {
@@ -20540,86 +19013,28 @@
             "license": "MIT"
         },
         "node_modules/vue-eslint-parser": {
-            "version": "9.4.3",
-            "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.4.3.tgz",
-            "integrity": "sha512-2rYRLWlIpaiN8xbPiDyXZXRgLGOtWxERV7ND5fFAv5qo1D2N9Fu9MNajBNc6o13lZ+24DAWCkQCvj4klgmcITg==",
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-10.4.1.tgz",
+            "integrity": "sha512-Gk6gRDj0n/fkRa3C3l0bBheoBckUq/Rs0F/TvMWIS6nzzx67amAViMe9CkNgsP2tXyQONvGiHQESHwFtZ3aYDA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "debug": "^4.3.4",
-                "eslint-scope": "^7.1.1",
-                "eslint-visitor-keys": "^3.3.0",
-                "espree": "^9.3.1",
-                "esquery": "^1.4.0",
-                "lodash": "^4.17.21",
-                "semver": "^7.3.6"
+                "debug": "^4.4.0",
+                "eslint-scope": "^8.2.0 || ^9.0.0",
+                "eslint-visitor-keys": "^4.2.0 || ^5.0.0",
+                "espree": "^10.3.0 || ^11.0.0",
+                "esquery": "^1.6.0",
+                "semver": "^7.6.3"
             },
             "engines": {
-                "node": "^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/mysticatea"
             },
             "peerDependencies": {
-                "eslint": ">=6.0.0"
-            }
-        },
-        "node_modules/vue-eslint-parser/node_modules/eslint-scope": {
-            "version": "7.2.2",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-            "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^5.2.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/vue-eslint-parser/node_modules/eslint-visitor-keys": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/vue-eslint-parser/node_modules/espree": {
-            "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "acorn": "^8.9.0",
-                "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^3.4.1"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/vue-eslint-parser/node_modules/estraverse": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=4.0"
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
             }
         },
         "node_modules/vue-eslint-parser/node_modules/semver": {
@@ -20628,6 +19043,7 @@
             "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -20680,14 +19096,14 @@
             "license": "MIT"
         },
         "node_modules/vue-tsc": {
-            "version": "2.2.12",
-            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.12.tgz",
-            "integrity": "sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==",
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.8.tgz",
+            "integrity": "sha512-xXmYlVQpcwJDWyGlqbHrGVOl1h3UOsASymRibrHc+iy9j/UNnOrOn4u+fntHz4D6Cs74RtapeqVV6CzJeg+UlA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@volar/typescript": "2.4.15",
-                "@vue/language-core": "2.2.12"
+                "@volar/typescript": "2.4.28",
+                "@vue/language-core": "3.3.8"
             },
             "bin": {
                 "vue-tsc": "bin/vue-tsc.js"
@@ -20730,9 +19146,9 @@
             "license": "MIT"
         },
         "node_modules/vue3-gettext/node_modules/brace-expansion": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -20805,16 +19221,6 @@
             "dependencies": {
                 "xml-name-validator": "^5.0.0"
             },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/w3c-xmlserializer/node_modules/xml-name-validator": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
-            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-            "dev": true,
-            "license": "Apache-2.0",
             "engines": {
                 "node": ">=18"
             }
@@ -21083,9 +19489,9 @@
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "5.2.3",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.3.tgz",
-            "integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
+            "integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -21163,6 +19569,37 @@
             "license": "MIT",
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/webpack/node_modules/es-module-lexer": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/webpack/node_modules/eslint-scope": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/webpack/node_modules/estraverse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=4.0"
             }
         },
         "node_modules/websocket-driver": {
@@ -21365,9 +19802,9 @@
             "license": "MIT"
         },
         "node_modules/wkt-parser": {
-            "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.5.5.tgz",
-            "integrity": "sha512-/zMYi94/7D7fxcOSlVmWn6vnOMj3Gq5d1xvVjaYOS9n6h0qOJ4I7YYVxBWYcH1vq9+suhqzXkn05Yx47zQNUIA==",
+            "version": "1.5.6",
+            "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.5.6.tgz",
+            "integrity": "sha512-cqHU3lzGt/gt2OqIORP0uVy5yeOX43WABmgFkmJsmcqH3HhQo9PiJG6ftytwGKmpQUbegeX7+pQc2BuNCRfcrw==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ahocevar"
@@ -21539,13 +19976,13 @@
             }
         },
         "node_modules/xml-name-validator": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-            "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/xmlchars": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@primevue/forms": "4.3.7",
                 "arches": "archesproject/arches#dev/8.1.x",
-                "arches-vue-components": "archesproject/arches-vue-components#dev/1.0.x",
+                "arches-vue-components": "archesproject/arches-vue-components#dev/2.0.x",
                 "pinia": "3.0.4",
                 "vue-router": "4.4.3"
             },
@@ -55,12 +55,12 @@
             "license": "ISC"
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.28.5",
+                "@babel/helper-validator-identifier": "^7.29.7",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             },
@@ -69,9 +69,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-            "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -129,14 +129,14 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.29.1",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-            "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+            "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.0",
-                "@babel/types": "^7.29.0",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/gen-mapping": "^0.3.12",
                 "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
@@ -146,27 +146,27 @@
             }
         },
         "node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.27.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
-            "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+            "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.27.3"
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-            "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.28.6",
-                "@babel/helper-validator-option": "^7.27.1",
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -176,18 +176,18 @@
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.3.tgz",
-            "integrity": "sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+            "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.3",
-                "@babel/helper-member-expression-to-functions": "^7.28.5",
-                "@babel/helper-optimise-call-expression": "^7.27.1",
-                "@babel/helper-replace-supers": "^7.28.6",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-                "@babel/traverse": "^7.29.0",
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-member-expression-to-functions": "^7.29.7",
+                "@babel/helper-optimise-call-expression": "^7.29.7",
+                "@babel/helper-replace-supers": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -198,13 +198,13 @@
             }
         },
         "node_modules/@babel/helper-create-regexp-features-plugin": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
-            "integrity": "sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.29.7.tgz",
+            "integrity": "sha512-907Uymvqgg1dwUA+7IGwFAOSYzQOuzPXKNJ1yxzwPffzkYFg2q2eHi1fIOs6sXkG9NbIUMunnUlkYsfRFNvomg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.3",
+                "@babel/helper-annotate-as-pure": "^7.29.7",
                 "regexpu-core": "^6.3.1",
                 "semver": "^6.3.1"
             },
@@ -233,9 +233,9 @@
             }
         },
         "node_modules/@babel/helper-globals": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -243,43 +243,43 @@
             }
         },
         "node_modules/@babel/helper-member-expression-to-functions": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
-            "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+            "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.28.5",
-                "@babel/types": "^7.28.5"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-            "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-            "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.28.6",
-                "@babel/helper-validator-identifier": "^7.28.5",
-                "@babel/traverse": "^7.28.6"
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -289,22 +289,22 @@
             }
         },
         "node_modules/@babel/helper-optimise-call-expression": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
-            "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+            "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.27.1"
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-            "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+            "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -312,15 +312,15 @@
             }
         },
         "node_modules/@babel/helper-remap-async-to-generator": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
-            "integrity": "sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.29.7.tgz",
+            "integrity": "sha512-16AMiW26DbXWBbr3B8wNozKM0ydMLB892vaOaJW/fPJdnT8vJk5sdkQcU/isqUxyCE0cEoa8wZOcbgDuC4b6Og==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.1",
-                "@babel/helper-wrap-function": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-wrap-function": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -330,15 +330,15 @@
             }
         },
         "node_modules/@babel/helper-replace-supers": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
-            "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+            "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-member-expression-to-functions": "^7.28.5",
-                "@babel/helper-optimise-call-expression": "^7.27.1",
-                "@babel/traverse": "^7.28.6"
+                "@babel/helper-member-expression-to-functions": "^7.29.7",
+                "@babel/helper-optimise-call-expression": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -348,41 +348,41 @@
             }
         },
         "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
-            "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+            "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.27.1",
-                "@babel/types": "^7.27.1"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -390,41 +390,41 @@
             }
         },
         "node_modules/@babel/helper-wrap-function": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.6.tgz",
-            "integrity": "sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.29.7.tgz",
+            "integrity": "sha512-iES0Skag9ERIF68aXadpO6dbXa03mNWK3sEqJaMnLNs/eC3l0lkImdfoy6Y09/SfkpawdAB4RjQ7PVA7TcVGdw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.28.6",
-                "@babel/traverse": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-            "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.29.0"
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.29.0"
+                "@babel/types": "^7.29.7"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -434,14 +434,14 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.28.5.tgz",
-            "integrity": "sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.29.7.tgz",
+            "integrity": "sha512-j8SrR0zLZrRsC09DlszEx8FpMiwukKffYXMK0d5LmOglO7vGG6sz/BR/20yHqWH+Lnn31JTt2PE3hIWNgM2J6w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/traverse": "^7.28.5"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -451,13 +451,13 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz",
-            "integrity": "sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.29.7.tgz",
+            "integrity": "sha512-r8j8escF+U2FUHo0KOhPUdMzUO+jp9fInva6+ACVAF3Y97Ev+5iNZwiqTghmzNeWwDkOPlYuTcfb1vDaoZKmAQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -467,13 +467,13 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz",
-            "integrity": "sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.29.7.tgz",
+            "integrity": "sha512-GE1TFSiuFeGsCxmYXZl8HwoPrVlwe4rHPFE8weieGKZqnDORK+Ar3vgWMgW+AOxQ6/2TgLSKx9p6W7O4rC6qgQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -483,15 +483,15 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz",
-            "integrity": "sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.29.7.tgz",
+            "integrity": "sha512-QQt9qKHZ2sg/kivaLr7lnQr8HVrQDdBNSfCsTjiDxRuX/K5ORyKq+Bu8Xr0cDE3Dfkv0cw28Ve0EKyKMvulkOw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-                "@babel/plugin-transform-optional-chaining": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+                "@babel/plugin-transform-optional-chaining": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -501,14 +501,14 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.6.tgz",
-            "integrity": "sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.29.7.tgz",
+            "integrity": "sha512-pn6QacGLgvCcwc+syUhKE/qSjV2D1IHDB84RNxWYSt1mW3K/SCtjinZ2p0cETJxAWBjPy3K/1lHwG5BjjPxNlw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.28.6",
-                "@babel/traverse": "^7.28.6"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -544,13 +544,13 @@
             }
         },
         "node_modules/@babel/plugin-syntax-import-assertions": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.28.6.tgz",
-            "integrity": "sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.29.7.tgz",
+            "integrity": "sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -560,13 +560,13 @@
             }
         },
         "node_modules/@babel/plugin-syntax-import-attributes": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
-            "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+            "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -593,13 +593,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-arrow-functions": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
-            "integrity": "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.29.7.tgz",
+            "integrity": "sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -609,15 +609,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-async-generator-functions": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz",
-            "integrity": "sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.7.tgz",
+            "integrity": "sha512-d98gXZkgswvkyohMBABkhm3GeXhYj8psWfwQ2C7gtfrKGTykQa/iOIi+JJhwMjPlZ6Vm2XN+DCf3Es1EoG4ZLA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.28.6",
-                "@babel/helper-remap-async-to-generator": "^7.27.1",
-                "@babel/traverse": "^7.29.0"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-remap-async-to-generator": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -627,15 +627,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-async-to-generator": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz",
-            "integrity": "sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.29.7.tgz",
+            "integrity": "sha512-pcUb2SS+RMo9TWVBwKGI5ShtoG7R+zBsFmCKDa6fe8c+hPr3XJlZgoE5j6i8W7gDjhyvy+85vmYexanvXh3d1w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.28.6",
-                "@babel/helper-plugin-utils": "^7.28.6",
-                "@babel/helper-remap-async-to-generator": "^7.27.1"
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-remap-async-to-generator": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -645,13 +645,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoped-functions": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz",
-            "integrity": "sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.29.7.tgz",
+            "integrity": "sha512-cUSmjh72N+rN4PrkFlN1dJwNCwjVp5d38/CQrEsFggkD10UiFlBFgdH3tv5dNsLuHY+3S8db2xCHjhZcv5WgvA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -661,13 +661,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoping": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.6.tgz",
-            "integrity": "sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.29.7.tgz",
+            "integrity": "sha512-ONyr4+AZhKh8yKWInVxU9AXA9EbsyeLcL6V0dJy6M2/62vuvpGm29zzuymbTpdc451GEpDIdAyPLP3r+P61yKQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -694,14 +694,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-class-static-block": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.6.tgz",
-            "integrity": "sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.29.7.tgz",
+            "integrity": "sha512-kibJgmEdX2iMwsHY2tSZNDgj8PwIlCQz7FK9KuGKO8zsuoUwSEhoNnNVp/emKWrbY4HeO6kkXfdMqRKKKXBm2A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.28.6",
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-create-class-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -711,18 +711,18 @@
             }
         },
         "node_modules/@babel/plugin-transform-classes": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.6.tgz",
-            "integrity": "sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.29.7.tgz",
+            "integrity": "sha512-qV0OGGBVacduzQHE649JyCneOFI/maT+YKsO+K4Yi3xv2wTPNjM/W2o2gdzMwEAZz7fXNTHAe0NcSg30bIN69g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.3",
-                "@babel/helper-compilation-targets": "^7.28.6",
-                "@babel/helper-globals": "^7.28.0",
-                "@babel/helper-plugin-utils": "^7.28.6",
-                "@babel/helper-replace-supers": "^7.28.6",
-                "@babel/traverse": "^7.28.6"
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-replace-supers": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -732,14 +732,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-computed-properties": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.28.6.tgz",
-            "integrity": "sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.29.7.tgz",
+            "integrity": "sha512-RK7/IyU5phpuCdBAuig5VkzG/EnbDaui5SQGdU9BFrHdV+mV4cUjLMQ9lJDjLNtWHsqtiefpGZUXQP2BiTYMsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.28.6",
-                "@babel/template": "^7.28.6"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/template": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -749,14 +749,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-destructuring": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.5.tgz",
-            "integrity": "sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.29.7.tgz",
+            "integrity": "sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/traverse": "^7.28.5"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -766,14 +766,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-dotall-regex": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.28.6.tgz",
-            "integrity": "sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.29.7.tgz",
+            "integrity": "sha512-3qc18hsD2RdZiyJNDNc7HQpv6xbncwh8FYtxNFFzclSyh/trPD9KkVR9BDECUjDLvb7yJVF15GfYUuC+LMkkiQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -783,13 +783,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-duplicate-keys": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz",
-            "integrity": "sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.29.7.tgz",
+            "integrity": "sha512-6IvRRriEMqnBwD6chtxdLpMYCHWEzN+oL5cyQtjykya19UgzbmKhxmhZgKC/LHxS2nYr9Q/qYPZ5Lr6jOL9+yQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -799,14 +799,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.0.tgz",
-            "integrity": "sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.7.tgz",
+            "integrity": "sha512-2wiIyo2BjtgU7HufSeDnL9L2O7zr8jmhFKuSr65VpRkUiRKRNpb0mdlk56+XPPKoIrfHqzbMuglDvZun0RISsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -816,13 +816,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-dynamic-import": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz",
-            "integrity": "sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.29.7.tgz",
+            "integrity": "sha512-giOlEm/EFjfjr+te9NsdjkUo2v4f8rS/SXPumRVHAtbNcyNlvtREkU1dZzaIDclNpnaVhlCqRdFKhJBjBikzLg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -832,14 +832,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-explicit-resource-management": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.6.tgz",
-            "integrity": "sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.29.7.tgz",
+            "integrity": "sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.28.6",
-                "@babel/plugin-transform-destructuring": "^7.28.5"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/plugin-transform-destructuring": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -849,13 +849,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-exponentiation-operator": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.28.6.tgz",
-            "integrity": "sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.29.7.tgz",
+            "integrity": "sha512-zFpMOTLZBdW5LfObqcSbL6kefg4R4eLdmvS0wbN9M6D5Mym/sKm9toOoWyVOa+xDjvCnuWcHls2YonXwHvH3CQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -865,13 +865,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-export-namespace-from": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz",
-            "integrity": "sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.29.7.tgz",
+            "integrity": "sha512-24B2nOy2TeJSMheqwPD4DDQOV/elLSIlKxjZt4i05H5AgdPdWR3n18HnNrcJ+j76WJd9gbwb9jPjNYUy6RautA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -881,14 +881,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-for-of": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
-            "integrity": "sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.29.7.tgz",
+            "integrity": "sha512-zeSIHh0+E1Um1WJRXCFlHQYu2ieJNdivLLjlBEp+dIBu3S51n+SZZmIXjxnItw6pz56Cn+KvK68BIBVsxq2JiQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -898,15 +898,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-function-name": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz",
-            "integrity": "sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.29.7.tgz",
+            "integrity": "sha512-otRWaHXE6fbAGkePvaj/kvs3HsqXfPhlnzwSOlnFgbqCPMd975dW+4wZ00WFBt+/YlBGcJwNrARQTOJOb4ZrIg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-compilation-targets": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -916,13 +916,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-json-strings": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.28.6.tgz",
-            "integrity": "sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.29.7.tgz",
+            "integrity": "sha512-RRnE2+eon1rJAq8MnoF1b5kTpY1vU88twHcvcKMrsqP/jxIRqDVs9iJB5fqPuqyeFAW0wJo4MlUIPpQCq/aRsg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -932,13 +932,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-literals": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz",
-            "integrity": "sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.29.7.tgz",
+            "integrity": "sha512-DZ/oLP21ZuWx1vKqnoNv6/tvEK48AQOBRai40CX9dTjGluvT/YZCyY3rryDtyUqCEoyNroy5KKPwX2iQCiRvyw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -948,13 +948,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-logical-assignment-operators": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.6.tgz",
-            "integrity": "sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.29.7.tgz",
+            "integrity": "sha512-A0H91hh6W8MFRkp5TqJmMr39jzGD1A1E1Ysiv2O06Sfbhkapm+XyIzxWCEh5kqwOZ1/8QZ0dY3SeQ7XBqfJd5Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -964,13 +964,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-member-expression-literals": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz",
-            "integrity": "sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.29.7.tgz",
+            "integrity": "sha512-hl1kwFZCCiDyfH25Xmco9jTrkPgnS9pmOzSG7W5I4SaGbLeqKv417hcU2RKmaxoPEgsoJh7ZPOrnPGq99bHoUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -980,14 +980,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-amd": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz",
-            "integrity": "sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.29.7.tgz",
+            "integrity": "sha512-fxtQoH3m5ywUSIfaH0FGCzWu4McsYon5bD3K4XnskC7f+OyQMj7rsOMi4NvvmJ83WwBAg4UCe+ov4VZlqEvyew==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -997,14 +997,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-commonjs": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
-            "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
+            "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.28.6",
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1014,16 +1014,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-systemjs": {
-            "version": "7.29.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
-            "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
+            "integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.28.6",
-                "@babel/helper-plugin-utils": "^7.28.6",
-                "@babel/helper-validator-identifier": "^7.28.5",
-                "@babel/traverse": "^7.29.0"
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1033,14 +1033,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-umd": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz",
-            "integrity": "sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.29.7.tgz",
+            "integrity": "sha512-B4UkaTK3QpgCwJnrxKfMPKdo92CN7OKXAlpAAnM3UPu0Q0lCCk57ylA9AJbRy2v8dDKOPAAWcoR6CMyeoHwRCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1050,14 +1050,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.0.tgz",
-            "integrity": "sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.7.tgz",
+            "integrity": "sha512-vuFoLwr4qnv2xbZ16SQd6uPcH5FNrLHhk/Jzo++0XJFcaDsr4gjJVg6j398oMHiC+83k/GiBzviwF5KBJkPUtQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1067,13 +1067,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-new-target": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz",
-            "integrity": "sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.29.7.tgz",
+            "integrity": "sha512-fEo41GmsOUhOBlw8ioo6zvjX5Xc2Lqkzlyfqbpsk3eB6TReV18uhxZ0esfEokVbY2+PVJAQHNKxER6lGrzNd3A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1083,13 +1083,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.28.6.tgz",
-            "integrity": "sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.29.7.tgz",
+            "integrity": "sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1099,13 +1099,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-numeric-separator": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.28.6.tgz",
-            "integrity": "sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.29.7.tgz",
+            "integrity": "sha512-zR7fv/z14OjgHl4AgRtkDBvBMhIzCxqV/qN/2BCRC7LjFwvuzjYe7gDWxC4Wl/SNsLM6SE1IWvRPYMgSJaUvNw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1115,17 +1115,17 @@
             }
         },
         "node_modules/@babel/plugin-transform-object-rest-spread": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.6.tgz",
-            "integrity": "sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.29.7.tgz",
+            "integrity": "sha512-Ld98jn4c0smUywL57m7SgsHq3OpThOa6LqZJif3G6jYOovPleoFhVrBJ1WegRApSFB2wu4+RelAj9AC9G08Z4A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-compilation-targets": "^7.28.6",
-                "@babel/helper-plugin-utils": "^7.28.6",
-                "@babel/plugin-transform-destructuring": "^7.28.5",
-                "@babel/plugin-transform-parameters": "^7.27.7",
-                "@babel/traverse": "^7.28.6"
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/plugin-transform-destructuring": "^7.29.7",
+                "@babel/plugin-transform-parameters": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1135,14 +1135,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-object-super": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz",
-            "integrity": "sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.29.7.tgz",
+            "integrity": "sha512-Ea/diGcw0twB5IlZPO5sgET6fJsLJqPABqTuFWIR+iMPGPZJkATEIWx0wa+aEQ5UY1CBQyP/gkAiLEqn1vBiQA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-replace-supers": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-replace-supers": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1152,13 +1152,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-optional-catch-binding": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz",
-            "integrity": "sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.29.7.tgz",
+            "integrity": "sha512-sLsyndxK2VwX6yNUOakMb7Sh553ZTe/vVM1XJ+9Z5aW1ytsc8xOIwmyk05NNjN60vkc5/KqoTH6hB4V41LJhng==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1168,14 +1168,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-optional-chaining": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.6.tgz",
-            "integrity": "sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.29.7.tgz",
+            "integrity": "sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.28.6",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1185,13 +1185,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-parameters": {
-            "version": "7.27.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
-            "integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.29.7.tgz",
+            "integrity": "sha512-ZDOBqV/qLYJI0YElr8DcENEyARsFQeESqWXH6gZlghYXuPPjvweuDhP4VyEi4BlUBlLRFZVjxoZDMjxhLW766g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1201,14 +1201,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-private-methods": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz",
-            "integrity": "sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.29.7.tgz",
+            "integrity": "sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.28.6",
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-create-class-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1218,15 +1218,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-private-property-in-object": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.28.6.tgz",
-            "integrity": "sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.29.7.tgz",
+            "integrity": "sha512-+BNo06dnrzdNNqCm1X6YUaVv0DKk8Q+JYcoZfOkLhYWNCXzlwTSRq8zGWayT1csjcpNXV9CQTBRRbmTLZac5cA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.3",
-                "@babel/helper-create-class-features-plugin": "^7.28.6",
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-create-class-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1236,13 +1236,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-property-literals": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz",
-            "integrity": "sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.29.7.tgz",
+            "integrity": "sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1252,13 +1252,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-regenerator": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.0.tgz",
-            "integrity": "sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.7.tgz",
+            "integrity": "sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1268,14 +1268,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-regexp-modifiers": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.28.6.tgz",
-            "integrity": "sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.29.7.tgz",
+            "integrity": "sha512-mB5Fs0VWrJ42ZCmc8114v60qetdaUVNkj9PmSZRmanCZM3S9hm0CFRLjRmYIsuXav14l2jvZ+4T8iiCGnhj3nQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1285,13 +1285,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-reserved-words": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz",
-            "integrity": "sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.29.7.tgz",
+            "integrity": "sha512-5+YhdpVgmfSmwZyLMftfaiffLRMHjzIRHFHHLdibcSyJm2pasMrKHrO3Ptrt2DRshjvpgjEJJ1zVW14WPq/6QA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1322,13 +1322,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-shorthand-properties": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
-            "integrity": "sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.29.7.tgz",
+            "integrity": "sha512-I+WYbGBAiCn7nA6xBrlgPH+MB7HWb4u8pv5S0Pv7OtwNvIFvCCb24YlttKEeUFVurfBCEaOTnuhlqsb7f0Z5Dg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1338,14 +1338,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-spread": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.28.6.tgz",
-            "integrity": "sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.29.7.tgz",
+            "integrity": "sha512-/u5K1QWada7tbYNqTjMh96718g9NTwh9tfPJMsSmVsQwGT447FskV+KcfeXkXq2GWki4EM/MuTdmBec+hOuVTQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.28.6",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1355,13 +1355,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-sticky-regex": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
-            "integrity": "sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.29.7.tgz",
+            "integrity": "sha512-BCHzNYJGe9l7EpwwDBN/ztlL2NYFFq8hp9ddjtUEM9f2O7S7kKV/lL6Fwo7IF7NSkYhPK2vO+86nIGltA90MsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1371,13 +1371,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-template-literals": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
-            "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.29.7.tgz",
+            "integrity": "sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1387,13 +1387,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-typeof-symbol": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz",
-            "integrity": "sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.29.7.tgz",
+            "integrity": "sha512-223mNGoTkBiTEWFoK+Q6Go3tueMRclO8vxxxxquNCYuNI4jWOofFKJRRDu6SDrB8Sgo1UEGW9T4GAQ8ZyRso1A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1403,13 +1403,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-escapes": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
-            "integrity": "sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.29.7.tgz",
+            "integrity": "sha512-jCfXxSjf94lf4E0hKE0AByxF6F3/pVFqRdUUNkDJhsY0m1ZKjnN6ZYyMeHNpzflxb/0q5b7t3p+BE+SLF1WOtA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1419,14 +1419,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-property-regex": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.28.6.tgz",
-            "integrity": "sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.29.7.tgz",
+            "integrity": "sha512-OgZ+zoAJgZLUCunsTRQ5LAjOywDv5zzZ2/hQ5aMw1pGXyY2rtE8/chXYUmu3AlVHKpm10KEdG9aMwbI/K76ZGw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1436,14 +1436,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-regex": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
-            "integrity": "sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.29.7.tgz",
+            "integrity": "sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1453,14 +1453,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-sets-regex": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.28.6.tgz",
-            "integrity": "sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.29.7.tgz",
+            "integrity": "sha512-BLOhLht9DOJwIxlmp91wHvkXv1lguuHS3/FwUO8HL1H0u8s4hR1gASVFyilu9iGtcTRYqjTZmlsFFeQletntEg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-                "@babel/helper-plugin-utils": "^7.28.6"
+                "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1593,33 +1593,33 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-            "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.28.6",
-                "@babel/parser": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-            "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+            "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-globals": "^7.28.0",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.29.0",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "debug": "^4.3.1"
             },
             "engines": {
@@ -1627,13 +1627,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1647,13 +1647,13 @@
             "license": "MIT"
         },
         "node_modules/@cacheable/memory": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz",
-            "integrity": "sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.2.0.tgz",
+            "integrity": "sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@cacheable/utils": "^2.4.0",
+                "@cacheable/utils": "^2.5.0",
                 "@keyv/bigmap": "^1.3.1",
                 "hookified": "^1.15.1",
                 "keyv": "^5.6.0"
@@ -1687,9 +1687,9 @@
             }
         },
         "node_modules/@cacheable/utils": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.1.tgz",
-            "integrity": "sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
+            "integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1803,9 +1803,9 @@
             }
         },
         "node_modules/@csstools/css-syntax-patches-for-csstree": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
-            "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+            "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
             "dev": true,
             "funding": [
                 {
@@ -2425,9 +2425,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2475,9 +2475,9 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "3.3.5",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-            "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+            "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2487,7 +2487,7 @@
                 "globals": "^14.0.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
-                "js-yaml": "^4.1.1",
+                "js-yaml": "^4.3.0",
                 "minimatch": "^3.1.5",
                 "strip-json-comments": "^3.1.1"
             },
@@ -2506,9 +2506,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2874,14 +2874,14 @@
             }
         },
         "node_modules/@jsonjoy.com/fs-core": {
-            "version": "4.57.2",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.57.2.tgz",
-            "integrity": "sha512-SVjwklkpIV5wrynpYtuYnfYH1QF4/nDuLBX7VXdb+3miglcAgBVZb/5y0cOsehRV/9Vb+3UqhkMq3/NR3ztdkQ==",
+            "version": "4.64.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.64.0.tgz",
+            "integrity": "sha512-zs2TAq7Six5jgMuoMNjpspAvOP3mhtgq/k1UyQodEzCtQi/N83y2/y+zcvnZSGp/Rxq96DBN+bValOBQAyn/ew==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@jsonjoy.com/fs-node-builtins": "4.57.2",
-                "@jsonjoy.com/fs-node-utils": "4.57.2",
+                "@jsonjoy.com/fs-node-builtins": "4.64.0",
+                "@jsonjoy.com/fs-node-utils": "4.64.0",
                 "thingies": "^2.5.0"
             },
             "engines": {
@@ -2896,15 +2896,15 @@
             }
         },
         "node_modules/@jsonjoy.com/fs-fsa": {
-            "version": "4.57.2",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.57.2.tgz",
-            "integrity": "sha512-fhO8+iR2I+OCw668ISDJdn1aArc9zx033sWejIyzQ8RBeXa9bDSaUeA3ix0poYOfrj1KdOzytmYNv2/uLDfV6g==",
+            "version": "4.64.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.64.0.tgz",
+            "integrity": "sha512-nMWOVbkLFyEgmXZih3wyvxA9XpgyyqyfrINMHvEFqhi7uqfRl7c9ERJt6yX7vgMPrB9Uo+OJO+Spa0cFzPD01w==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@jsonjoy.com/fs-core": "4.57.2",
-                "@jsonjoy.com/fs-node-builtins": "4.57.2",
-                "@jsonjoy.com/fs-node-utils": "4.57.2",
+                "@jsonjoy.com/fs-core": "4.64.0",
+                "@jsonjoy.com/fs-node-builtins": "4.64.0",
+                "@jsonjoy.com/fs-node-utils": "4.64.0",
                 "thingies": "^2.5.0"
             },
             "engines": {
@@ -2919,17 +2919,17 @@
             }
         },
         "node_modules/@jsonjoy.com/fs-node": {
-            "version": "4.57.2",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.57.2.tgz",
-            "integrity": "sha512-nX2AdL6cOFwLdju9G4/nbRnYevmCJbh7N7hvR3gGm97Cs60uEjyd0rpR+YBS7cTg175zzl22pGKXR5USaQMvKg==",
+            "version": "4.64.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.64.0.tgz",
+            "integrity": "sha512-dO+NNkODbUli4uV42bcNrrLvq5rE7SNpdZ5TNd0dtbLsAaNK3MDiIC9lUi+brboGoIjW6vd2fB1qao60nrk5xA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@jsonjoy.com/fs-core": "4.57.2",
-                "@jsonjoy.com/fs-node-builtins": "4.57.2",
-                "@jsonjoy.com/fs-node-utils": "4.57.2",
-                "@jsonjoy.com/fs-print": "4.57.2",
-                "@jsonjoy.com/fs-snapshot": "4.57.2",
+                "@jsonjoy.com/fs-core": "4.64.0",
+                "@jsonjoy.com/fs-node-builtins": "4.64.0",
+                "@jsonjoy.com/fs-node-utils": "4.64.0",
+                "@jsonjoy.com/fs-print": "4.64.0",
+                "@jsonjoy.com/fs-snapshot": "4.64.0",
                 "glob-to-regex.js": "^1.0.0",
                 "thingies": "^2.5.0"
             },
@@ -2945,9 +2945,9 @@
             }
         },
         "node_modules/@jsonjoy.com/fs-node-builtins": {
-            "version": "4.57.2",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.57.2.tgz",
-            "integrity": "sha512-xhiegylRmhw43Ki2HO1ZBL7DQ5ja/qpRsL29VtQ2xuUHiuDGbgf2uD4p9Qd8hJI5P6RCtGYD50IXHXVq/Ocjcg==",
+            "version": "4.64.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.64.0.tgz",
+            "integrity": "sha512-/o7WRFhUWaM/fOrslwLZGnzn4RmRILykn+lAL+mNObqqRNw+CQSiij6hpCeZ+C7buhdoVo7go/OYqzaSUfDYmA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -2962,15 +2962,15 @@
             }
         },
         "node_modules/@jsonjoy.com/fs-node-to-fsa": {
-            "version": "4.57.2",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.57.2.tgz",
-            "integrity": "sha512-18LmWTSONhoAPW+IWRuf8w/+zRolPFGPeGwMxlAhhfY11EKzX+5XHDBPAw67dBF5dxDErHJbl40U+3IXSDRXSQ==",
+            "version": "4.64.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.64.0.tgz",
+            "integrity": "sha512-WDD9WVs0hb7UAEKTgZW2f66WDrbj7gIIWwpP3spbLyXa0rghtUaFTB8L4gdR3ZCWwiKIsj38/CNijpVmpnuPUw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@jsonjoy.com/fs-fsa": "4.57.2",
-                "@jsonjoy.com/fs-node-builtins": "4.57.2",
-                "@jsonjoy.com/fs-node-utils": "4.57.2"
+                "@jsonjoy.com/fs-fsa": "4.64.0",
+                "@jsonjoy.com/fs-node-builtins": "4.64.0",
+                "@jsonjoy.com/fs-node-utils": "4.64.0"
             },
             "engines": {
                 "node": ">=10.0"
@@ -2984,13 +2984,14 @@
             }
         },
         "node_modules/@jsonjoy.com/fs-node-utils": {
-            "version": "4.57.2",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.57.2.tgz",
-            "integrity": "sha512-rsPSJgekz43IlNbLyAM/Ab+ouYLWGp5DDBfYBNNEqDaSpsbXfthBn29Q4muFA9L0F+Z3mKo+CWlgSCXrf+mOyQ==",
+            "version": "4.64.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.64.0.tgz",
+            "integrity": "sha512-k5Indsx9hWW9xSF7Y6oSKKwtCUNhzZxadub3owhIlitc+iMRVlPPdX2duTKQWBL3qNWpXya8jykgaaWpheeS4w==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@jsonjoy.com/fs-node-builtins": "4.57.2"
+                "@jsonjoy.com/fs-node-builtins": "4.64.0",
+                "glob-to-regex.js": "^1.0.1"
             },
             "engines": {
                 "node": ">=10.0"
@@ -3004,13 +3005,13 @@
             }
         },
         "node_modules/@jsonjoy.com/fs-print": {
-            "version": "4.57.2",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.57.2.tgz",
-            "integrity": "sha512-wK9NSow48i4DbDl9F1CQE5TqnyZOJ04elU3WFG5aJ76p+YxO/ulyBBQvKsessPxdo381Bc2pcEoyPujMOhcRqQ==",
+            "version": "4.64.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.64.0.tgz",
+            "integrity": "sha512-PHZFccchvkhWrwPWHjmVAhbC3vSHCtyZvlZfJJ3ho2bnzl450hXri6/8e6pbkWdH+SkmLXNml0sV8e5HDAfxKw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@jsonjoy.com/fs-node-utils": "4.57.2",
+                "@jsonjoy.com/fs-node-utils": "4.64.0",
                 "tree-dump": "^1.1.0"
             },
             "engines": {
@@ -3025,14 +3026,14 @@
             }
         },
         "node_modules/@jsonjoy.com/fs-snapshot": {
-            "version": "4.57.2",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.57.2.tgz",
-            "integrity": "sha512-GdduDZuoP5V/QCgJkx9+BZ6SC0EZ/smXAdTS7PfMqgMTGXLlt/bH/FqMYaqB9JmLf05sJPtO0XRbAwwkEEPbVw==",
+            "version": "4.64.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.64.0.tgz",
+            "integrity": "sha512-oM7UDeL83q6NBzzsfKAsYKXKVXlykKFqqOLh4xZZKAzzROTlInkPbc6LTDGThEOnPiFiUzA7tYziHG9xavd76Q==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@jsonjoy.com/buffers": "^17.65.0",
-                "@jsonjoy.com/fs-node-utils": "4.57.2",
+                "@jsonjoy.com/fs-node-utils": "4.64.0",
                 "@jsonjoy.com/json-pack": "^17.65.0",
                 "@jsonjoy.com/util": "^17.65.0"
             },
@@ -3374,11 +3375,12 @@
             }
         },
         "node_modules/@mapbox/jsonlint-lines-primitives": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
-            "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz",
+            "integrity": "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==",
+            "license": "MIT",
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 22"
             }
         },
         "node_modules/@mapbox/mapbox-gl-draw": {
@@ -3601,138 +3603,138 @@
             "license": "MIT"
         },
         "node_modules/@peculiar/asn1-cms": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.7.0.tgz",
-            "integrity": "sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
+            "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.7.0",
-                "@peculiar/asn1-x509": "^2.7.0",
-                "@peculiar/asn1-x509-attr": "^2.7.0",
-                "asn1js": "^3.0.6",
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "@peculiar/asn1-x509-attr": "^2.8.0",
+                "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
             }
         },
         "node_modules/@peculiar/asn1-csr": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.7.0.tgz",
-            "integrity": "sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
+            "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.7.0",
-                "@peculiar/asn1-x509": "^2.7.0",
-                "asn1js": "^3.0.6",
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
             }
         },
         "node_modules/@peculiar/asn1-ecc": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.7.0.tgz",
-            "integrity": "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
+            "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.7.0",
-                "@peculiar/asn1-x509": "^2.7.0",
-                "asn1js": "^3.0.6",
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
             }
         },
         "node_modules/@peculiar/asn1-pfx": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.7.0.tgz",
-            "integrity": "sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
+            "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-cms": "^2.7.0",
-                "@peculiar/asn1-pkcs8": "^2.7.0",
-                "@peculiar/asn1-rsa": "^2.7.0",
-                "@peculiar/asn1-schema": "^2.7.0",
-                "asn1js": "^3.0.6",
+                "@peculiar/asn1-cms": "^2.8.0",
+                "@peculiar/asn1-pkcs8": "^2.8.0",
+                "@peculiar/asn1-rsa": "^2.8.0",
+                "@peculiar/asn1-schema": "^2.8.0",
+                "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
             }
         },
         "node_modules/@peculiar/asn1-pkcs8": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.7.0.tgz",
-            "integrity": "sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
+            "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.7.0",
-                "@peculiar/asn1-x509": "^2.7.0",
-                "asn1js": "^3.0.6",
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
             }
         },
         "node_modules/@peculiar/asn1-pkcs9": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.7.0.tgz",
-            "integrity": "sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
+            "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-cms": "^2.7.0",
-                "@peculiar/asn1-pfx": "^2.7.0",
-                "@peculiar/asn1-pkcs8": "^2.7.0",
-                "@peculiar/asn1-schema": "^2.7.0",
-                "@peculiar/asn1-x509": "^2.7.0",
-                "@peculiar/asn1-x509-attr": "^2.7.0",
-                "asn1js": "^3.0.6",
+                "@peculiar/asn1-cms": "^2.8.0",
+                "@peculiar/asn1-pfx": "^2.8.0",
+                "@peculiar/asn1-pkcs8": "^2.8.0",
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "@peculiar/asn1-x509-attr": "^2.8.0",
+                "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
             }
         },
         "node_modules/@peculiar/asn1-rsa": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.7.0.tgz",
-            "integrity": "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
+            "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.7.0",
-                "@peculiar/asn1-x509": "^2.7.0",
-                "asn1js": "^3.0.6",
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
             }
         },
         "node_modules/@peculiar/asn1-schema": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
-            "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+            "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@peculiar/utils": "^2.0.2",
-                "asn1js": "^3.0.6",
+                "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
             }
         },
         "node_modules/@peculiar/asn1-x509": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.7.0.tgz",
-            "integrity": "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+            "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.7.0",
+                "@peculiar/asn1-schema": "^2.8.0",
                 "@peculiar/utils": "^2.0.2",
-                "asn1js": "^3.0.6",
+                "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
             }
         },
         "node_modules/@peculiar/asn1-x509-attr": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.7.0.tgz",
-            "integrity": "sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
+            "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.7.0",
-                "@peculiar/asn1-x509": "^2.7.0",
-                "asn1js": "^3.0.6",
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
             }
         },
@@ -3874,9 +3876,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
-            "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+            "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
             "cpu": [
                 "arm"
             ],
@@ -3888,9 +3890,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
-            "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+            "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
             "cpu": [
                 "arm64"
             ],
@@ -3902,9 +3904,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
-            "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+            "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
             "cpu": [
                 "arm64"
             ],
@@ -3916,9 +3918,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
-            "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+            "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
             "cpu": [
                 "x64"
             ],
@@ -3930,9 +3932,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
-            "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+            "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
             "cpu": [
                 "arm64"
             ],
@@ -3944,9 +3946,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
-            "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+            "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
             "cpu": [
                 "x64"
             ],
@@ -3958,9 +3960,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
-            "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+            "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
             "cpu": [
                 "arm"
             ],
@@ -3972,9 +3974,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
-            "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+            "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
             "cpu": [
                 "arm"
             ],
@@ -3986,9 +3988,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
-            "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+            "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
             "cpu": [
                 "arm64"
             ],
@@ -4000,9 +4002,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
-            "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+            "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
             "cpu": [
                 "arm64"
             ],
@@ -4014,9 +4016,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
-            "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+            "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
             "cpu": [
                 "loong64"
             ],
@@ -4028,9 +4030,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
-            "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+            "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
             "cpu": [
                 "loong64"
             ],
@@ -4042,9 +4044,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
-            "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+            "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
             "cpu": [
                 "ppc64"
             ],
@@ -4056,9 +4058,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
-            "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+            "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
             "cpu": [
                 "ppc64"
             ],
@@ -4070,9 +4072,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
-            "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+            "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
             "cpu": [
                 "riscv64"
             ],
@@ -4084,9 +4086,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
-            "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+            "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
             "cpu": [
                 "riscv64"
             ],
@@ -4098,9 +4100,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
-            "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+            "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
             "cpu": [
                 "s390x"
             ],
@@ -4112,9 +4114,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
-            "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+            "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
             "cpu": [
                 "x64"
             ],
@@ -4126,9 +4128,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
-            "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+            "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
             "cpu": [
                 "x64"
             ],
@@ -4140,9 +4142,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
-            "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+            "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
             "cpu": [
                 "x64"
             ],
@@ -4154,9 +4156,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
-            "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+            "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
             "cpu": [
                 "arm64"
             ],
@@ -4168,9 +4170,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
-            "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+            "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
             "cpu": [
                 "arm64"
             ],
@@ -4182,9 +4184,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
-            "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+            "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
             "cpu": [
                 "ia32"
             ],
@@ -4196,9 +4198,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
-            "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+            "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
             "cpu": [
                 "x64"
             ],
@@ -4210,9 +4212,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
-            "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+            "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
             "cpu": [
                 "x64"
             ],
@@ -4224,9 +4226,9 @@
             ]
         },
         "node_modules/@sinclair/typebox": {
-            "version": "0.27.10",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-            "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+            "version": "0.27.12",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+            "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
             "dev": true,
             "license": "MIT"
         },
@@ -6028,9 +6030,9 @@
             }
         },
         "node_modules/@types/express-serve-static-core": {
-            "version": "4.19.8",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
-            "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+            "version": "4.19.9",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz",
+            "integrity": "sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6175,12 +6177,12 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.8.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
-            "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
+            "version": "26.1.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+            "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
             "license": "MIT",
             "dependencies": {
-                "undici-types": ">=7.24.0 <7.24.7"
+                "undici-types": "~8.3.0"
             }
         },
         "node_modules/@types/normalize-package-data": {
@@ -6363,9 +6365,9 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6522,9 +6524,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -6774,55 +6776,55 @@
             }
         },
         "node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.40.tgz",
+            "integrity": "sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
+                "@babel/parser": "^7.29.7",
+                "@vue/shared": "3.5.40",
                 "entities": "^7.0.1",
                 "estree-walker": "^2.0.2",
                 "source-map-js": "^1.2.1"
             }
         },
         "node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.40.tgz",
+            "integrity": "sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
+                "@vue/compiler-core": "3.5.40",
+                "@vue/shared": "3.5.40"
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.40.tgz",
+            "integrity": "sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
+                "@babel/parser": "^7.29.7",
+                "@vue/compiler-core": "3.5.40",
+                "@vue/compiler-dom": "3.5.40",
+                "@vue/compiler-ssr": "3.5.40",
+                "@vue/shared": "3.5.40",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
+                "postcss": "^8.5.19",
                 "source-map-js": "^1.2.1"
             }
         },
         "node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.40.tgz",
+            "integrity": "sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
+                "@vue/compiler-dom": "3.5.40",
+                "@vue/shared": "3.5.40"
             }
         },
         "node_modules/@vue/compiler-vue2": {
@@ -6837,21 +6839,21 @@
             }
         },
         "node_modules/@vue/devtools-api": {
-            "version": "7.7.9",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
-            "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+            "version": "7.7.10",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.10.tgz",
+            "integrity": "sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==",
             "license": "MIT",
             "dependencies": {
-                "@vue/devtools-kit": "^7.7.9"
+                "@vue/devtools-kit": "^7.7.10"
             }
         },
         "node_modules/@vue/devtools-kit": {
-            "version": "7.7.9",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
-            "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+            "version": "7.7.10",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.10.tgz",
+            "integrity": "sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==",
             "license": "MIT",
             "dependencies": {
-                "@vue/devtools-shared": "^7.7.9",
+                "@vue/devtools-shared": "^7.7.10",
                 "birpc": "^2.3.0",
                 "hookable": "^5.5.3",
                 "mitt": "^3.0.1",
@@ -6861,9 +6863,9 @@
             }
         },
         "node_modules/@vue/devtools-shared": {
-            "version": "7.7.9",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
-            "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+            "version": "7.7.10",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.10.tgz",
+            "integrity": "sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==",
             "license": "MIT",
             "dependencies": {
                 "rfdc": "^1.4.1"
@@ -6902,9 +6904,9 @@
             "license": "MIT"
         },
         "node_modules/@vue/language-core/node_modules/brace-expansion": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6928,57 +6930,55 @@
             }
         },
         "node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.40.tgz",
+            "integrity": "sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@vue/shared": "3.5.34"
+                "@vue/shared": "3.5.40"
             }
         },
         "node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.40.tgz",
+            "integrity": "sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
+                "@vue/reactivity": "3.5.40",
+                "@vue/shared": "3.5.40"
             }
         },
         "node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.40.tgz",
+            "integrity": "sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
+                "@vue/reactivity": "3.5.40",
+                "@vue/runtime-core": "3.5.40",
+                "@vue/shared": "3.5.40",
                 "csstype": "^3.2.3"
             }
         },
         "node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.40.tgz",
+            "integrity": "sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
+                "@vue/compiler-ssr": "3.5.40",
+                "@vue/runtime-dom": "3.5.40",
+                "@vue/shared": "3.5.40"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.40.tgz",
+            "integrity": "sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==",
             "license": "MIT"
         },
         "node_modules/@vue/test-utils": {
@@ -7249,9 +7249,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-            "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -7435,7 +7435,7 @@
         },
         "node_modules/arches": {
             "version": "8.1.3",
-            "resolved": "git+ssh://git@github.com/archesproject/arches.git#da8f3b3d2ac315bc255b6fddc82c06c041dd8da1",
+            "resolved": "git+ssh://git@github.com/archesproject/arches.git#fb23bd6ea6142753b999ca66886e2e1772b8c4be",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@babel/runtime": "7.28.3",
@@ -7503,8 +7503,8 @@
             }
         },
         "node_modules/arches-dev-dependencies": {
-            "version": "8.1.2",
-            "resolved": "git+ssh://git@github.com/archesproject/arches-dev-dependencies.git#cf850a50dcfdfba1dfb73f26863b2f6ba11cabdd",
+            "version": "8.1.3",
+            "resolved": "git+ssh://git@github.com/archesproject/arches-dev-dependencies.git#7420e451511f199b491c3d8dc0e23b132ff3750c",
             "dev": true,
             "dependencies": {
                 "@babel/core": "7.29.0",
@@ -7561,9 +7561,9 @@
             }
         },
         "node_modules/arches-dev-dependencies/node_modules/nanoid": {
-            "version": "3.3.12",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "dev": true,
             "funding": [
                 {
@@ -7610,7 +7610,7 @@
         },
         "node_modules/arches-vue-components": {
             "name": "arches_vue_components",
-            "resolved": "git+ssh://git@github.com/archesproject/arches-vue-components.git#633a11adea94496b2f99707ca9ed9adf5634b0a4",
+            "resolved": "git+ssh://git@github.com/archesproject/arches-vue-components.git#c62e8a8eee8b6d2cd16462782fe9bc0cc948af59",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@mapbox/geojson-extent": "^1.0.1",
@@ -8073,9 +8073,9 @@
             "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.29",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
-            "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+            "version": "2.10.43",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+            "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -8115,9 +8115,9 @@
             }
         },
         "node_modules/body-parser": {
-            "version": "1.20.5",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-            "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+            "version": "1.20.6",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+            "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8170,9 +8170,9 @@
             "license": "MIT"
         },
         "node_modules/bonjour-service": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.3.0.tgz",
-            "integrity": "sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.3.tgz",
+            "integrity": "sha512-2Kd5UYlFUVgAKMTyuBLl6w49wqfOnbxHqmuH0oCl/n7TfAikR0zoowNOP5BU4dfXmm+Vr9JyEN370auSMx+CNg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8208,9 +8208,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8234,9 +8234,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+            "version": "4.28.6",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+            "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
             "dev": true,
             "funding": [
                 {
@@ -8254,10 +8254,10 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.10.12",
-                "caniuse-lite": "^1.0.30001782",
-                "electron-to-chromium": "^1.5.328",
-                "node-releases": "^2.0.36",
+                "baseline-browser-mapping": "^2.10.42",
+                "caniuse-lite": "^1.0.30001803",
+                "electron-to-chromium": "^1.5.389",
+                "node-releases": "^2.0.51",
                 "update-browserslist-db": "^1.2.3"
             },
             "bin": {
@@ -8326,14 +8326,14 @@
             }
         },
         "node_modules/cacheable": {
-            "version": "2.3.5",
-            "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.5.tgz",
-            "integrity": "sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.5.0.tgz",
+            "integrity": "sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@cacheable/memory": "^2.0.8",
-                "@cacheable/utils": "^2.4.1",
+                "@cacheable/memory": "^2.2.0",
+                "@cacheable/utils": "^2.5.0",
                 "hookified": "^1.15.0",
                 "keyv": "^5.6.0",
                 "qified": "^0.10.1"
@@ -8468,9 +8468,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001792",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-            "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+            "version": "1.0.30001806",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+            "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
             "dev": true,
             "funding": [
                 {
@@ -9009,9 +9009,9 @@
             "license": "MIT"
         },
         "node_modules/cosmiconfig": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
-            "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+            "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
             "license": "MIT",
             "dependencies": {
                 "env-paths": "^2.2.1",
@@ -9122,9 +9122,9 @@
             }
         },
         "node_modules/css-loader/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -9803,9 +9803,9 @@
             }
         },
         "node_modules/dayjs": {
-            "version": "1.11.20",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
-            "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+            "version": "1.11.21",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+            "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
             "license": "MIT"
         },
         "node_modules/de-indent": {
@@ -10140,9 +10140,9 @@
             "integrity": "sha512-JkCVGnN4ofKGbjf5Uvc8mmxaATIErKQKSgACdBXpsQ3fY6DlIpAyWfiBSrGkttATssbDCp3psiAKWXk5gmjycA=="
         },
         "node_modules/dompurify": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.3.tgz",
-            "integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
+            "version": "3.4.12",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+            "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
@@ -10207,9 +10207,9 @@
             "license": "MIT"
         },
         "node_modules/editorconfig/node_modules/brace-expansion": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10243,9 +10243,9 @@
             }
         },
         "node_modules/editorconfig/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -10263,9 +10263,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.355",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.355.tgz",
-            "integrity": "sha512-LUPZhKzZPYSPme1jEYohpkA+ybYCJztr1quAdBd7E7h3+VOBVcKkwwtBJu41nrjawrRzfb8mtMfzWozoaK0ZIQ==",
+            "version": "1.5.393",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+            "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
             "dev": true,
             "license": "ISC"
         },
@@ -10295,9 +10295,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.21.3",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.3.tgz",
-            "integrity": "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==",
+            "version": "5.24.2",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
+            "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10437,6 +10437,24 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/es-abstract-get": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+            "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.2",
+                "is-callable": "^1.2.7",
+                "object-inspect": "^1.13.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/es-define-property": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -10456,16 +10474,16 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-            "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -10490,14 +10508,17 @@
             }
         },
         "node_modules/es-to-primitive": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
-            "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+            "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
             "license": "MIT",
             "dependencies": {
+                "es-abstract-get": "^1.0.0",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
                 "is-callable": "^1.2.7",
-                "is-date-object": "^1.0.5",
-                "is-symbol": "^1.0.4"
+                "is-date-object": "^1.1.0",
+                "is-symbol": "^1.1.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -10507,9 +10528,9 @@
             }
         },
         "node_modules/es-toolkit": {
-            "version": "1.46.1",
-            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
-            "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+            "version": "1.49.0",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
+            "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
             "license": "MIT",
             "workspaces": [
                 "docs",
@@ -10702,9 +10723,9 @@
             }
         },
         "node_modules/eslint-plugin-vue/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -10759,9 +10780,9 @@
             "license": "MIT"
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11139,9 +11160,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+            "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
             "dev": true,
             "funding": [
                 {
@@ -11389,15 +11410,15 @@
             }
         },
         "node_modules/form-data": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
-            "integrity": "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.5.tgz",
+            "integrity": "sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
+                "hasown": "^2.0.4",
                 "mime-types": "^2.1.35"
             },
             "engines": {
@@ -11455,17 +11476,20 @@
             }
         },
         "node_modules/function.prototype.name": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
-            "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+            "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.3",
-                "define-properties": "^1.2.1",
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
                 "functions-have-names": "^1.2.3",
-                "hasown": "^2.0.2",
-                "is-callable": "^1.2.7"
+                "has-property-descriptors": "^1.0.2",
+                "hasown": "^2.0.4",
+                "is-callable": "^1.2.7",
+                "is-document.all": "^1.0.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -11738,9 +11762,9 @@
             "license": "MIT"
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -12072,9 +12096,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -12262,9 +12286,9 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-            "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+            "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12416,9 +12440,9 @@
             "license": "ISC"
         },
         "node_modules/immutable": {
-            "version": "4.3.8",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
-            "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+            "version": "4.3.9",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+            "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -12818,6 +12842,21 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-document.all": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+            "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-extglob": {
@@ -13432,9 +13471,9 @@
             "license": "MIT"
         },
         "node_modules/js-beautify/node_modules/brace-expansion": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13495,9 +13534,19 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -13548,17 +13597,17 @@
             }
         },
         "node_modules/jsdom/node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -13656,9 +13705,9 @@
             }
         },
         "node_modules/kdbush": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
-            "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz",
+            "integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
             "license": "ISC"
         },
         "node_modules/keyv": {
@@ -13719,14 +13768,14 @@
             "license": "MIT"
         },
         "node_modules/launch-editor": {
-            "version": "2.13.2",
-            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.13.2.tgz",
-            "integrity": "sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==",
+            "version": "2.14.1",
+            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+            "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "picocolors": "^1.1.1",
-                "shell-quote": "^1.8.3"
+                "shell-quote": "^1.8.4"
             }
         },
         "node_modules/leaflet": {
@@ -13975,9 +14024,9 @@
             }
         },
         "node_modules/make-dir/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -14098,9 +14147,9 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/maplibre-gl/node_modules/earcut": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
-            "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
+            "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
             "license": "ISC"
         },
         "node_modules/maplibre-gl/node_modules/geojson-vt": {
@@ -14168,20 +14217,20 @@
             }
         },
         "node_modules/memfs": {
-            "version": "4.57.2",
-            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.2.tgz",
-            "integrity": "sha512-2nWzSsJzrukurSDna4Z0WywuScK4Id3tSKejgu74u8KCdW4uNrseKRSIDg75C6Yw5ZRqBe0F0EtMNlTbUq8bAQ==",
+            "version": "4.64.0",
+            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.64.0.tgz",
+            "integrity": "sha512-Kw72fgY7Wn+sD8KmtNWSafl1dz0UvAsE/PHs3YVfLiaZuA3HxNm9sRLqAu0ATiBGJvME1PxZXbBZPv5GycDeAw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@jsonjoy.com/fs-core": "4.57.2",
-                "@jsonjoy.com/fs-fsa": "4.57.2",
-                "@jsonjoy.com/fs-node": "4.57.2",
-                "@jsonjoy.com/fs-node-builtins": "4.57.2",
-                "@jsonjoy.com/fs-node-to-fsa": "4.57.2",
-                "@jsonjoy.com/fs-node-utils": "4.57.2",
-                "@jsonjoy.com/fs-print": "4.57.2",
-                "@jsonjoy.com/fs-snapshot": "4.57.2",
+                "@jsonjoy.com/fs-core": "4.64.0",
+                "@jsonjoy.com/fs-fsa": "4.64.0",
+                "@jsonjoy.com/fs-node": "4.64.0",
+                "@jsonjoy.com/fs-node-builtins": "4.64.0",
+                "@jsonjoy.com/fs-node-to-fsa": "4.64.0",
+                "@jsonjoy.com/fs-node-utils": "4.64.0",
+                "@jsonjoy.com/fs-print": "4.64.0",
+                "@jsonjoy.com/fs-snapshot": "4.64.0",
                 "@jsonjoy.com/json-pack": "^1.11.0",
                 "@jsonjoy.com/util": "^1.9.0",
                 "glob-to-regex.js": "^1.0.1",
@@ -14581,11 +14630,14 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.44",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
-            "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+            "version": "2.0.51",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+            "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/nodemon": {
             "version": "3.1.14",
@@ -14627,9 +14679,9 @@
             }
         },
         "node_modules/nodemon/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -14699,9 +14751,9 @@
             }
         },
         "node_modules/normalize-package-data/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -14796,9 +14848,9 @@
             }
         },
         "node_modules/nwsapi": {
-            "version": "2.2.23",
-            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
-            "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+            "version": "2.2.24",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+            "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
             "dev": true,
             "license": "MIT"
         },
@@ -15522,9 +15574,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.14",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+            "version": "8.5.19",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+            "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -15541,7 +15593,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.12",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -15582,9 +15634,9 @@
             }
         },
         "node_modules/postcss-loader/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -15626,9 +15678,9 @@
             }
         },
         "node_modules/postcss-modules-local-by-default/node_modules/postcss-selector-parser": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-            "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15656,9 +15708,9 @@
             }
         },
         "node_modules/postcss-modules-scope/node_modules/postcss-selector-parser": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-            "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15720,9 +15772,9 @@
             }
         },
         "node_modules/postcss-selector-parser": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-            "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+            "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15741,9 +15793,9 @@
             "license": "MIT"
         },
         "node_modules/postcss/node_modules/nanoid": {
-            "version": "3.3.12",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "funding": [
                 {
                     "type": "github",
@@ -15977,13 +16029,14 @@
             "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.15.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-            "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+            "version": "6.15.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.1.0"
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
             },
             "engines": {
                 "node": ">=0.6"
@@ -16412,9 +16465,9 @@
             "license": "MIT"
         },
         "node_modules/regjsparser": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
-            "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
+            "version": "0.13.2",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.2.tgz",
+            "integrity": "sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -16581,9 +16634,9 @@
             "license": "MIT"
         },
         "node_modules/rimraf/node_modules/brace-expansion": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -16635,13 +16688,13 @@
             "license": "Unlicense"
         },
         "node_modules/rollup": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
-            "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+            "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/estree": "1.0.8"
+                "@types/estree": "1.0.9"
             },
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -16651,40 +16704,33 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.60.3",
-                "@rollup/rollup-android-arm64": "4.60.3",
-                "@rollup/rollup-darwin-arm64": "4.60.3",
-                "@rollup/rollup-darwin-x64": "4.60.3",
-                "@rollup/rollup-freebsd-arm64": "4.60.3",
-                "@rollup/rollup-freebsd-x64": "4.60.3",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
-                "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
-                "@rollup/rollup-linux-arm64-gnu": "4.60.3",
-                "@rollup/rollup-linux-arm64-musl": "4.60.3",
-                "@rollup/rollup-linux-loong64-gnu": "4.60.3",
-                "@rollup/rollup-linux-loong64-musl": "4.60.3",
-                "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
-                "@rollup/rollup-linux-ppc64-musl": "4.60.3",
-                "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
-                "@rollup/rollup-linux-riscv64-musl": "4.60.3",
-                "@rollup/rollup-linux-s390x-gnu": "4.60.3",
-                "@rollup/rollup-linux-x64-gnu": "4.60.3",
-                "@rollup/rollup-linux-x64-musl": "4.60.3",
-                "@rollup/rollup-openbsd-x64": "4.60.3",
-                "@rollup/rollup-openharmony-arm64": "4.60.3",
-                "@rollup/rollup-win32-arm64-msvc": "4.60.3",
-                "@rollup/rollup-win32-ia32-msvc": "4.60.3",
-                "@rollup/rollup-win32-x64-gnu": "4.60.3",
-                "@rollup/rollup-win32-x64-msvc": "4.60.3",
+                "@rollup/rollup-android-arm-eabi": "4.62.2",
+                "@rollup/rollup-android-arm64": "4.62.2",
+                "@rollup/rollup-darwin-arm64": "4.62.2",
+                "@rollup/rollup-darwin-x64": "4.62.2",
+                "@rollup/rollup-freebsd-arm64": "4.62.2",
+                "@rollup/rollup-freebsd-x64": "4.62.2",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+                "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+                "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+                "@rollup/rollup-linux-arm64-musl": "4.62.2",
+                "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+                "@rollup/rollup-linux-loong64-musl": "4.62.2",
+                "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+                "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+                "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+                "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+                "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+                "@rollup/rollup-linux-x64-gnu": "4.62.2",
+                "@rollup/rollup-linux-x64-musl": "4.62.2",
+                "@rollup/rollup-openbsd-x64": "4.62.2",
+                "@rollup/rollup-openharmony-arm64": "4.62.2",
+                "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+                "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+                "@rollup/rollup-win32-x64-gnu": "4.62.2",
+                "@rollup/rollup-win32-x64-msvc": "4.62.2",
                 "fsevents": "~2.3.2"
             }
-        },
-        "node_modules/rollup/node_modules/@types/estree": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/rrweb-cssom": {
             "version": "0.7.1",
@@ -17204,9 +17250,9 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-            "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+            "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -17228,14 +17274,14 @@
             }
         },
         "node_modules/side-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
                 "side-channel-map": "^1.0.1",
                 "side-channel-weakmap": "^1.0.2"
             },
@@ -17332,9 +17378,9 @@
             }
         },
         "node_modules/simple-update-notifier/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -17603,18 +17649,19 @@
             }
         },
         "node_modules/string.prototype.trim": {
-            "version": "1.2.10",
-            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-            "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+            "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.2",
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
                 "define-data-property": "^1.1.4",
                 "define-properties": "^1.2.1",
-                "es-abstract": "^1.23.5",
-                "es-object-atoms": "^1.0.0",
-                "has-property-descriptors": "^1.0.2"
+                "es-abstract": "^1.24.2",
+                "es-object-atoms": "^1.1.2",
+                "has-property-descriptors": "^1.0.2",
+                "safe-regex-test": "^1.1.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -17624,15 +17671,15 @@
             }
         },
         "node_modules/string.prototype.trimend": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
-            "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+            "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.2",
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
                 "define-properties": "^1.2.1",
-                "es-object-atoms": "^1.0.0"
+                "es-object-atoms": "^1.1.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -17968,23 +18015,23 @@
             "license": "MIT"
         },
         "node_modules/stylelint/node_modules/file-entry-cache": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.3.tgz",
-            "integrity": "sha512-oMbq0PD6VIiIwMF6LIa7MEwd/l9huKwmqRKXqmrkqIZv8CvRbfowL+L0ryAl8h//HfAS0zS+4SbYoRyAoA6BJA==",
+            "version": "11.1.5",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.5.tgz",
+            "integrity": "sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "flat-cache": "^6.1.22"
+                "flat-cache": "^6.1.23"
             }
         },
         "node_modules/stylelint/node_modules/flat-cache": {
-            "version": "6.1.22",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.22.tgz",
-            "integrity": "sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==",
+            "version": "6.1.23",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.23.tgz",
+            "integrity": "sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "cacheable": "^2.3.4",
+                "cacheable": "^2.5.0",
                 "flatted": "^3.4.2",
                 "hookified": "^1.15.0"
             }
@@ -18021,9 +18068,9 @@
             }
         },
         "node_modules/stylelint/node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -18044,9 +18091,9 @@
             }
         },
         "node_modules/stylelint/node_modules/postcss-selector-parser": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-            "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -18220,9 +18267,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.47.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
-            "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
+            "version": "5.49.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+            "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -18239,9 +18286,9 @@
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.0.tgz",
-            "integrity": "sha512-Eum+5ajkaOhf5KbM26osvv21kLD7BaGqQ1UA4Ami4arYwylmGUQTgHFpHDdmJod1q4QXa66p0to/FBKID+J1vA==",
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
+            "integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -18360,9 +18407,9 @@
             "license": "MIT"
         },
         "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -18415,9 +18462,9 @@
             "license": "MIT"
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.16",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -18450,9 +18497,9 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -18666,9 +18713,9 @@
             }
         },
         "node_modules/ts-loader/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -18820,17 +18867,17 @@
             }
         },
         "node_modules/typed-array-length": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
-            "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+            "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "is-typed-array": "^1.1.13",
-                "possible-typed-array-names": "^1.0.0",
-                "reflect.getprototypeof": "^1.0.6"
+                "call-bind": "^1.0.9",
+                "for-each": "^0.3.5",
+                "gopd": "^1.2.0",
+                "is-typed-array": "^1.1.15",
+                "possible-typed-array-names": "^1.1.0",
+                "reflect.getprototypeof": "^1.0.10"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -18952,9 +18999,9 @@
             "license": "MIT"
         },
         "node_modules/undici-types": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-            "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+            "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
             "license": "MIT"
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -19268,9 +19315,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.4.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-            "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+            "version": "6.4.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+            "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -19876,9 +19923,9 @@
             }
         },
         "node_modules/vite/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -20464,17 +20511,17 @@
             }
         },
         "node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.40.tgz",
+            "integrity": "sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
+                "@vue/compiler-dom": "3.5.40",
+                "@vue/compiler-sfc": "3.5.40",
+                "@vue/runtime-dom": "3.5.40",
+                "@vue/server-renderer": "3.5.40",
+                "@vue/shared": "3.5.40"
             },
             "peerDependencies": {
                 "typescript": "*"
@@ -20576,9 +20623,9 @@
             }
         },
         "node_modules/vue-eslint-parser/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -20683,9 +20730,9 @@
             "license": "MIT"
         },
         "node_modules/vue3-gettext/node_modules/brace-expansion": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -20773,13 +20820,12 @@
             }
         },
         "node_modules/watchpack": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
-            "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+            "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
             },
             "engines": {
@@ -21110,9 +21156,9 @@
             }
         },
         "node_modules/webpack-sources": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.1.tgz",
-            "integrity": "sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==",
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
+            "integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -21120,9 +21166,9 @@
             }
         },
         "node_modules/websocket-driver": {
-            "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-            "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+            "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -21274,13 +21320,13 @@
             }
         },
         "node_modules/which-typed-array": {
-            "version": "1.1.20",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-            "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+            "version": "1.1.22",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+            "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
             "license": "MIT",
             "dependencies": {
                 "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.8",
+                "call-bind": "^1.0.9",
                 "call-bound": "^1.0.4",
                 "for-each": "^0.3.5",
                 "get-proto": "^1.0.1",
@@ -21455,9 +21501,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.20.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-            "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+            "version": "8.21.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+            "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@primevue/forms": "4.3.7",
                 "arches": "archesproject/arches#dev/8.1.x",
-                "arches-component-lab": "archesproject/arches-component-lab#main",
+                "arches-vue-components": "archesproject/arches-vue-components#dev/1.0.x",
                 "pinia": "3.0.4",
                 "vue-router": "4.4.3"
             },
@@ -7502,53 +7502,6 @@
                 "webpack-bundle-tracker": "3.2.0"
             }
         },
-        "node_modules/arches-component-lab": {
-            "name": "arches_component_lab",
-            "resolved": "git+ssh://git@github.com/archesproject/arches-component-lab.git#5e6847dfff1ee85f492931b0bc657edfc9d7e690",
-            "license": "AGPL-3.0-only",
-            "dependencies": {
-                "@mapbox/geojson-extent": "^1.0.1",
-                "@mapbox/mapbox-gl-draw": "^1.4.3",
-                "@primevue/forms": "4.3.9",
-                "@types/geojson": "^7946.0.16",
-                "arches": "archesproject/arches#dev/8.0.x",
-                "dayjs": "^1.11.13",
-                "dompurify": "^3.2.6",
-                "es-toolkit": "^1.44.0",
-                "maplibre-gl": "^4.7.1",
-                "quill": "2.0.3"
-            }
-        },
-        "node_modules/arches-component-lab/node_modules/@primevue/core": {
-            "version": "4.3.9",
-            "resolved": "https://registry.npmjs.org/@primevue/core/-/core-4.3.9.tgz",
-            "integrity": "sha512-P08MhVD8WrldbropVuiG25ku6il+v+cKKrspES6RijDc4NE/CrGMAwOlrdpOkpy7pcfTzqC9eIGBx5ifS28S5g==",
-            "license": "MIT",
-            "dependencies": {
-                "@primeuix/styled": "^0.7.2",
-                "@primeuix/utils": "^0.6.1"
-            },
-            "engines": {
-                "node": ">=12.11.0"
-            },
-            "peerDependencies": {
-                "vue": "^3.5.0"
-            }
-        },
-        "node_modules/arches-component-lab/node_modules/@primevue/forms": {
-            "version": "4.3.9",
-            "resolved": "https://registry.npmjs.org/@primevue/forms/-/forms-4.3.9.tgz",
-            "integrity": "sha512-j/GGxFwpfzP3kdxpfxezmsWohmFjoiNHTZlDxGwrNBGrXfb9GExghgoPPKc0K4OeAX5enufS+g8YGqcglABHAQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@primeuix/forms": "^0.1.0",
-                "@primeuix/utils": "^0.6.1",
-                "@primevue/core": "4.3.9"
-            },
-            "engines": {
-                "node": ">=12.11.0"
-            }
-        },
         "node_modules/arches-dev-dependencies": {
             "version": "8.1.2",
             "resolved": "git+ssh://git@github.com/archesproject/arches-dev-dependencies.git#cf850a50dcfdfba1dfb73f26863b2f6ba11cabdd",
@@ -7653,6 +7606,97 @@
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/arches-vue-components": {
+            "name": "arches_vue_components",
+            "resolved": "git+ssh://git@github.com/archesproject/arches-vue-components.git#633a11adea94496b2f99707ca9ed9adf5634b0a4",
+            "license": "AGPL-3.0-only",
+            "dependencies": {
+                "@mapbox/geojson-extent": "^1.0.1",
+                "@mapbox/mapbox-gl-draw": "^1.4.3",
+                "@primeuix/themes": "1.0.1",
+                "@primevue/forms": "4.3.9",
+                "@types/geojson": "^7946.0.16",
+                "arches": "archesproject/arches#dev/8.0.x",
+                "dayjs": "^1.11.13",
+                "dompurify": "^3.2.6",
+                "es-toolkit": "^1.44.0",
+                "maplibre-gl": "^4.7.1",
+                "pinia": "^3.0.4",
+                "quill": "2.0.3"
+            }
+        },
+        "node_modules/arches-vue-components/node_modules/@primeuix/styled": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-0.5.1.tgz",
+            "integrity": "sha512-5Ftw/KSauDPClQ8F2qCyCUF7cIUEY4yLNikf0rKV7Vsb8zGYNK0dahQe7CChaR6M2Kn+NA2DSBSk76ZXqj6Uog==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/utils": "^0.5.3"
+            },
+            "engines": {
+                "node": ">=12.11.0"
+            }
+        },
+        "node_modules/arches-vue-components/node_modules/@primeuix/styled/node_modules/@primeuix/utils": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.5.4.tgz",
+            "integrity": "sha512-8LggV3Jz59pymHQD10e/u63z/GemQ22RBeu2Gb1eJgBYVwn1iOb82LR+daeAc/LxrXCC5pHnftnCmnZO6vInLA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.11.0"
+            }
+        },
+        "node_modules/arches-vue-components/node_modules/@primeuix/themes": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@primeuix/themes/-/themes-1.0.1.tgz",
+            "integrity": "sha512-RllttI3oGTZa66UQDCIA2lPnJvO/xqtNpy+0eNql6fIxdS2AUg5n7L81jTZrHNZ+31T5OBzL/SGFCDycmHTz2g==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/styled": "^0.5.1"
+            }
+        },
+        "node_modules/arches-vue-components/node_modules/@primevue/core": {
+            "version": "4.3.9",
+            "resolved": "https://registry.npmjs.org/@primevue/core/-/core-4.3.9.tgz",
+            "integrity": "sha512-P08MhVD8WrldbropVuiG25ku6il+v+cKKrspES6RijDc4NE/CrGMAwOlrdpOkpy7pcfTzqC9eIGBx5ifS28S5g==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/styled": "^0.7.2",
+                "@primeuix/utils": "^0.6.1"
+            },
+            "engines": {
+                "node": ">=12.11.0"
+            },
+            "peerDependencies": {
+                "vue": "^3.5.0"
+            }
+        },
+        "node_modules/arches-vue-components/node_modules/@primevue/core/node_modules/@primeuix/styled": {
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-0.7.4.tgz",
+            "integrity": "sha512-QSO/NpOQg8e9BONWRBx9y8VGMCMYz0J/uKfNJEya/RGEu7ARx0oYW0ugI1N3/KB1AAvyGxzKBzGImbwg0KUiOQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/utils": "^0.6.1"
+            },
+            "engines": {
+                "node": ">=12.11.0"
+            }
+        },
+        "node_modules/arches-vue-components/node_modules/@primevue/forms": {
+            "version": "4.3.9",
+            "resolved": "https://registry.npmjs.org/@primevue/forms/-/forms-4.3.9.tgz",
+            "integrity": "sha512-j/GGxFwpfzP3kdxpfxezmsWohmFjoiNHTZlDxGwrNBGrXfb9GExghgoPPKc0K4OeAX5enufS+g8YGqcglABHAQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/forms": "^0.1.0",
+                "@primeuix/utils": "^0.6.1",
+                "@primevue/core": "4.3.9"
+            },
+            "engines": {
+                "node": ">=12.11.0"
             }
         },
         "node_modules/arches/node_modules/@vue/compiler-core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
                 "vue-router": "4.4.3"
             },
             "devDependencies": {
-                "arches-dev-dependencies": "archesproject/arches-dev-dependencies#dev/8.1.x"
+                "arches-dev-dependencies": "archesproject/arches-dev-dependencies#dev/8.1.x",
+                "globals": "17.8.0"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -11596,6 +11597,19 @@
             },
             "engines": {
                 "node": "^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/globals": {
+            "version": "17.8.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
+            "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/globalthis": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "@primevue/forms": "4.3.7",
         "arches": "archesproject/arches#dev/8.1.x",
         "arches-vue-components": "archesproject/arches-vue-components#dev/2.0.x",
+        "arches-controlled-lists": "archesproject/arches-controlled-lists#dev/1.2.x",
         "pinia": "3.0.4",
         "vue-router": "4.4.3"
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
         "vitest": "vitest --run --coverage"
     },
     "devDependencies": {
-        "arches-dev-dependencies": "archesproject/arches-dev-dependencies#dev/8.1.x"
+        "arches-dev-dependencies": "archesproject/arches-dev-dependencies#dev/8.1.x",
+        "globals": "17.8.0"
     },
     "dependencies": {
         "@primevue/forms": "4.3.7",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dependencies": {
         "@primevue/forms": "4.3.7",
         "arches": "archesproject/arches#dev/8.1.x",
-        "arches-vue-components": "archesproject/arches-vue-components#dev/1.0.x",
+        "arches-vue-components": "archesproject/arches-vue-components#dev/2.0.x",
         "pinia": "3.0.4",
         "vue-router": "4.4.3"
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dependencies": {
         "@primevue/forms": "4.3.7",
         "arches": "archesproject/arches#dev/8.1.x",
-        "arches-component-lab": "archesproject/arches-component-lab#main",
+        "arches-vue-components": "archesproject/arches-vue-components#dev/1.0.x",
         "pinia": "3.0.4",
         "vue-router": "4.4.3"
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "arches @ git+https://github.com/archesproject/arches@dev/8.1.x",
-    "arches_vue_components @ git+https://github.com/archesproject/arches-vue-components@dev/1.0.x",
+    "arches_vue_components @ git+https://github.com/archesproject/arches-vue-components@dev/2.0.x",
     "arches_querysets @ git+https://github.com/archesproject/arches-querysets@dev/1.1.x",
     "arches_controlled_lists @ git+https://github.com/archesproject/arches-controlled-lists@dev/1.1.x",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,10 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "arches @ git+https://github.com/archesproject/arches@dev/8.1.x",
-    "arches_vue_components @ git+https://github.com/archesproject/arches-vue-components@dev/2.0.x",
-    "arches_querysets @ git+https://github.com/archesproject/arches-querysets@dev/1.1.x",
-    "arches_controlled_lists @ git+https://github.com/archesproject/arches-controlled-lists@dev/1.2.x",
+    "arches==8.1.3",
+    "arches_vue_components>=2.0.2",
+    "arches_querysets>=1.2.0",
+    "arches_controlled_lists>=1.2.0",
 ]
 version = "1.1.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "arches @ git+https://github.com/archesproject/arches@dev/8.1.x",
     "arches_vue_components @ git+https://github.com/archesproject/arches-vue-components@dev/2.0.x",
     "arches_querysets @ git+https://github.com/archesproject/arches-querysets@dev/1.1.x",
-    "arches_controlled_lists @ git+https://github.com/archesproject/arches-controlled-lists@dev/1.1.x",
+    "arches_controlled_lists @ git+https://github.com/archesproject/arches-controlled-lists@dev/1.2.x",
 ]
 version = "1.1.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "arches @ git+https://github.com/archesproject/arches@dev/8.1.x",
-    "arches_component_lab @ git+https://github.com/archesproject/arches-component-lab@main",
+    "arches_vue_components @ git+https://github.com/archesproject/arches-vue-components@dev/1.0.x",
     "arches_querysets @ git+https://github.com/archesproject/arches-querysets@dev/1.1.x",
     "arches_controlled_lists @ git+https://github.com/archesproject/arches-controlled-lists@dev/1.1.x",
 ]

--- a/tests/test_advanced_search.py
+++ b/tests/test_advanced_search.py
@@ -60,6 +60,17 @@ from arches_lingo.const import (
     IDENTIFIER_CONTENT_NODE,
     MATCH_STATUS_NODEGROUP,
     MATCH_STATUS_COMPARATE_NODE,
+    DEPICTING_DIGITAL_ASSET_INTERNAL_NODEGROUP,
+    DEPICTING_DIGITAL_ASSET_INTERNAL_NODE,
+    DEPICTING_DIGITAL_ASSET_EXTERNAL_NODEGROUP,
+    DEPICTING_DIGITAL_ASSET_EXTERNAL_NODE,
+    DIGITAL_OBJECT_GRAPH_ID,
+    DIGITAL_OBJECT_CONTENT_NODEGROUP,
+    DIGITAL_OBJECT_CONTENT_NODE,
+    DIGITAL_OBJECT_NAME_NODEGROUP,
+    DIGITAL_OBJECT_NAME_CONTENT_NODE,
+    DIGITAL_OBJECT_STATEMENT_NODEGROUP,
+    DIGITAL_OBJECT_STATEMENT_CONTENT_NODE,
 )
 from arches_lingo.models import ConceptSet, ConceptSetMember, SavedSearch
 from arches_lingo.utils.advanced_search import AdvancedSearchEvaluator
@@ -1084,6 +1095,220 @@ class HierarchicalCascadeTests(AdvancedSearchEvaluatorTests):
             self.concept_b.pk,
             self.concept_c.pk,
             self.concept_d.pk,
+        }
+        self.assertTrue(all_concepts.issubset(set(result)))
+
+
+# ────────────────────────────────────────────────────────────────
+# Related image facet tests — concept -> digital object depictions
+# ────────────────────────────────────────────────────────────────
+
+
+class RelatedImageFacetTests(TestCase):
+    """Tests for the related_image facet (concept -> image relationships).
+
+    Fixtures build three concepts:
+
+    * ``concept_with_internal_image`` depicts a digital object carrying a file,
+      title, and description.
+    * ``concept_with_external_image`` has only an external image URL.
+    * ``concept_without_image`` has no depiction at all.
+    """
+
+    graph_fixtures = ["Scheme.json", "Concept.json", "digital_object_system.json"]
+
+    @classmethod
+    def load_ontology(cls):
+        path = Path(settings.APP_ROOT) / "pkg" / "ontologies" / "takin"
+        management.call_command("load_ontology", source=path, verbosity=0)
+
+    @classmethod
+    def load_graphs(cls):
+        path = Path(settings.APP_ROOT) / "pkg" / "graphs" / "resource_models"
+        for file_path in cls.graph_fixtures:
+            with captured_stdout(), open(path / file_path, "r") as graph_file:
+                archesfile = JSONDeserializer().deserialize(graph_file)
+                ResourceGraphImporter(archesfile["graph"], overwrite_graphs=True)
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.load_ontology()
+        cls.load_graphs()
+        cls.admin = User.objects.get(username="admin")
+
+        cls.digital_object = ResourceInstance.objects.create(
+            graph_id=DIGITAL_OBJECT_GRAPH_ID, name="Bronze Sculpture Photo"
+        )
+        TileModel.objects.create(
+            resourceinstance=cls.digital_object,
+            nodegroup_id=DIGITAL_OBJECT_CONTENT_NODEGROUP,
+            data={
+                DIGITAL_OBJECT_CONTENT_NODE: [
+                    {"name": "sculpture-front.jpg", "file_id": str(uuid.uuid4())}
+                ]
+            },
+        )
+        TileModel.objects.create(
+            resourceinstance=cls.digital_object,
+            nodegroup_id=DIGITAL_OBJECT_NAME_NODEGROUP,
+            data={DIGITAL_OBJECT_NAME_CONTENT_NODE: "Bronze Sculpture"},
+        )
+        TileModel.objects.create(
+            resourceinstance=cls.digital_object,
+            nodegroup_id=DIGITAL_OBJECT_STATEMENT_NODEGROUP,
+            data={
+                DIGITAL_OBJECT_STATEMENT_CONTENT_NODE: (
+                    "A photograph of the front of the sculpture"
+                )
+            },
+        )
+
+        cls.concept_with_internal_image = ResourceInstance.objects.create(
+            graph_id=CONCEPTS_GRAPH_ID, name="Concept With Internal Image"
+        )
+        TileModel.objects.create(
+            resourceinstance=cls.concept_with_internal_image,
+            nodegroup_id=DEPICTING_DIGITAL_ASSET_INTERNAL_NODEGROUP,
+            data={
+                DEPICTING_DIGITAL_ASSET_INTERNAL_NODE: [
+                    {"resourceId": str(cls.digital_object.pk)}
+                ]
+            },
+        )
+
+        cls.concept_with_external_image = ResourceInstance.objects.create(
+            graph_id=CONCEPTS_GRAPH_ID, name="Concept With External Image"
+        )
+        TileModel.objects.create(
+            resourceinstance=cls.concept_with_external_image,
+            nodegroup_id=DEPICTING_DIGITAL_ASSET_EXTERNAL_NODEGROUP,
+            data={
+                DEPICTING_DIGITAL_ASSET_EXTERNAL_NODE: {
+                    "url": "http://example.com/image.jpg",
+                    "url_label": "External image",
+                }
+            },
+        )
+
+        cls.concept_without_image = ResourceInstance.objects.create(
+            graph_id=CONCEPTS_GRAPH_ID, name="Concept Without Image"
+        )
+
+    def setUp(self):
+        self.evaluator = AdvancedSearchEvaluator(user=self.admin)
+
+    def test_has_image_includes_internal_and_external(self):
+        result = self.evaluator.evaluate(
+            {"facet": "related_image", "image_attribute": "has_image"}
+        )
+        ids = set(result)
+        self.assertIn(self.concept_with_internal_image.pk, ids)
+        self.assertIn(self.concept_with_external_image.pk, ids)
+        self.assertNotIn(self.concept_without_image.pk, ids)
+
+    def test_has_image_negated_returns_concepts_without_images(self):
+        result = self.evaluator.evaluate(
+            {
+                "facet": "related_image",
+                "image_attribute": "has_image",
+                "negated": True,
+            }
+        )
+        ids = set(result)
+        self.assertIn(self.concept_without_image.pk, ids)
+        self.assertNotIn(self.concept_with_internal_image.pk, ids)
+        self.assertNotIn(self.concept_with_external_image.pk, ids)
+
+    def test_file_name_contains(self):
+        result = self.evaluator.evaluate(
+            {
+                "facet": "related_image",
+                "image_attribute": "file_name",
+                "value": "sculpture",
+            }
+        )
+        ids = set(result)
+        self.assertIn(self.concept_with_internal_image.pk, ids)
+        self.assertNotIn(self.concept_with_external_image.pk, ids)
+        self.assertNotIn(self.concept_without_image.pk, ids)
+
+    def test_file_name_ends_with_extension(self):
+        result = self.evaluator.evaluate(
+            {
+                "facet": "related_image",
+                "image_attribute": "file_name",
+                "value": ".jpg",
+                "match_mode": "ends_with",
+            }
+        )
+        self.assertIn(self.concept_with_internal_image.pk, set(result))
+
+    def test_file_name_no_match_returns_empty(self):
+        result = self.evaluator.evaluate(
+            {
+                "facet": "related_image",
+                "image_attribute": "file_name",
+                "value": "no_such_file",
+            }
+        )
+        self.assertFalse(list(result))
+
+    def test_file_name_exists(self):
+        result = self.evaluator.evaluate(
+            {
+                "facet": "related_image",
+                "image_attribute": "file_name",
+                "value": "",
+                "match_mode": "exists",
+            }
+        )
+        ids = set(result)
+        self.assertIn(self.concept_with_internal_image.pk, ids)
+        self.assertNotIn(self.concept_with_external_image.pk, ids)
+
+    def test_title_contains(self):
+        result = self.evaluator.evaluate(
+            {
+                "facet": "related_image",
+                "image_attribute": "title",
+                "value": "Bronze",
+            }
+        )
+        ids = set(result)
+        self.assertIn(self.concept_with_internal_image.pk, ids)
+        self.assertNotIn(self.concept_without_image.pk, ids)
+
+    def test_title_exact_no_partial(self):
+        result = self.evaluator.evaluate(
+            {
+                "facet": "related_image",
+                "image_attribute": "title",
+                "value": "Bronze",
+                "match_mode": "exact",
+            }
+        )
+        self.assertFalse(list(result))
+
+    def test_description_contains(self):
+        result = self.evaluator.evaluate(
+            {
+                "facet": "related_image",
+                "image_attribute": "description",
+                "value": "photograph",
+            }
+        )
+        ids = set(result)
+        self.assertIn(self.concept_with_internal_image.pk, ids)
+        self.assertNotIn(self.concept_with_external_image.pk, ids)
+
+    def test_text_attribute_empty_value_returns_all(self):
+        result = self.evaluator.evaluate(
+            {"facet": "related_image", "image_attribute": "title", "value": ""}
+        )
+        all_concepts = {
+            self.concept_with_internal_image.pk,
+            self.concept_with_external_image.pk,
+            self.concept_without_image.pk,
         }
         self.assertTrue(all_concepts.issubset(set(result)))
 

--- a/tests/test_advanced_search.py
+++ b/tests/test_advanced_search.py
@@ -1312,6 +1312,51 @@ class RelatedImageFacetTests(TestCase):
         }
         self.assertTrue(all_concepts.issubset(set(result)))
 
+    def _make_concept_depicting_file(self, file_name):
+        """Create a digital object with the given file name and a concept depicting it."""
+        digital_object = ResourceInstance.objects.create(
+            graph_id=DIGITAL_OBJECT_GRAPH_ID, name=f"Digital Object {file_name}"
+        )
+        TileModel.objects.create(
+            resourceinstance=digital_object,
+            nodegroup_id=DIGITAL_OBJECT_CONTENT_NODEGROUP,
+            data={
+                DIGITAL_OBJECT_CONTENT_NODE: [
+                    {"name": file_name, "file_id": str(uuid.uuid4())}
+                ]
+            },
+        )
+        concept = ResourceInstance.objects.create(
+            graph_id=CONCEPTS_GRAPH_ID, name=f"Concept depicting {file_name}"
+        )
+        TileModel.objects.create(
+            resourceinstance=concept,
+            nodegroup_id=DEPICTING_DIGITAL_ASSET_INTERNAL_NODEGROUP,
+            data={
+                DEPICTING_DIGITAL_ASSET_INTERNAL_NODE: [
+                    {"resourceId": str(digital_object.pk)}
+                ]
+            },
+        )
+        return concept
+
+    def test_file_name_wildcard_characters_matched_literally(self):
+        """An underscore in the value must match literally, not as a LIKE wildcard."""
+        literal_underscore = self._make_concept_depicting_file("report_v1.jpg")
+        wildcard_collision = self._make_concept_depicting_file("reportXv1.jpg")
+
+        result = self.evaluator.evaluate(
+            {
+                "facet": "related_image",
+                "image_attribute": "file_name",
+                "value": "report_v1.jpg",
+                "match_mode": "exact",
+            }
+        )
+        ids = set(result)
+        self.assertIn(literal_underscore.pk, ids)
+        self.assertNotIn(wildcard_collision.pk, ids)
+
 
 # ────────────────────────────────────────────────────────────────
 # API view tests  (require graph fixtures + tile data)

--- a/tests/test_dereference.py
+++ b/tests/test_dereference.py
@@ -1,0 +1,348 @@
+import json
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.http import HttpResponse
+from django.test import SimpleTestCase, TestCase, override_settings
+from django.urls import reverse
+
+from pyld import jsonld
+from rdflib import Graph, Literal, URIRef
+from rdflib.namespace import OWL, RDF, SKOS
+
+from arches.app.datatypes.datatypes import DataTypeFactory
+from arches.app.models.models import ResourceIdentifier, ResourceInstance, TileModel
+
+from arches_lingo.const import (
+    MATCH_STATUS_COMPARATE_NODE,
+    MATCH_STATUS_NODEGROUP,
+    MATCH_STATUS_RELATION_NODE,
+    URI_CONTENT_NODE,
+    URI_NODEGROUP,
+)
+from arches_lingo.utils.concept_lifecycle import (
+    DRAFT_STATE_ID,
+    PUBLISHED_STATE_ID,
+)
+from arches_lingo.utils.skos import ARCHES
+from arches_lingo.utils.skos_serializer import (
+    NOT_ACCEPTABLE,
+    negotiate_rdf_format,
+    serialize_resource,
+)
+from tests.tests import ViewTests
+
+# Controlled list backing match_status_ascribed_relation (SKOS mapping properties).
+MAPPING_PROPERTIES_LIST_ID = "769fa072-6247-4e23-b638-4e801f8c50dc"
+
+
+def _graph_from_jsonld(content):
+    """Parse a JSON-LD document into an rdflib Graph via pyld.
+
+    rdflib 4.2.2 has no JSON-LD parser, so bridge through N-Quads like the
+    serializer does in the other direction.
+    """
+    nquads = jsonld.to_rdf(json.loads(content), {"format": "application/nquads"})
+    return Graph().parse(data=nquads, format="nquads")
+
+
+class NegotiateRdfFormatTests(SimpleTestCase):
+    """Content negotiation is pure logic; exercise it directly without the DB."""
+
+    def test_explicit_format_tokens(self):
+        for token, expected in [
+            ("jsonld", "jsonld"),
+            ("xml", "xml"),
+            ("turtle", "turtle"),
+            ("nt", "nt"),
+        ]:
+            self.assertEqual(negotiate_rdf_format("", explicit_format=token), expected)
+
+    def test_explicit_format_aliases(self):
+        for token, expected in [
+            ("json-ld", "jsonld"),
+            ("ttl", "turtle"),
+            ("rdf", "xml"),
+            ("n-triples", "nt"),
+        ]:
+            self.assertEqual(negotiate_rdf_format("", explicit_format=token), expected)
+
+    def test_explicit_html_is_the_spa(self):
+        self.assertIsNone(negotiate_rdf_format("", explicit_format="html"))
+
+    def test_explicit_unsupported_format_is_not_acceptable(self):
+        self.assertIs(negotiate_rdf_format("", explicit_format="csv"), NOT_ACCEPTABLE)
+
+    def test_accept_header_maps_to_format(self):
+        for accept, expected in [
+            ("application/ld+json", "jsonld"),
+            ("application/rdf+xml", "xml"),
+            ("text/turtle", "turtle"),
+            ("application/n-triples", "nt"),
+        ]:
+            self.assertEqual(negotiate_rdf_format(accept), expected)
+
+    def test_browser_accept_headers_get_the_spa(self):
+        self.assertIsNone(negotiate_rdf_format("text/html,application/xhtml+xml,*/*"))
+        self.assertIsNone(negotiate_rdf_format("*/*"))
+        self.assertIsNone(negotiate_rdf_format(""))
+
+    def test_quality_values_decide_the_winner(self):
+        # HTML preferred over RDF -> serve the SPA.
+        self.assertIsNone(
+            negotiate_rdf_format("application/ld+json;q=0.2, text/html;q=0.9")
+        )
+        # RDF preferred over HTML -> serve RDF.
+        self.assertEqual(
+            negotiate_rdf_format("text/html;q=0.5, application/ld+json;q=0.9"),
+            "jsonld",
+        )
+
+    def test_explicit_format_beats_accept_header(self):
+        self.assertEqual(
+            negotiate_rdf_format("text/html", explicit_format="turtle"), "turtle"
+        )
+
+
+class _LingoResourceTestCase(TestCase):
+    """Reuses the ViewTests fixture (a scheme with five hierarchical concepts)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        ViewTests.setUpTestData()
+        cls.scheme = ResourceInstance.objects.get(name="Test Scheme")
+        cls.concept_1 = ResourceInstance.objects.get(name="Concept 1")  # top concept
+        cls.concept_2 = ResourceInstance.objects.get(name="Concept 2")  # narrower
+
+    @staticmethod
+    def _add_uri_tile(resource, uri):
+        TileModel.objects.create(
+            resourceinstance=resource,
+            nodegroup_id=URI_NODEGROUP,
+            data={URI_CONTENT_NODE: uri},
+        )
+
+
+class SkosSerializerTests(_LingoResourceTestCase):
+    def test_serialize_concept_emits_skos_concept_with_relations(self):
+        body, content_type = serialize_resource(self.concept_2.pk, "concept", "xml")
+        self.assertEqual(content_type, "application/rdf+xml")
+
+        graph = Graph().parse(data=body, format="xml")
+        subject = ARCHES[str(self.concept_2.pk)]
+
+        self.assertIn((subject, RDF.type, SKOS.Concept), graph)
+        self.assertIn((subject, SKOS.prefLabel, Literal("Concept 2", lang="en")), graph)
+        # Concept 2 is narrower than Concept 1 and in the scheme.
+        self.assertIn((subject, SKOS.broader, ARCHES[str(self.concept_1.pk)]), graph)
+        self.assertIn((subject, SKOS.inScheme, ARCHES[str(self.scheme.pk)]), graph)
+
+    def test_serialize_scheme_emits_concept_scheme(self):
+        body, _content_type = serialize_resource(self.scheme.pk, "scheme", "xml")
+        graph = Graph().parse(data=body, format="xml")
+        subject = ARCHES[str(self.scheme.pk)]
+
+        self.assertIn((subject, RDF.type, SKOS.ConceptScheme), graph)
+        self.assertIn(
+            (subject, SKOS.prefLabel, Literal("Test Scheme", lang="en")), graph
+        )
+
+    def test_serialize_scheme_enumerates_top_concepts(self):
+        # Concept 1 is the top concept of the scheme in the fixture data.
+        body, _content_type = serialize_resource(self.scheme.pk, "scheme", "xml")
+        graph = Graph().parse(data=body, format="xml")
+        self.assertIn(
+            (
+                ARCHES[str(self.scheme.pk)],
+                SKOS.hasTopConcept,
+                ARCHES[str(self.concept_1.pk)],
+            ),
+            graph,
+        )
+
+    def test_serialize_concept_emits_match_as_uri_reference(self):
+        external_uri = "http://vocab.getty.edu/aat/300000000"
+        exact_match_reference = (
+            DataTypeFactory()
+            .get_instance("reference")
+            .transform_value_for_tile(
+                "exactMatch", controlledList=MAPPING_PROPERTIES_LIST_ID
+            )
+        )
+        TileModel.objects.create(
+            resourceinstance=self.concept_2,
+            nodegroup_id=MATCH_STATUS_NODEGROUP,
+            data={
+                MATCH_STATUS_RELATION_NODE: exact_match_reference,
+                MATCH_STATUS_COMPARATE_NODE: external_uri,
+            },
+        )
+
+        body, _content_type = serialize_resource(self.concept_2.pk, "concept", "xml")
+        graph = Graph().parse(data=body, format="xml")
+        subject = ARCHES[str(self.concept_2.pk)]
+
+        # The match target is a URI reference (not a string literal), under a SKOS
+        # mapping predicate.
+        match_objects = set(graph.objects(subject, SKOS.exactMatch))
+        self.assertIn(URIRef(external_uri), match_objects)
+
+    def test_every_rdf_format_round_trips(self):
+        for rdf_format, parse_format, expected_type in [
+            ("jsonld", None, "application/ld+json"),
+            ("xml", "xml", "application/rdf+xml"),
+            ("turtle", "turtle", "text/turtle; charset=utf-8"),
+            ("nt", "nt", "application/n-triples"),
+        ]:
+            with self.subTest(rdf_format=rdf_format):
+                body, content_type = serialize_resource(
+                    self.concept_2.pk, "concept", rdf_format
+                )
+                self.assertEqual(content_type, expected_type)
+                if rdf_format == "jsonld":
+                    graph = _graph_from_jsonld(body)
+                else:
+                    graph = Graph().parse(data=body, format=parse_format)
+                self.assertIn(
+                    (ARCHES[str(self.concept_2.pk)], RDF.type, SKOS.Concept), graph
+                )
+
+    def test_public_uri_becomes_subject_and_links_use_it(self):
+        concept_2_uri = "https://vocab.example.org/schemes/test/concepts/c2"
+        concept_1_uri = "https://vocab.example.org/schemes/test/concepts/c1"
+        self._add_uri_tile(self.concept_2, concept_2_uri)
+        self._add_uri_tile(self.concept_1, concept_1_uri)
+
+        body, _content_type = serialize_resource(self.concept_2.pk, "concept", "xml")
+        graph = Graph().parse(data=body, format="xml")
+
+        subject = URIRef(concept_2_uri)
+        # The public URI is the subject, and the UUID form is retained via owl:sameAs.
+        self.assertIn((subject, RDF.type, SKOS.Concept), graph)
+        self.assertIn((subject, OWL.sameAs, ARCHES[str(self.concept_2.pk)]), graph)
+        # A link to another resource uses that resource's public URI, not its UUID.
+        self.assertIn((subject, SKOS.broader, URIRef(concept_1_uri)), graph)
+
+    def test_retired_resource_is_marked_deprecated(self):
+        body, _content_type = serialize_resource(
+            self.concept_2.pk, "concept", "xml", mark_deprecated=True
+        )
+        graph = Graph().parse(data=body, format="xml")
+        self.assertIn(
+            (ARCHES[str(self.concept_2.pk)], OWL.deprecated, Literal(True)), graph
+        )
+
+    def test_missing_resource_returns_none(self):
+        body, content_type = serialize_resource(
+            "00000000-0000-0000-0000-000000000000", "concept", "xml"
+        )
+        self.assertIsNone(body)
+        self.assertIsNone(content_type)
+
+
+class DereferenceViewTests(_LingoResourceTestCase):
+    def setUp(self):
+        self.admin = User.objects.get(username="admin")
+
+    def _set_state(self, resource, state_id):
+        ResourceInstance.objects.filter(pk=resource.pk).update(
+            resource_instance_lifecycle_state_id=state_id
+        )
+
+    @patch("arches_lingo.views.api.dereference.LingoRootView")
+    def test_browser_request_delegates_to_spa(self, mock_root_view):
+        mock_root_view.as_view.return_value = lambda request, *a, **k: HttpResponse(
+            "SPA-HTML"
+        )
+        self.client.force_login(self.admin)
+        response = self.client.get(
+            reverse("concept", kwargs={"id": self.concept_2.pk}),
+            HTTP_ACCEPT="text/html,application/xhtml+xml,*/*",
+        )
+        self.assertEqual(response.content, b"SPA-HTML")
+
+    def test_accept_ldjson_returns_negotiated_skos(self):
+        self.client.force_login(self.admin)
+        response = self.client.get(
+            reverse("concept", kwargs={"id": self.concept_2.pk}),
+            HTTP_ACCEPT="application/ld+json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/ld+json")
+        self.assertIn("Accept", response["Vary"])
+        graph = _graph_from_jsonld(response.content)
+        self.assertIn((ARCHES[str(self.concept_2.pk)], RDF.type, SKOS.Concept), graph)
+
+    def test_format_query_overrides_accept(self):
+        self.client.force_login(self.admin)
+        response = self.client.get(
+            reverse("concept", kwargs={"id": self.concept_2.pk}),
+            {"format": "turtle"},
+            HTTP_ACCEPT="text/html",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/turtle; charset=utf-8")
+
+    def test_unsupported_format_returns_406(self):
+        self.client.force_login(self.admin)
+        response = self.client.get(
+            reverse("concept", kwargs={"id": self.concept_2.pk}),
+            {"format": "csv"},
+        )
+        self.assertEqual(response.status_code, 406)
+
+    @override_settings(LINGO_ALLOW_ANONYMOUS_ACCESS=True)
+    def test_anonymous_can_dereference_published_resource(self):
+        self._set_state(self.concept_2, PUBLISHED_STATE_ID)
+        response = self.client.get(
+            reverse("concept", kwargs={"id": self.concept_2.pk}),
+            HTTP_ACCEPT="application/ld+json",
+        )
+        self.assertEqual(response.status_code, 200)
+
+    @override_settings(LINGO_ALLOW_ANONYMOUS_ACCESS=True)
+    def test_anonymous_cannot_dereference_draft_resource(self):
+        self._set_state(self.concept_2, DRAFT_STATE_ID)
+        response = self.client.get(
+            reverse("concept", kwargs={"id": self.concept_2.pk}),
+            HTTP_ACCEPT="application/ld+json",
+        )
+        self.assertEqual(response.status_code, 404)
+
+    @override_settings(LINGO_ALLOW_ANONYMOUS_ACCESS=False)
+    def test_anonymous_denied_when_setting_disabled(self):
+        self._set_state(self.concept_2, PUBLISHED_STATE_ID)
+        response = self.client.get(
+            reverse("concept", kwargs={"id": self.concept_2.pk}),
+            HTTP_ACCEPT="application/ld+json",
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_authenticated_user_can_preview_draft(self):
+        self._set_state(self.concept_2, DRAFT_STATE_ID)
+        self.client.force_login(self.admin)
+        response = self.client.get(
+            reverse("concept", kwargs={"id": self.concept_2.pk}),
+            HTTP_ACCEPT="application/ld+json",
+        )
+        self.assertEqual(response.status_code, 200)
+
+    @override_settings(LINGO_ALLOW_ANONYMOUS_ACCESS=True)
+    def test_slug_route_resolves_and_serializes(self):
+        self._set_state(self.scheme, PUBLISHED_STATE_ID)
+        ResourceIdentifier.objects.create(
+            resourceid=self.scheme,
+            identifier="test-scheme",
+            source="arches-lingo",
+        )
+        response = self.client.get(
+            reverse(
+                "scheme-by-identifier", kwargs={"scheme_identifier": "test-scheme"}
+            ),
+            HTTP_ACCEPT="text/turtle",
+        )
+        self.assertEqual(response.status_code, 200)
+        graph = Graph().parse(data=response.content, format="turtle")
+        self.assertIn(
+            (ARCHES[str(self.scheme.pk)], RDF.type, SKOS.ConceptScheme), graph
+        )

--- a/webpack/webpack-utils/build-filepath-lookup.test.js
+++ b/webpack/webpack-utils/build-filepath-lookup.test.js
@@ -1,0 +1,80 @@
+/* eslint-disable */
+
+const fs = require('fs');
+const os = require('os');
+const Path = require('path');
+
+const { buildFilepathLookup } = require('./build-filepath-lookup');
+
+describe('buildFilepathLookup', () => {
+    let fixtureRoot;
+
+    beforeAll(() => {
+        fixtureRoot = Path.join(fs.mkdtempSync(Path.join(os.tmpdir(), 'build-filepath-lookup-')), 'fixtureRoot');
+
+        fs.mkdirSync(Path.join(fixtureRoot, 'nested'), { recursive: true });
+        fs.writeFileSync(Path.join(fixtureRoot, 'entry.js'), '');
+        fs.writeFileSync(Path.join(fixtureRoot, 'nested', 'widget.js'), '');
+        fs.writeFileSync(Path.join(fixtureRoot, 'styles.css'), '');
+        fs.writeFileSync(Path.join(fixtureRoot, 'nested', 'theme.scss'), '');
+        fs.writeFileSync(Path.join(fixtureRoot, 'logo.png'), '');
+        fs.writeFileSync(Path.join(fixtureRoot, '.DS_Store'), '');
+    });
+
+    afterAll(() => {
+        fs.rmSync(Path.dirname(fixtureRoot), { recursive: true, force: true });
+    });
+
+    test('returns undefined for a directory that does not exist', () => {
+        expect(buildFilepathLookup(Path.join(fixtureRoot, 'does-not-exist'))).toBeUndefined();
+    });
+
+    test('ignores dotfiles', () => {
+        expect(Object.keys(buildFilepathLookup(fixtureRoot)).some((key) => key.includes('DS_Store'))).toBe(false);
+    });
+
+    test('maps .js files to an entry-point descriptor, recursing into subdirectories', () => {
+        const lookup = buildFilepathLookup(fixtureRoot);
+
+        expect(lookup['entry']).toEqual({
+            import: Path.join(fixtureRoot, 'entry.js'),
+            filename: 'fixtureRoot/[name].[contenthash].js',
+        });
+        expect(lookup['nested/widget']).toEqual({
+            import: Path.join(fixtureRoot, 'nested', 'widget.js'),
+            filename: 'fixtureRoot/[name].[contenthash].js',
+        });
+    });
+
+    test('maps .css and .scss files under a css/ prefix', () => {
+        const lookup = buildFilepathLookup(fixtureRoot);
+
+        expect(lookup['css/styles']).toEqual({
+            import: Path.join(fixtureRoot, 'styles.css'),
+            filename: 'fixtureRoot/[name].[contenthash].css',
+        });
+        expect(lookup['css/nested/theme']).toEqual({
+            import: Path.join(fixtureRoot, 'nested', 'theme.scss'),
+            filename: 'fixtureRoot/[name].[contenthash].scss',
+        });
+    });
+
+    test('maps other extensions to their raw file path, keyed under an optional static URL prefix', () => {
+        const filepath = Path.join(fixtureRoot, 'logo.png');
+
+        expect(buildFilepathLookup(fixtureRoot)['fixtureRoot/logo.png']).toBe(filepath);
+        expect(buildFilepathLookup(fixtureRoot, '/static/')['/static/fixtureRoot/logo.png']).toBe(filepath);
+    });
+
+    // kept in sync by hand across projects; this project and arches core are the two known copies
+    const thisFile = Path.resolve(__dirname, 'build-filepath-lookup.test.js');
+    const otherCopies = ['test-modular-reports', 'arches']
+        .map((project) => Path.resolve(__dirname, '..', '..', '..', project, 'webpack', 'webpack-utils', 'build-filepath-lookup.test.js'))
+        .filter((copy) => copy !== thisFile && fs.existsSync(copy));
+
+    test.skipIf(otherCopies.length === 0)('stays byte-identical to the other project copies of this file', () => {
+        const thisContent = fs.readFileSync(thisFile, 'utf-8');
+        const mismatches = otherCopies.filter((copy) => fs.readFileSync(copy, 'utf-8') !== thisContent);
+        expect(mismatches).toEqual([]);
+    });
+});

--- a/webpack/webpack-utils/patch-vue-compiler-sfc-type-resolution.js
+++ b/webpack/webpack-utils/patch-vue-compiler-sfc-type-resolution.js
@@ -1,0 +1,67 @@
+/* eslint-disable */
+
+const fs = require('fs');
+const Path = require('path');
+
+// vue's compiler can't find a tsconfig.json for a regular (non-editable) pip install, so
+// defineProps<T>() type resolution breaks. We feed it a fake one in memory using its own fs
+// option. Don't move this below the vue-loader require. vue-loader grabs compileScript once when
+// it loads and never looks again.
+function requireVueLoaderWithTypeResolutionPatch() {
+    const ts = require('typescript');
+    const vueSingleFileComponentCompiler = require('vue/compiler-sfc');
+
+    if (typeof vueSingleFileComponentCompiler.compileScript !== 'function') {
+        throw new Error(
+            'vue/compiler-sfc.compileScript is not a function; the installed vue/vue-loader ' +
+            'version may no longer support this patch and it needs to be revisited.'
+        );
+    }
+
+    const frontendConfigurationDirectory = Path.join(__dirname, '..', '..', 'frontend_configuration');
+    const { compilerOptions: { paths: tsconfigPathsRelativeToFrontendConfiguration } } = JSON.parse(
+        fs.readFileSync(Path.join(frontendConfigurationDirectory, 'tsconfig-paths.json'), 'utf-8')
+    );
+
+    const archesApplicationPathAliases = Object.fromEntries(
+        Object.entries(tsconfigPathsRelativeToFrontendConfiguration).map(([alias, relativePaths]) => [
+            alias,
+            relativePaths.map((relativePath) => Path.resolve(frontendConfigurationDirectory, relativePath)),
+        ])
+    );
+
+    const virtualTsconfigContent = JSON.stringify({
+        compilerOptions: {
+            moduleResolution: 'bundler',
+            module: 'ESNext',
+            paths: archesApplicationPathAliases,
+        },
+    });
+
+    const originalCompileScript = vueSingleFileComponentCompiler.compileScript;
+    vueSingleFileComponentCompiler.compileScript = function (descriptor, options) {
+        const tsConfigPath = Path.join(global.SITE_PACKAGES_DIRECTORY, 'tsconfig.json');
+
+        const virtualFileSystem = {
+            fileExists(filePath) {
+                if (filePath === tsConfigPath) {
+                    return true;
+                }
+                return ts.sys.fileExists(filePath);
+            },
+            readFile(filePath, encoding) {
+                if (filePath === tsConfigPath) {
+                    return virtualTsconfigContent;
+                }
+                return ts.sys.readFile(filePath, encoding);
+            },
+            realpath: ts.sys.realpath,
+        };
+
+        return originalCompileScript(descriptor, { ...options, fs: virtualFileSystem });
+    };
+
+    return require('vue-loader');
+}
+
+module.exports = { requireVueLoaderWithTypeResolutionPatch };

--- a/webpack/webpack-utils/patch-vue-compiler-sfc-type-resolution.js
+++ b/webpack/webpack-utils/patch-vue-compiler-sfc-type-resolution.js
@@ -3,10 +3,9 @@
 const fs = require('fs');
 const Path = require('path');
 
-// vue's compiler can't find a tsconfig.json for a regular (non-editable) pip install, so
-// defineProps<T>() type resolution breaks. We feed it a fake one in memory using its own fs
-// option. Don't move this below the vue-loader require. vue-loader grabs compileScript once when
-// it loads and never looks again.
+// We answer every tsconfig.json lookup vue's type resolver makes with our own config, so it
+// never walks into some dependency's own (possibly missing/broken) tsconfig.json chain.
+// Don't move this below the vue-loader require -- it only patches compileScript once, on load.
 function requireVueLoaderWithTypeResolutionPatch() {
     const ts = require('typescript');
     const vueSingleFileComponentCompiler = require('vue/compiler-sfc');
@@ -40,22 +39,10 @@ function requireVueLoaderWithTypeResolutionPatch() {
 
     const originalCompileScript = vueSingleFileComponentCompiler.compileScript;
     vueSingleFileComponentCompiler.compileScript = function (descriptor, options) {
-        const tsConfigPath = Path.join(global.SITE_PACKAGES_DIRECTORY, 'tsconfig.json');
-
         const virtualFileSystem = {
-            fileExists(filePath) {
-                if (filePath === tsConfigPath) {
-                    return true;
-                }
-                return ts.sys.fileExists(filePath);
-            },
-            readFile(filePath, encoding) {
-                if (filePath === tsConfigPath) {
-                    return virtualTsconfigContent;
-                }
-                return ts.sys.readFile(filePath, encoding);
-            },
-            realpath: ts.sys.realpath,
+            ...ts.sys,
+            fileExists: (filePath) => Path.basename(filePath) === 'tsconfig.json' || ts.sys.fileExists(filePath),
+            readFile: (filePath, encoding) => Path.basename(filePath) === 'tsconfig.json' ? virtualTsconfigContent : ts.sys.readFile(filePath, encoding),
         };
 
         return originalCompileScript(descriptor, { ...options, fs: virtualFileSystem });

--- a/webpack/webpack-utils/patch-vue-compiler-sfc-type-resolution.test.js
+++ b/webpack/webpack-utils/patch-vue-compiler-sfc-type-resolution.test.js
@@ -1,0 +1,63 @@
+/* eslint-disable */
+
+const fs = require('fs');
+const Path = require('path');
+
+const vueCompilerSfc = require('vue/compiler-sfc');
+const { requireVueLoaderWithTypeResolutionPatch } = require('./patch-vue-compiler-sfc-type-resolution');
+
+requireVueLoaderWithTypeResolutionPatch();  // must patch compileScript before reading it off below
+
+const { parse, compileScript } = vueCompilerSfc;
+
+function findVueFiles(directory) {
+    if (!fs.existsSync(directory)) {
+        return [];
+    }
+    return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+        const entryPath = Path.join(directory, entry.name);
+        return entry.isDirectory() ? findVueFiles(entryPath) : (entry.name.endsWith('.vue') ? [entryPath] : []);
+    });
+}
+
+const webpackMetadataPath = Path.join(__dirname, '..', '..', 'frontend_configuration', 'webpack-metadata.json');
+const { ARCHES_APPLICATIONS, ARCHES_APPLICATIONS_PATHS } = fs.existsSync(webpackMetadataPath)
+    ? JSON.parse(fs.readFileSync(webpackMetadataPath, 'utf-8'))
+    : { ARCHES_APPLICATIONS: [], ARCHES_APPLICATIONS_PATHS: {} };  // this project's own manage.py hasn't generated it yet
+
+describe('patch-vue-compiler-sfc-type-resolution', () => {
+    for (const archesApplication of ARCHES_APPLICATIONS) {
+        const vueFiles = findVueFiles(Path.join(ARCHES_APPLICATIONS_PATHS[archesApplication], 'src'));
+
+        test.skipIf(vueFiles.length === 0)(`resolves @ alias type imports in every ${archesApplication} .vue file`, () => {
+            const failures = vueFiles
+                .map((filename) => {
+                    const { descriptor } = parse(fs.readFileSync(filename, 'utf-8'), { filename });
+                    if (!descriptor.script && !descriptor.scriptSetup) {
+                        return null;
+                    }
+                    try {
+                        compileScript(descriptor, { id: filename });
+                        return null;
+                    } catch (error) {
+                        return `${filename}: ${error.message}`;
+                    }
+                })
+                .filter(Boolean);
+
+            expect(failures).toEqual([]);
+        });
+    }
+
+    // kept in sync by hand across projects; this project and arches core are the two known copies
+    const thisFile = Path.resolve(__dirname, 'patch-vue-compiler-sfc-type-resolution.js');
+    const otherCopies = ['test-modular-reports', 'arches']
+        .map((project) => Path.resolve(__dirname, '..', '..', '..', project, 'webpack', 'webpack-utils', 'patch-vue-compiler-sfc-type-resolution.js'))
+        .filter((copy) => copy !== thisFile && fs.existsSync(copy));
+
+    test.skipIf(otherCopies.length === 0)('stays byte-identical to the other project copies of this file', () => {
+        const thisContent = fs.readFileSync(thisFile, 'utf-8');
+        const mismatches = otherCopies.filter((copy) => fs.readFileSync(copy, 'utf-8') !== thisContent);
+        expect(mismatches).toEqual([]);
+    });
+});

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -7,7 +7,9 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const BundleTracker = require('webpack-bundle-tracker');
 
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-const { VueLoaderPlugin } = require("vue-loader");
+
+const { requireVueLoaderWithTypeResolutionPatch } = require('./webpack-utils/patch-vue-compiler-sfc-type-resolution');
+const { VueLoaderPlugin } = requireVueLoaderWithTypeResolutionPatch();
 
 const { buildFilepathLookup } = require('./webpack-utils/build-filepath-lookup');
 
@@ -338,6 +340,7 @@ module.exports = () => {
                 new VueLoaderPlugin(),
             ],
             resolve: {
+                extensions: ['.ts', '.tsx', '.wasm', '.mjs', '.js', '.json'],
                 modules: [Path.resolve(__dirname, PROJECT_RELATIVE_NODE_MODULES_PATH)],
                 alias: {
                     ...javascriptRelativeFilepathToAbsoluteFilepathLookup,

--- a/webpack/webpack.config.dev.js
+++ b/webpack/webpack.config.dev.js
@@ -35,7 +35,11 @@ module.exports = () => {
                 cache: {
                     type: 'filesystem',
                     buildDependencies: {
-                        config: [__filename],
+                        config: [
+                            __filename,
+                            Path.join(__dirname, '..', 'frontend_configuration', 'webpack-metadata.json'),
+                            Path.join(__dirname, '..', 'frontend_configuration', 'tsconfig-paths.json'),
+                        ],
                     },
                 },
                 devtool: 'inline-source-map',
@@ -58,6 +62,7 @@ module.exports = () => {
                     modules: false,
                 },
                 plugins: [
+                    new Webpack.HotModuleReplacementPlugin(),
                     new Webpack.DefinePlugin({
                         'process.env.NODE_ENV': JSON.stringify('development'),
                     }),

--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -24,6 +24,8 @@ module.exports = () => {
                                     drop_console: true,
                                 },
                                 mangle: true,
+                                keep_classnames: true,
+                                keep_fnames: true,
                             },
                         }),
                     ],


### PR DESCRIPTION
serves scheme/concept identity URIs as either HTML or SKOS based on the Accept header or a ?format= override, supporting RDF/XML, Turtle, N-Triples, and JSON-LD. published resources are dereferenceable anonymously; drafts require authentication and retired concepts are marked owl:deprecated.

also, uses each resource's minted public URI as the RDF subject (with owl:sameAs back to the UUID URI), serialize skos mapping properties (exactMatch/closeMatch/etc.) as URI references, and enumerate skos:hasTopConcept when serializing a scheme alone.